### PR TITLE
add place holders for dotnet workflows

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -1,0 +1,21 @@
+#
+# Place holder to enable dotnet-ci workflow
+#
+
+name: dotnet-ci
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - DOTNET
+    paths:
+      - 'dotnet/packages/**'
+
+jobs:
+  echo:
+    runs-on: "windows-latest"
+    steps:
+      - name: echo
+        shell: bash
+        run: echo dotnet

--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -1,0 +1,20 @@
+#
+# Place holder to enable dotnet-pr workflow
+#
+
+name: dotnet-pr
+
+on:
+  pull_request:
+    branches:
+      - DOTNET
+    paths:
+      - 'dotnet/**'
+
+jobs:
+  echo:
+    runs-on: "windows-latest"
+    steps:
+      - name: echo
+        shell: bash
+        run: echo dotnet


### PR DESCRIPTION
For https://github.com/microsoft/teams-ai/issues/210.
GitHub detects workflows from the default branch. This PR adds place holders to `main` branch, while https://github.com/microsoft/teams-ai/pull/222 adds detailed dotnet workflows to `DOTNET` branch.