### PR TITLE
Fix case where adaptive card task module does not return anything

### DIFF
--- a/js/packages/teams-ai/src/TaskModules.ts
+++ b/js/packages/teams-ai/src/TaskModules.ts
@@ -182,10 +182,6 @@ export class TaskModules<TState extends TurnState> {
                                     value: result as TaskModuleTaskInfo
                                 }
                             };
-                        } else {
-                            response = {
-                                task: undefined
-                            }
                         }
 
                         // Queue up invoke response


### PR DESCRIPTION
As a response to the task/submit invoke, Teams expects [either a HTTP 200 with no payload (meaning success), a string or a new TaskInfo object](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/task-modules/task-modules-bots?tabs=nodejs#responds-to-the-tasksubmit-messages). Currently the TaskModules submit() method returns this if there is no string or object:
```
response = {
     task: undefined
}
```
which is not valid and causes the backend to send this error to Teams:
```
{"errorCode":1008,"message":"<BotError>Error when processing invoke response: Task or Task Type is missing in Task Module response","standardizedError":{"errorCode":1008,"errorSubCode":1,"errorDescription":"<BotError>Error when processing invoke response: Task or Task Type is missing in Task Module response"}}
```

The submit() method should just return an empty HTTP 200 instead of the response above in this case.