### PR TITLE
Dial down temp to 0 to improve accuracy

### DIFF
--- a/js/samples/04.ai.d.chainedActions.listBot/src/prompts/chat/config.json
+++ b/js/samples/04.ai.d.chainedActions.listBot/src/prompts/chat/config.json
@@ -4,7 +4,7 @@
     "type": "completion",
     "completion": {
       "max_tokens": 1024,
-      "temperature": 0.4,
+      "temperature": 0,
       "top_p": 0.0,
       "presence_penalty": 0.6,
       "frequency_penalty": 0.0,


### PR DESCRIPTION
Due to excessive code-like plans generated for List bot, dialing down the temp to 0 is leading to more reliable planning.