### PR TITLE
fix: fix typing timer and state bugs

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateManagerTests.cs
@@ -153,9 +153,13 @@ namespace Microsoft.TeamsAI.Tests.StateTests
             var storage = new MemoryStorage();
 
             // Act
+            /// Mutate the conversation state to so that the changes are saved.
+            state.Conversation!.Set("test", "test");
+            /// Save the state first
+            await turnStateManager.SaveStateAsync(storage, turnContext, state);
             /// Delete conversation state
             state.ConversationStateEntry.Delete();
-            /// Save the state
+            /// Save the state again
             await turnStateManager.SaveStateAsync(storage, turnContext, state);
             /// Load from storage
             IDictionary<string, object> storedItems = await storage.ReadAsync(new string[] { storageKey }, default);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnStateManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnStateManager.cs
@@ -101,7 +101,7 @@ namespace Microsoft.TeamsAI.State
                         {
                             if (entry.IsDeleted)
                             {
-                                deletions.Add(key);
+                                deletions.Add(entry.StorageKey);
                             }
 
                             if (entry.HasChanged)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
@@ -42,7 +42,10 @@ namespace Microsoft.TeamsAI
         {
             Verify.ParamNotNull(turnContext);
 
-            if (turnContext.Activity.Type != ActivityTypes.Message || IsRunning()) return false;
+            if (turnContext.Activity.Type != ActivityTypes.Message || IsRunning())
+            {
+                return false;
+            }
 
             // Listen for outgoing activities
             turnContext.OnSendActivities(StopTimerWhenSendMessageActivityHandler);
@@ -102,12 +105,12 @@ namespace Microsoft.TeamsAI
                 {
                     _timer?.Change(_interval, Timeout.Infinite);
                 }
-            } 
-            catch (ObjectDisposedException)
+            }
+            catch (Exception e) when (e is ObjectDisposedException || e is TaskCanceledException)
             {
                 // We're in the middle of sending an activity on a background thread when the turn ends and
-                // the turn context object is dispoed of. We can just eat the error but lets
-                // make sure our states cleaned up a bit.
+                // the turn context object is dispoed of or the request is cancelled. We can just eat the
+                // error but lets make sure our states cleaned up a bit.
                 Dispose();
             }
         }
@@ -116,7 +119,7 @@ namespace Microsoft.TeamsAI
         {
             if (_timer != null)
             {
-                foreach (var activity in activities)
+                foreach (Activity activity in activities)
                 {
                     if (activity.Type == ActivityTypes.Message)
                     {


### PR DESCRIPTION
https://github.com/microsoft/teams-ai/issues/271 to track. I found these issues when creating sample.
- In state manager, use correct storage key to delete state entry from storage.
- In typing timer, treat `TaskCanceledException` as expected since `turnContext.SendActivityAsync` may be canceled when current turn finished.