### PR TITLE
Add tests for OpenAI moderator

### DIFF
--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/OpenAIModeratorTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/OpenAIModeratorTests.cs
@@ -1,0 +1,251 @@
+﻿using Castle.Core.Logging;
+using Microsoft.Bot.Builder.M365.AI.Action;
+using Microsoft.Bot.Builder.M365.AI;
+using Microsoft.Bot.Builder.M365.AI.Moderator;
+using Microsoft.Bot.Builder.M365.AI.Planner;
+using Microsoft.Bot.Builder.M365.AI.Prompt;
+using Microsoft.Bot.Builder.M365.Exceptions;
+using Microsoft.Bot.Builder.M365.OpenAI;
+using Microsoft.Bot.Schema;
+using Moq;
+using System.Reflection;
+
+namespace Microsoft.Bot.Builder.M365.Tests.AITests
+{
+    public class OpenAIModeratorTests
+    {
+        [Fact]
+        public async void Test_ReviewPrompt_ThrowsException()
+        {
+            // Arrange
+            var apiKey = "randomApiKey";
+
+            var botAdapterMock = new Mock<BotAdapter>();
+            // TODO: when TurnState is implemented, get the user input
+            var activity = new Activity()
+            {
+                Text = "input",
+            };
+            var turnContext = new TurnContext(botAdapterMock.Object, activity);
+            var turnStateMock = new Mock<TurnState>();
+            var promptTemplate = new PromptTemplate(
+                "prompt",
+                new PromptTemplateConfiguration
+                {
+                    Completion =
+                        {
+                            MaxTokens = 2000,
+                        Temperature = 0.2,
+                            TopP = 0.5,
+                        }
+                }
+            );
+
+            var clientMock = new Mock<OpenAIClient>(It.IsAny<OpenAIClientOptions>(), It.IsAny<ILogger>(), It.IsAny<HttpClient>());
+            var exception = new OpenAIClientException("Exception Message");
+            clientMock.Setup(client => client.ExecuteTextModeration(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(exception);
+
+            var options = new OpenAIModeratorOptions(apiKey, ModerationType.Both);
+            var moderator = new OpenAIModerator<TurnState>(options);
+            moderator.GetType().GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(moderator, clientMock.Object);
+
+            // Act
+            var result = await Assert.ThrowsAsync<OpenAIClientException>(async () => await moderator.ReviewPrompt(turnContext, turnStateMock.Object, promptTemplate));
+
+            // Assert
+            Assert.Equal("Exception Message", result.Message);
+        }
+
+        [Theory]
+        [InlineData(ModerationType.Input)]
+        [InlineData(ModerationType.Output)]
+        [InlineData(ModerationType.Both)]
+        public async void Test_ReviewPrompt_Flagged(ModerationType moderate)
+        {
+            // Arrange
+            var apiKey = "randomApiKey";
+
+            var botAdapterMock = new Mock<BotAdapter>();
+            // TODO: when TurnState is implemented, get the user input
+            var activity = new Activity()
+            {
+                Text = "input",
+            };
+            var turnContext = new TurnContext(botAdapterMock.Object, activity);
+            var turnStateMock = new Mock<TurnState>();
+            var promptTemplate = new PromptTemplate(
+                "prompt",
+                new PromptTemplateConfiguration
+                {
+                    Completion =
+                        {
+                            MaxTokens = 2000,
+                        Temperature = 0.2,
+                            TopP = 0.5,
+                        }
+                }
+            );
+
+            var clientMock = new Mock<OpenAIClient>(It.IsAny<OpenAIClientOptions>(), It.IsAny<ILogger>(), It.IsAny<HttpClient>());
+            var response = new ModerationResponse()
+            {
+                Id = "Id",
+                Model = "Model",
+                Results = new List<ModerationResult>()
+                {
+                    new ModerationResult()
+                    {
+                        Flagged = true,
+                        CategoriesFlagged = new ModerationCategoriesFlagged()
+                        {
+                            Hate = false,
+                            HateThreatening = false,
+                            SelfHarm = false,
+                            Sexual = false,
+                            SexualMinors = false,
+                            Violence = true,
+                            ViolenceGraphic = false,
+                        },
+                        CategoryScores = new ModerationCategoryScores()
+                        {
+                            Hate = 0,
+                            HateThreatening = 0,
+                            SelfHarm = 0,
+                            Sexual = 0,
+                            SexualMinors = 0,
+                            Violence = 0.9,
+                            ViolenceGraphic = 0,
+                        }
+                    }
+                }
+            };
+            clientMock.Setup(client => client.ExecuteTextModeration(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
+
+            var options = new OpenAIModeratorOptions(apiKey, moderate);
+            var moderator = new OpenAIModerator<TurnState>(options);
+            moderator.GetType().GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(moderator, clientMock.Object);
+
+            // Act
+            var result = await moderator.ReviewPrompt(turnContext, turnStateMock.Object, promptTemplate);
+
+            // Assert
+            if (moderate == ModerationType.Input || moderate == ModerationType.Both)
+            {
+                Assert.NotNull(result);
+                Assert.Equal(AITypes.DoCommand, result.Commands[0].Type);
+                Assert.Equal(DefaultActionTypes.FlaggedInputActionName, ((PredictedDoCommand)result.Commands[0]).Action);
+                Assert.NotNull(((PredictedDoCommand)result.Commands[0]).Entities);
+                Assert.True(((PredictedDoCommand)result.Commands[0]).Entities.ContainsKey("Result"));
+                Assert.StrictEqual(response.Results[0], ((PredictedDoCommand)result.Commands[0]).Entities.GetValueOrDefault("Result"));
+            }
+            else
+            {
+                Assert.Null(result);
+            }
+        }
+
+        [Fact]
+        public async void Test_ReviewPlan_ThrowsException()
+        {
+            // Arrange
+            var apiKey = "randomApiKey";
+
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnStateMock = new Mock<TurnState>();
+            var plan = new Plan(new List<IPredictedCommand>()
+            {
+                new PredictedDoCommand("action"),
+                new PredictedSayCommand("response"),
+            });
+
+            var clientMock = new Mock<OpenAIClient>(It.IsAny<OpenAIClientOptions>(), It.IsAny<ILogger>(), It.IsAny<HttpClient>());
+            var exception = new OpenAIClientException("Exception Message");
+            clientMock.Setup(client => client.ExecuteTextModeration(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(exception);
+
+            var options = new OpenAIModeratorOptions(apiKey, ModerationType.Both);
+            var moderator = new OpenAIModerator<TurnState>(options);
+            moderator.GetType().GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(moderator, clientMock.Object);
+
+            // Act
+            var result = await Assert.ThrowsAsync<OpenAIClientException>(async () => await moderator.ReviewPlan(turnContextMock.Object, turnStateMock.Object, plan));
+
+            // Assert
+            Assert.Equal("Exception Message", result.Message);
+        }
+
+        [Theory]
+        [InlineData(ModerationType.Input)]
+        [InlineData(ModerationType.Output)]
+        [InlineData(ModerationType.Both)]
+        public async void Test_ReviewPlan_Flagged(ModerationType moderate)
+        {
+            // Arrange
+            var apiKey = "randomApiKey";
+
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnStateMock = new Mock<TurnState>();
+            var plan = new Plan(new List<IPredictedCommand>()
+            {
+                new PredictedDoCommand("action"),
+                new PredictedSayCommand("response"),
+            });
+
+            var clientMock = new Mock<OpenAIClient>(It.IsAny<OpenAIClientOptions>(), It.IsAny<ILogger>(), It.IsAny<HttpClient>());
+            var response = new ModerationResponse()
+            {
+                Id = "Id",
+                Model = "Model",
+                Results = new List<ModerationResult>()
+                {
+                    new ModerationResult()
+                    {
+                        Flagged = true,
+                        CategoriesFlagged = new ModerationCategoriesFlagged()
+                        {
+                            Hate = false,
+                            HateThreatening = false,
+                            SelfHarm = false,
+                            Sexual = false,
+                            SexualMinors = false,
+                            Violence = true,
+                            ViolenceGraphic = false,
+                        },
+                        CategoryScores = new ModerationCategoryScores()
+                        {
+                            Hate = 0,
+                            HateThreatening = 0,
+                            SelfHarm = 0,
+                            Sexual = 0,
+                            SexualMinors = 0,
+                            Violence = 0.9,
+                            ViolenceGraphic = 0,
+                        }
+                    }
+                }
+            };
+            clientMock.Setup(client => client.ExecuteTextModeration(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
+
+            var options = new OpenAIModeratorOptions(apiKey, moderate);
+            var moderator = new OpenAIModerator<TurnState>(options);
+            moderator.GetType().GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(moderator, clientMock.Object);
+
+            // Act
+            var result = await moderator.ReviewPlan(turnContextMock.Object, turnStateMock.Object, plan);
+
+            // Assert
+            if (moderate == ModerationType.Output || moderate == ModerationType.Both)
+            {
+                Assert.NotNull(result);
+                Assert.Equal(AITypes.DoCommand, result.Commands[0].Type);
+                Assert.Equal(DefaultActionTypes.FlaggedOutputActionName, ((PredictedDoCommand)result.Commands[0]).Action);
+                Assert.NotNull(((PredictedDoCommand)result.Commands[0]).Entities);
+                Assert.True(((PredictedDoCommand)result.Commands[0]).Entities.ContainsKey("Result"));
+                Assert.StrictEqual(response.Results[0], ((PredictedDoCommand)result.Commands[0]).Entities.GetValueOrDefault("Result"));
+            }
+            else
+            {
+                Assert.StrictEqual(plan, result);
+            }
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/OpenAIModeratorTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/OpenAIModeratorTests.cs
@@ -33,11 +33,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AITests
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
+                    {
+                        MaxTokens = 2000,
                         Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -78,11 +78,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AITests
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
+                    {
+                        MaxTokens = 2000,
                         Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                        TopP = 0.5,
+                    }
                 }
             );
 

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/OpenAIPlannerTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/OpenAIPlannerTests.cs
@@ -30,11 +30,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AITests
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
+                    {
+                        MaxTokens = 2000,
                         Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -72,11 +72,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AITests
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
+                    {
+                        MaxTokens = 2000,
                         Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -109,11 +109,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AITests
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
+                    {
+                        MaxTokens = 2000,
                         Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -148,11 +148,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AITests
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
+                    {
+                        MaxTokens = 2000,
                         Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -191,11 +191,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AITests
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
+                    {
+                        MaxTokens = 2000,
                         Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                        TopP = 0.5,
+                    }
                 }
             );
 

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/PromptManagerTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/AITests/PromptManagerTests.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AI
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -104,11 +104,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AI
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -131,11 +131,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AI
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -233,11 +233,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AI
             var configuration = new PromptTemplateConfiguration
             {
                 Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                {
+                    MaxTokens = 2000,
+                    Temperature = 0.2,
+                    TopP = 0.5,
+                }
             };
 
             var name = "promptTemplateName";
@@ -267,11 +267,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AI
             var configuration = new PromptTemplateConfiguration
             {
                 Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                {
+                    MaxTokens = 2000,
+                    Temperature = 0.2,
+                    TopP = 0.5,
+                }
             };
             /// Configure function
             var promptFunctionName = "promptFunctionName";
@@ -306,11 +306,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.AI
             var configuration = new PromptTemplateConfiguration
             {
                 Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                {
+                    MaxTokens = 2000,
+                    Temperature = 0.2,
+                    TopP = 0.5,
+                }
             };
             
             /// Prompt function not configured

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/IntegrationTests/AzureOpenAIPlannerTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/IntegrationTests/AzureOpenAIPlannerTests.cs
@@ -55,11 +55,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -96,11 +96,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -134,11 +134,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -169,11 +169,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/IntegrationTests/OpenAIModeratorTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/IntegrationTests/OpenAIModeratorTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.Bot.Builder.M365.AI.Action;
+using Microsoft.Bot.Builder.M365.AI.Moderator;
+using Microsoft.Bot.Builder.M365.AI.Planner;
+using Microsoft.Bot.Builder.M365.AI.Prompt;
+using Microsoft.Bot.Builder.M365.AI;
+using Microsoft.Bot.Builder.M365.Tests.Integration;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.M365.Tests.IntegrationTests
+{
+    public sealed class OpenAIModeratorTests
+    {
+        private readonly IConfigurationRoot _configuration;
+        private readonly RedirectOutput _output;
+
+        public OpenAIModeratorTests(ITestOutputHelper output)
+        {
+            _output = new RedirectOutput(output);
+
+            var currentAssemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            if (string.IsNullOrWhiteSpace(currentAssemblyDirectory))
+            {
+                throw new InvalidOperationException("Unable to determine current assembly directory.");
+            }
+
+            var directoryPath = Path.GetFullPath(Path.Combine(currentAssemblyDirectory, $"../../../IntegrationTests/"));
+            var settingsPath = Path.Combine(directoryPath, "testsettings.json");
+
+            _configuration = new ConfigurationBuilder()
+                .AddJsonFile(path: settingsPath, optional: false, reloadOnChange: true)
+                .AddEnvironmentVariables()
+                .AddUserSecrets<AzureOpenAICompletionTests>()
+                .Build();
+        }
+
+        [Theory(Skip = "This test should only be run manually.")]
+        [InlineData("I want to kill them.", true)]
+        public async Task OpenAIModerator_ReviewPrompt(string input, bool flagged)
+        {
+            // Arrange
+            var config = _configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
+            var options = new OpenAIModeratorOptions(config.ApiKey, ModerationType.Both);
+            var moderator = new OpenAIModerator<TurnState>(options, _output);
+
+            var botAdapterMock = new Mock<BotAdapter>();
+            // TODO: when TurnState is implemented, get the user input
+            var activity = new Activity()
+            {
+                Text = input,
+            };
+            var turnContext = new TurnContext(botAdapterMock.Object, activity);
+            var turnStateMock = new Mock<TurnState>();
+            var promptTemplateMock = new Mock<PromptTemplate>(String.Empty, new PromptTemplateConfiguration());
+
+            // Act
+            var result = await moderator.ReviewPrompt(turnContext, turnStateMock.Object, promptTemplateMock.Object);
+
+            // Assert
+            if (flagged)
+            {
+                Assert.NotNull(result);
+                Assert.Equal(AITypes.DoCommand, result.Commands[0].Type);
+                Assert.Equal(DefaultActionTypes.FlaggedInputActionName, ((PredictedDoCommand)result.Commands[0]).Action);
+            }
+            else
+            {
+                Assert.Null(result);
+            }
+        }
+
+        [Theory(Skip = "This test should only be run manually.")]
+        [InlineData("I want to kill them.", true)]
+        public async Task AzureContentSafetyModerator_ReviewPlan(string response, bool flagged)
+        {
+            // Arrange
+            var config = _configuration.GetSection("OpenAI").Get<OpenAIConfiguration>();
+            var options = new OpenAIModeratorOptions(config.ApiKey, ModerationType.Both);
+            var moderator = new OpenAIModerator<TurnState>(options, _output);
+
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnStateMock = new Mock<TurnState>();
+            var plan = new Plan(new List<IPredictedCommand>()
+            {
+                new PredictedSayCommand(response)
+            });
+
+            // Act
+            var result = await moderator.ReviewPlan(turnContextMock.Object, turnStateMock.Object, plan);
+
+            // Assert
+            if (flagged)
+            {
+                Assert.Equal(AITypes.DoCommand, result.Commands[0].Type);
+                Assert.Equal(DefaultActionTypes.FlaggedOutputActionName, ((PredictedDoCommand)result.Commands[0]).Action);
+            }
+            else
+            {
+                Assert.Equal(AITypes.SayCommand, result.Commands[0].Type);
+            }
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/IntegrationTests/OpenAIPlannerTests.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365.Tests/IntegrationTests/OpenAIPlannerTests.cs
@@ -58,11 +58,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -99,11 +99,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -137,11 +137,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 
@@ -172,11 +172,11 @@ namespace Microsoft.Bot.Builder.M365.Tests.Integration
                 new PromptTemplateConfiguration
                 {
                     Completion =
-                        {
-                            MaxTokens = 2000,
-                            Temperature = 0.2,
-                            TopP = 0.5,
-                        }
+                    {
+                        MaxTokens = 2000,
+                        Temperature = 0.2,
+                        TopP = 0.5,
+                    }
                 }
             );
 

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/Moderator/OpenAIModerator.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/Moderator/OpenAIModerator.cs
@@ -21,11 +21,12 @@ namespace Microsoft.Bot.Builder.M365.AI.Moderator
         /// </summary>
         /// <param name="options">Options to configure the moderator</param>
         /// <param name="logger">A logger instance</param>
+        /// <param name="httpClient">HTTP client.</param>
         public OpenAIModerator(OpenAIModeratorOptions options, ILogger? logger = null, HttpClient? httpClient = null)
         {
             _options = options;
 
-            OpenAIClientOptions clientOptions = new(_options.ApiKey, _options.DefaultModel)
+            OpenAIClientOptions clientOptions = new(_options.ApiKey)
             {
                 Organization = _options.Organization,
             };
@@ -88,9 +89,9 @@ namespace Microsoft.Bot.Builder.M365.AI.Moderator
         {
             try
             {
-                ModerationResponse response = await _client.ExecuteTextModeration(text);
+                ModerationResponse response = await _client.ExecuteTextModeration(text, _options.Model);
                 ModerationResult? result = response.Results.Count > 0 ? response.Results[0] : null;
-                            
+                
                 if (result != null)
                 {
                     if (result.Flagged)

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/Moderator/OpenAIModeratorOptions.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/Moderator/OpenAIModeratorOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Bot.Builder.M365.AI.Moderator
         public string ApiKey { get; set; }
 
         /// <summary>
-        /// Which parts of the conversation to moderate
+        /// Which parts of the conversation to moderate.
         /// </summary>
         public ModerationType Moderate { get; set; }
 
@@ -24,23 +24,19 @@ namespace Microsoft.Bot.Builder.M365.AI.Moderator
         public string? Endpoint { get; set; }
 
         /// <summary>
-        /// The default model to use.
+        /// The moderation model to use.
         /// </summary>
-        /// <remarks>
-        /// Prompts can override this model.
-        /// </remarks>
-        public string DefaultModel { get; set; }
+        public string? Model { get; set; }
 
         /// <summary>
         /// Create an instance of the OpenAIModeratorOptions class.
         /// </summary>
         /// <param name="apiKey">OpenAI API key.</param>
-        /// <param name="defaultModel">The default model to use.</param>
-        public OpenAIModeratorOptions(string apiKey, ModerationType moderate, string defaultModel)
+        /// <param name="moderate">Which parts of the conversation to moderate.</param>
+        public OpenAIModeratorOptions(string apiKey, ModerationType moderate)
         {
             ApiKey = apiKey;
             Moderate = moderate;
-            DefaultModel = defaultModel;
         }
     }
 

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/OpenAI/OpenAIClient.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/OpenAI/OpenAIClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.M365.OpenAI
 {
@@ -32,17 +33,21 @@ namespace Microsoft.Bot.Builder.M365.OpenAI
         /// Make a call to the OpenAI text moderation endpoint.
         /// </summary>
         /// <param name="text">The input text to moderate.</param>
+        /// <param name="model">The moderation model to use.</param>
         /// <returns>The moderation result from the API call.</returns>
         /// <exception cref="OpenAIClientException" />
-        public async Task<ModerationResponse> ExecuteTextModeration(string text)
+        public virtual async Task<ModerationResponse> ExecuteTextModeration(string text, string? model)
         {
             try
             {
                 using HttpContent content = new StringContent(
                     JsonSerializer.Serialize(new
                     {
-                        model = _options.DefaultModel,
+                        model = model,
                         input = text 
+                    }, new JsonSerializerOptions()
+                    {
+                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                     }),
                     Encoding.UTF8,
                     "application/json"

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/OpenAI/OpenAIClientOptions.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/AI/OpenAI/OpenAIClientOptions.cs
@@ -13,22 +13,12 @@
         public string? Organization { get; set; }
 
         /// <summary>
-        /// The default model to use.
-        /// </summary>
-        /// <remarks>
-        /// Prompts can override this model.
-        /// </remarks>
-        public string DefaultModel { get; set; }
-
-        /// <summary>
         /// Create an instance of the OpenAIModeratorOptions class.
         /// </summary>
         /// <param name="apiKey">OpenAI API key.</param>
-        /// <param name="defaultModel">The default model to use.</param>
-        public OpenAIClientOptions(string apiKey, string defaultModel)
+        public OpenAIClientOptions(string apiKey)
         {
             ApiKey = apiKey;
-            DefaultModel = defaultModel;
         }
     }
 }

--- a/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/Exceptions/OpenAIClientException.cs
+++ b/dotnet/packages/Microsoft.Bot.Builder.M365/Microsoft.Bot.Builder.M365/Exceptions/OpenAIClientException.cs
@@ -3,7 +3,7 @@ using System.Runtime.Serialization;
 
 namespace Microsoft.Bot.Builder.M365.Exceptions
 {
-    internal class OpenAIClientException : Exception
+    public class OpenAIClientException : Exception
     {
         public readonly HttpStatusCode? statusCode;
 


### PR DESCRIPTION
- rename DefaultModel to Model in OpenAIModeratorOptions
- remove DefaultModel from OpenAIClientOptions
- add unit test for OpenAI moderator
- add integration test for OpenAI moderator

Resolves https://github.com/microsoft/teams-ai/issues/213