### PR TITLE
[C# fix] Ignore NullReferenceException in TypingTimer

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TypingTimerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TypingTimerTests.cs
@@ -162,9 +162,18 @@ namespace Microsoft.TeamsAI.Tests
                 new ObjectDisposedException("test")
             };
             yield return new[]
-{
+            {
                 new TaskCanceledException("test")
             };
+
+            yield return new[]
+            {
+#pragma warning disable CA2201 // Do not raise reserved exception types
+                // For test purpose only
+                new NullReferenceException()
+#pragma warning restore CA2201 // Do not raise reserved exception types
+            };
+
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.TeamsAI
                     _timer?.Change(_interval, Timeout.Infinite);
                 }
             }
-            catch (Exception e) when (e is ObjectDisposedException || e is TaskCanceledException)
+            catch (Exception e) when (e is ObjectDisposedException || e is TaskCanceledException || e is NullReferenceException)
             {
                 // We're in the middle of sending an activity on a background thread when the turn ends and
                 // the turn context object is dispoed of or the request is cancelled. We can just eat the


### PR DESCRIPTION
Found this https://github.com/microsoft/teams-ai/issues/329 when debugging sample.
Add NullReferenceException to ignore list as well.