### PR TITLE
[C#] Add unit tests for AI classes

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
@@ -1,0 +1,242 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.TeamsAI.AI;
+using Microsoft.TeamsAI.AI.Action;
+using Microsoft.TeamsAI.AI.Planner;
+using Microsoft.TeamsAI.AI.Prompt;
+using Microsoft.TeamsAI.State;
+using Microsoft.TeamsAI.Tests.TestUtils;
+using Moq;
+
+namespace Microsoft.TeamsAI.Tests.AITests
+{
+    public class AITests
+    {
+        [Fact]
+        public async Task AI_ChainAsync_Default_Prompt()
+        {
+            // Arrange
+            var planner = new TestPlanner();
+            var promptManager = new TestPromptManager();
+            var moderator = new TestModerator();
+            var options = new AIOptions<TestTurnState>(planner, promptManager, moderator)
+            {
+                Prompt = "Test",
+                History = new AIHistoryOptions
+                {
+                    TrackHistory = false
+                }
+            };
+            var ai = new AI<TestTurnState>(options);
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnState = new TestTurnState();
+            var actions = new TestActions();
+            ai.ImportActions(actions);
+
+            // Act
+            var result = await ai.ChainAsync(turnContextMock.Object, turnState);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(new string[] { "GeneratePlanAsync" }, planner.Record.ToArray());
+            Assert.Equal(new string[] { "RenderPrompt", "RenderPrompt" }, promptManager.Record.ToArray());
+            Assert.Equal(new string[] { "ReviewPrompt", "ReviewPlan" }, moderator.Record.ToArray());
+            Assert.Equal(new string[] { "Test-DO" }, actions.DoActionRecord.ToArray());
+            Assert.Equal(new string[] { "Test-SAY" }, actions.SayActionRecord.ToArray());
+        }
+
+        [Fact]
+        public async Task AI_ChainAsync_PromptTemplate()
+        {
+            // Arrange
+            var planner = new TestPlanner();
+            var promptManager = new TestPromptManager();
+            var moderator = new TestModerator();
+            var options = new AIOptions<TestTurnState>(planner, promptManager, moderator)
+            {
+                Prompt = "Test",
+                History = new AIHistoryOptions
+                {
+                    TrackHistory = false
+                }
+            };
+            var ai = new AI<TestTurnState>(options);
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnState = new TestTurnState();
+            var actions = new TestActions();
+            ai.ImportActions(actions);
+            var prompt = new PromptTemplate("Test", new());
+
+            // Act
+            var result = await ai.ChainAsync(turnContextMock.Object, turnState, prompt);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(new string[] { "GeneratePlanAsync" }, planner.Record.ToArray());
+            Assert.Equal(new string[] { "RenderPrompt" }, promptManager.Record.ToArray());
+            Assert.Equal(new string[] { "ReviewPrompt", "ReviewPlan" }, moderator.Record.ToArray());
+            Assert.Equal(new string[] { "Test-DO" }, actions.DoActionRecord.ToArray());
+            Assert.Equal(new string[] { "Test-SAY" }, actions.SayActionRecord.ToArray());
+        }
+
+        [Fact]
+        public async Task AI_ChainAsync_TempState_IsSet()
+        {
+            // Arrange
+            var options = new AIOptions<TestTurnState>(new TestPlanner(), new TestPromptManager())
+            {
+                Prompt = "Test",
+                History = new AIHistoryOptions
+                {
+                    TrackHistory = false
+                }
+            };
+            var ai = new AI<TestTurnState>(options);
+            var turnContext = new TurnContext(new NotImplementedAdapter(), MessageFactory.Text("hello"));
+            var turnState = new TestTurnState
+            {
+                TempStateEntry = new TurnStateEntry<TempState>(new())
+            };
+            var actions = new TestActions();
+            ai.ImportActions(actions);
+
+            // Act
+            var result = await ai.ChainAsync(turnContext, turnState);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("hello", turnState.Temp!.Input);
+        }
+
+        [Fact]
+        public async Task AI_ChainAsync_History_IsSet()
+        {
+            // Arrange
+            var options = new AIOptions<TestTurnState>(new TestPlanner(), new TestPromptManager())
+            {
+                Prompt = "Test",
+                History = new AIHistoryOptions
+                {
+                    TrackHistory = true,
+                    AssistantHistoryType = AssistantHistoryType.Text
+                }
+            };
+            var ai = new AI<TestTurnState>(options);
+            var turnContext = new TurnContext(new NotImplementedAdapter(), MessageFactory.Text("hello"));
+            var turnState = new TestTurnState
+            {
+                ConversationStateEntry = new TurnStateEntry<StateBase>(new()),
+                TempStateEntry = new TurnStateEntry<TempState>(new())
+            };
+            // Add last history
+            ConversationHistory.AddLine(turnState, "test");
+            var actions = new TestActions();
+            ai.ImportActions(actions);
+
+            // Act
+            var result = await ai.ChainAsync(turnContext, turnState);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal("test", turnState.Temp!.History);
+            Assert.Equal(new string[] { "test", "User: hello", "Assistant:, Test-SAY" }, ConversationHistory.GetHistory(turnState).ToArray());
+        }
+
+        [Fact]
+        public async Task AI_CompletePromptAsync_PromptName()
+        {
+            // Arrange
+            var planner = new TestPlanner();
+            var promptManager = new TestPromptManager();
+            var options = new AIOptions<TestTurnState>(planner, promptManager)
+            {
+                Prompt = "Test"
+            };
+            var ai = new AI<TestTurnState>(options);
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnState = new TestTurnState();
+
+            // Act
+            var result = await ai.CompletePromptAsync(turnContextMock.Object, turnState, "Test", null, CancellationToken.None);
+
+            // Assert
+            Assert.Equal("Default", result);
+            Assert.Equal(new string[] { "CompletePromptAsync" }, planner.Record.ToArray());
+            Assert.Equal(new string[] { "RenderPrompt" }, promptManager.Record.ToArray());
+        }
+
+        [Fact]
+        public async Task AI_CompletePromptAsync_PromptTemplate()
+        {
+            // Arrange
+            var planner = new TestPlanner();
+            var promptManager = new TestPromptManager();
+            var options = new AIOptions<TestTurnState>(planner, promptManager)
+            {
+                Prompt = "Test"
+            };
+            var ai = new AI<TestTurnState>(options);
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnState = new TestTurnState();
+            var prompt = new PromptTemplate("Test", new());
+
+            // Act
+            var result = await ai.CompletePromptAsync(turnContextMock.Object, turnState, prompt, null, CancellationToken.None);
+
+            // Assert
+            Assert.Equal("Default", result);
+            Assert.Equal(new string[] { "CompletePromptAsync" }, planner.Record.ToArray());
+            Assert.Equal(new string[] { "RenderPrompt" }, promptManager.Record.ToArray());
+        }
+
+        [Fact]
+        public async Task AI_CompletePromptAsync_CreateSemanticFunction()
+        {
+            // Arrange
+            var planner = new TestPlanner();
+            var promptManager = new TestPromptManager();
+            var options = new AIOptions<TestTurnState>(planner, promptManager)
+            {
+                Prompt = "Test"
+            };
+            var ai = new AI<TestTurnState>(options);
+            var turnContextMock = new Mock<ITurnContext>();
+            var turnState = new TestTurnState();
+            var prompt = new PromptTemplate("Test", new());
+
+            // Act
+            var function = ai.CreateSemanticFunction("Test", prompt, null);
+            var result = await function(turnContextMock.Object, turnState);
+
+            // Assert
+            Assert.NotNull(function);
+            Assert.Equal("Default", result);
+            Assert.Equal(new string[] { "CompletePromptAsync" }, planner.Record.ToArray());
+            Assert.Equal(new string[] { "AddPromptTemplate", "RenderPrompt" }, promptManager.Record.ToArray());
+        }
+
+        /// <summary>
+        /// Override default DO and SAY actions for test
+        /// </summary>
+        private class TestActions
+        {
+            public IList<string> DoActionRecord { get; } = new List<string>();
+
+            public IList<string> SayActionRecord { get; } = new List<string>();
+
+            [Action("Test-DO")]
+            public bool DoCommand([ActionName] string action)
+            {
+                DoActionRecord.Add(action);
+                return true;
+            }
+
+            [Action(DefaultActionTypes.SayCommandActionName)]
+            public bool SayCommand([ActionEntities] PredictedSayCommand command)
+            {
+                SayActionRecord.Add(command.Response);
+                return true;
+            }
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestModerator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestModerator.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+
+using Microsoft.Bot.Builder;
+using Microsoft.TeamsAI.AI.Moderator;
+using Microsoft.TeamsAI.AI.Planner;
+using Microsoft.TeamsAI.AI.Prompt;
+
+namespace Microsoft.TeamsAI.Tests.TestUtils
+{
+    public class TestModerator : IModerator<TestTurnState>
+    {
+        public IList<string> Record { get; } = new List<string>();
+
+        public Task<Plan> ReviewPlan(ITurnContext turnContext, TestTurnState turnState, Plan plan)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return Task.FromResult(plan);
+        }
+
+        public Task<Plan?> ReviewPrompt(ITurnContext turnContext, TestTurnState turnState, PromptTemplate prompt)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return Task.FromResult<Plan?>(null);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPlanner.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+
+using Microsoft.Bot.Builder;
+using Microsoft.TeamsAI.AI;
+using Microsoft.TeamsAI.AI.Planner;
+using Microsoft.TeamsAI.AI.Prompt;
+
+namespace Microsoft.TeamsAI.Tests.TestUtils
+{
+    public class TestPlanner : IPlanner<TestTurnState>
+    {
+        public IList<string> Record { get; } = new List<string>();
+
+        public string CompletePromptResult { get; set; } = "Default";
+
+        public Plan GeneratePlanResult { get; set; } = new Plan
+        {
+            Commands = new List<IPredictedCommand>
+            {
+                new PredictedDoCommand("Test-DO"),
+                new PredictedSayCommand("Test-SAY")
+            }
+        };
+
+        public Task<string> CompletePromptAsync(ITurnContext turnContext, TestTurnState turnState, PromptTemplate promptTemplate, AIOptions<TestTurnState> options, CancellationToken cancellationToken)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return Task.FromResult(CompletePromptResult);
+        }
+
+        public Task<Plan> GeneratePlanAsync(ITurnContext turnContext, TestTurnState turnState, PromptTemplate promptTemplate, AIOptions<TestTurnState> options, CancellationToken cancellationToken)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return Task.FromResult(GeneratePlanResult);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPromptManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPromptManager.cs
@@ -1,0 +1,52 @@
+﻿using System.Reflection;
+
+using Microsoft.Bot.Builder;
+using Microsoft.TeamsAI.AI.Prompt;
+
+namespace Microsoft.TeamsAI.Tests.TestUtils
+{
+    public class TestPromptManager : IPromptManager<TestTurnState>
+    {
+        public IList<string> Record { get; } = new List<string>();
+
+        public PromptTemplate RenderPromptResult { get; set; } = new PromptTemplate("Default", new());
+
+        public IDictionary<string, string> Variables => throw new NotImplementedException();
+
+        public IPromptManager<TestTurnState> AddFunction(string name, PromptFunction<TestTurnState> promptFunction, bool allowOverrides = false)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return this;
+        }
+
+        public IPromptManager<TestTurnState> AddPromptTemplate(string name, PromptTemplate promptTemplate)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return this;
+        }
+
+        public Task<string> InvokeFunction(ITurnContext turnContext, TestTurnState turnState, string name)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            throw new NotImplementedException();
+        }
+
+        public PromptTemplate LoadPromptTemplate(string name)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            throw new NotImplementedException();
+        }
+
+        public Task<PromptTemplate> RenderPrompt(ITurnContext turnContext, TestTurnState turnState, string name)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return Task.FromResult(RenderPromptResult);
+        }
+
+        public Task<PromptTemplate> RenderPrompt(ITurnContext turnContext, TestTurnState turnState, PromptTemplate promptTemplate)
+        {
+            Record.Add(MethodBase.GetCurrentMethod()!.Name);
+            return Task.FromResult(RenderPromptResult);
+        }
+    }
+}


### PR DESCRIPTION
For https://github.com/microsoft/teams-ai/issues/233
- Add unit tests for `AI.cs` (19.2% -> 88.0%) and `OpenAIPlanner.cs` (41.1% -> 81.7%).
- Fix code warnings in `AI.cs` and `OpenAIPlanner.cs`.
- Fix a non-blocking issue in `AI.cs` to use configured options instead of pass-in options.