### PR TITLE
Typing Timer update

### DIFF
--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/TypingTimerTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/TypingTimerTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.M365.Tests
     {
 
         [Fact]
-        public void StartTypingTimer_MessageActivityType()
+        public void Start_MessageActivityType()
         {
             // Arrange
             var botAdapterStub = Mock.Of<BotAdapter>();
@@ -22,14 +22,31 @@ namespace Microsoft.Bot.Builder.M365.Tests
             TypingTimer typingTimer = new TypingTimer(timerDelay);
 
             // Act
-            typingTimer.StartTypingTimer(turnContextMock.Object);
+            typingTimer.Start(turnContextMock.Object);
 
             // Assert
-            Assert.False(typingTimer.Disposed());
+            Assert.True(typingTimer.IsRunning());
         }
 
         [Fact]
-        public void StartTypingTimer_NotMessageActivityType()
+        public void Start_DoubleStart_ShouldFail()
+        {
+            // Arrange
+            var botAdapterStub = Mock.Of<BotAdapter>();
+            var turnContextMock = new Mock<TurnContext>(botAdapterStub, new Activity { Type = ActivityTypes.Message });
+
+            int timerDelay = 1000;
+            TypingTimer typingTimer = new TypingTimer(timerDelay);
+
+            // Act
+            typingTimer.Start(turnContextMock.Object);
+
+            // Assert
+            Assert.False(typingTimer.Start(turnContextMock.Object));
+        }
+
+        [Fact]
+        public void Start_NotMessageActivityType()
         {
             // Arrange
             var botAdapterStub = Mock.Of<BotAdapter>();
@@ -40,14 +57,14 @@ namespace Microsoft.Bot.Builder.M365.Tests
             TypingTimer typingTimer = new TypingTimer(timerDelay);
 
             // Act
-            typingTimer.StartTypingTimer(turnContextMock.Object);
+            typingTimer.Start(turnContextMock.Object);
 
             // Assert
-            Assert.True(typingTimer.Disposed());
+            Assert.False(typingTimer.IsRunning());
         }
 
         [Fact]
-        public void StartTypingTimer_Registers_OnSendActivites_EventHandler()
+        public void Start_Registers_OnSendActivites_EventHandler()
         {
             // Arrange
             var botAdapterStub = Mock.Of<BotAdapter>();
@@ -59,7 +76,7 @@ namespace Microsoft.Bot.Builder.M365.Tests
             TypingTimer typingTimer = new TypingTimer(timerDelay);
 
             // Act
-            typingTimer.StartTypingTimer(turnContextMock.Object);
+            typingTimer.Start(turnContextMock.Object);
 
             // Assert
             turnContextMock.Verify(tc => tc.OnSendActivities(It.IsAny<SendActivitiesHandler>()), Times.Once);
@@ -67,7 +84,7 @@ namespace Microsoft.Bot.Builder.M365.Tests
         }
 
         [Fact]
-        public void StopTypingTimer_ShouldResetProperties()
+        public void Dispose_ShouldResetProperties()
         {
             // Arrange
             var botAdapterStub = Mock.Of<BotAdapter>();
@@ -77,11 +94,11 @@ namespace Microsoft.Bot.Builder.M365.Tests
             TypingTimer typingTimer = new TypingTimer(timerDelay);
 
             // Act
-            typingTimer.StartTypingTimer(turnContextMock.Object);
+            typingTimer.Start(turnContextMock.Object);
             typingTimer.Dispose();
 
             // Assert
-            Assert.True(typingTimer.Disposed());
+            Assert.False(typingTimer.IsRunning());
         }
     }
 }

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/TypingTimerTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/TypingTimerTests.cs
@@ -84,6 +84,35 @@ namespace Microsoft.Bot.Builder.M365.Tests
         }
 
         [Fact]
+        public void Start_ShouldSendTypingActivity_OneAtATime()
+        {
+            // Arrange
+            var botAdapterStub = Mock.Of<BotAdapter>();
+            var turnContextMock = new Mock<ITurnContext>();
+            turnContextMock.Setup(tc => tc.Activity).Returns(new Activity { Type = ActivityTypes.Message });
+            turnContextMock.Setup(tc => tc.OnSendActivities(It.IsAny<SendActivitiesHandler>()));
+            turnContextMock.Setup(tc => tc.SendActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>())).Callback(() =>
+            {
+                // Blocking the thread for 2 seconds to simulate a long running operation
+                Thread.Sleep(2000);
+            });
+
+            // Sending typing activity 10 times per second
+            int timerDelay = 100;
+            TypingTimer typingTimer = new TypingTimer(timerDelay);
+
+            // Act
+            typingTimer.Start(turnContextMock.Object);
+
+            // In the mean time, simulating sending 10 typing activities
+            Thread.Sleep(1000);
+
+            // Assert
+            // Only one typing timer is sent
+            turnContextMock.Verify(tc => tc.SendActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
         public void Dispose_ShouldResetProperties()
         {
             // Arrange

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/TypingTimerTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/TypingTimerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.M365.Tests
             typingTimer.StartTypingTimer(turnContextMock.Object);
 
             // Assert
-            Assert.NotNull(typingTimer.timer);
+            Assert.False(typingTimer.Disposed());
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.M365.Tests
             typingTimer.StartTypingTimer(turnContextMock.Object);
 
             // Assert
-            Assert.Null(typingTimer.timer);
+            Assert.True(typingTimer.Disposed());
         }
 
         [Fact]
@@ -78,10 +78,10 @@ namespace Microsoft.Bot.Builder.M365.Tests
 
             // Act
             typingTimer.StartTypingTimer(turnContextMock.Object);
-            typingTimer.StopTypingTimer();
+            typingTimer.Dispose();
 
             // Assert
-            Assert.Null(typingTimer.timer);
+            Assert.True(typingTimer.Disposed());
         }
     }
 }

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/Application.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/Application.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Builder.M365
                 if (_options.StartTypingTimer)
                 {
                     timer = new TypingTimer(_options.TypingTimerDelay);
-                    timer.StartTypingTimer(turnContext);
+                    timer.Start(turnContext);
                 }
 
                 // Remove @mentions

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/Application.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/Application.cs
@@ -142,8 +142,8 @@ namespace Microsoft.Bot.Builder.M365
             }
             finally
             {
-                // End typing timer if configured
-                timer?.StopTypingTimer();
+                // Dipose the timer if configured
+                timer?.Dispose();
             }
 
 

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/TypingTimer.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/TypingTimer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.M365
         private bool _disposedValue = false;
 
         /// <summary>
-        /// Data passed to the timer callback
+        /// Data passed to the timer callback.
         /// </summary>
         private TimerState? _timerState;
 


### PR DESCRIPTION
Made a few changes to the TypingTimer based on @vule-msft's suggestions

* It implements the `IDisposable` interface to follow C# conventions on object that need to have resources explicitly disposed by the users.
* Implemented a destructor to properly dispose the timer resource when garbage collector destroys this object
* Made timer property private to avoid unexpected mutations from outside this class
