### PR TITLE
fix missing case from ResponseParser.parseDoCommand

### DIFF
--- a/js/packages/botbuilder-m365/src/ResponseParser.ts
+++ b/js/packages/botbuilder-m365/src/ResponseParser.ts
@@ -195,7 +195,7 @@ export class ResponseParser {
                             entityValue += token;
                         }
                         break;
-                    case DoCommandParseState.findEntityValue:
+                    case DoCommandParseState.inEntityValue:
                         // Accumulate tokens until you hit a space
                         if (SPACE_CHARACTERS.indexOf(token) >= 0) {
                             // Save pair and look for additional pairs


### PR DESCRIPTION
There was a typo in `ResponseParser.parseDoCommand()` where there were two cases for `DoCommandParseState.findEntityValue`, and none for `DoCommandParseState.inEntityValue`.

Switching the second `findEntityValue` case to `inEntityValue` restores support for entity values that have characters like a comma or period. E.g., latitude and longitide; or locations like `"Seattle, WA"` 