### PR TITLE
Minor updates

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planner/AzureOpenAIPlannerOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planner/AzureOpenAIPlannerOptions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TeamsAI.AI.Planner
         /// Create an instance of the OpenAIPlannerOptions class.
         /// </summary>
         /// <param name="apiKey">OpenAI API key.</param>
-        /// <param name="defaultModel">The default model to use.</param>
+        /// <param name="defaultModel">The default model to use. This should be the model deployment name, not the model</param>
         public AzureOpenAIPlannerOptions(string apiKey, string defaultModel, string endpoint) : base(apiKey, defaultModel)
         {
             Verify.ParamNotNull(endpoint);

--- a/dotnet/samples/README.md
+++ b/dotnet/samples/README.md
@@ -13,10 +13,8 @@ In this folder you will find various examples showcasing the different capabilit
 
 There are two paths to get the package. Please do one of the following, not both.
 
-1. [Download via GitHub package manager](#option-1-install-package-via-github-package-manager)
-2. [Build the package locally](#option-2-install-package-via-local-build)
-
-#### Option 1: Install package via GitHub package manager
+<details>
+    <summary><h4>Option 1: Install package via GitHub package manager</h4></summary>
 
 The development versions of the library might not be available on NuGet's public registry. Follow the instructions below to generate the `.nukpg` NuGet package file of the library to locally consume within the sample:
 
@@ -33,7 +31,10 @@ The development versions of the library might not be available on NuGet's public
 
 ❕❕ If you followed the above directions, you do not need to do Option 2 below. [Skip to building your sample](#setting-up-a-sample)
 
-#### Option 2: Install Package via local build
+</details>
+
+<details>
+    <summary><h4>Option 2: Install Package via local build</h4></summary>
 
 1. Clone the repository and verify you are on `main` branch:
 
@@ -50,8 +51,9 @@ Successfully created package "C:...\teams-ai\dotnet\packages\Microsoft.TeamsAI\M
 1. Move the `Microsoft.TeamsAI.1.0.0.nupkg` to the `LocalPkg/` folder within the sample folder you are testing.
 1. Navigate to `Tools > Nuget Package Manager > Manage Nuget Packages For Solution` and install `Microsoft.TeamsAI`.
    > Alternatively, you can run `dotnet add package Microsoft.TeamsAI`.
+   </details>
 
-Now can you proceed to setting up the sample.
+Now you may proceed with setting up the sample.
 
 ## Setting up a sample
 

--- a/dotnet/samples/README.md
+++ b/dotnet/samples/README.md
@@ -1,65 +1,69 @@
 # Samples
 
-In this folder you will find various examples showcasing the different capabilities of the .NET Teams AI Library. Here are the general instructions for setting up a sample: 
+In this folder you will find various examples showcasing the different capabilities of the .NET Teams AI Library. Here are the general instructions for setting up a sample:
 
 ## Prerequisites
 
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
 - [Azure OpenAI](https://aka.ms/oai/access) resource or an account with [OpenAI](https://platform.openai.com).
 
-### Consuming the latest version of the library (preview only) 
+### Consuming the latest version of the library (preview only)
 
-> **NOTE:**  As the library has not been published to NuGet's public registry, please complete the following steps to be able to use the samples. Otherwise, the samples will not work.
+> **NOTE:** As the library has not been published to NuGet's public registry, please complete the following steps to be able to use the samples. Otherwise, the samples will not work.
+
+There are two paths to get the package. Please do one of the following, not both.
+
+1. [Download via GitHub package manager](#option-1-install-package-via-github-package-manager)
+2. [Build the package locally](#option-2-install-package-via-local-build)
+
+#### Option 1: Install package via GitHub package manager
 
 The development versions of the library might not be available on NuGet's public registry. Follow the instructions below to generate the `.nukpg` NuGet package file of the library to locally consume within the sample:
 
-1. Clone the repository:
+1. Clone the repository and verify you are on `main` branch:
 
 `git clone https://github.com/Microsoft/teams-ai.git`
 
-2. Checkout the `DOTNET` branch.
-`git checkout DOTNET`
-3. Navigate to the `teams-ai/dotnet/packages/Microsoft.TeamsAI` folder.
-
-### Install Package
-
-4. Generate a [Personal Github Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `package:read` permission.
-
-5. Update the `Nuget.Config` file with your Github username and your new access token as the password.
-
-![Nuget.Config](./assets/screenshot-1.png)
-
-6. Navigate to `Tools > Nuget Package Manager > Manage Nuget Packages For Solution` and install `Microsoft.TeamsAI`.
+1. Generate a [Personal Github Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `package:read` permission.
+1. Update the `Nuget.Config` file with your Github username and your new access token as the password.
+   ![Nuget.Config](./assets/screenshot-1.png)
+1. Navigate to `Tools > Nuget Package Manager > Manage Nuget Packages For Solution` and install `Microsoft.TeamsAI`.
 
 ![Install Package](./assets/screenshot-0.png)
 
-### Build/Install Package
+❕❕ If you followed the above directions, you do not need to do Option 2 below. [Skip to building your sample](#setting-up-a-sample)
 
-Alternatively if you want to build the package locally:
+#### Option 2: Install Package via local build
 
-4. Run `dotnet pack` in terminal.
+1. Clone the repository and verify you are on `main` branch:
 
-5. You should then see the following output: 
+`git clone https://github.com/Microsoft/teams-ai.git`
 
-`Successfully created package "C:...\teams-ai\dotnet\packages\Microsoft.TeamsAI\Microsoft.TeamsAI\bin\Debug\Microsoft.TeamsAI.1.0.0.nupkg"`
+1. Navigate to the `teams-ai/dotnet/packages/Microsoft.TeamsAI` folder.
+1. Run `dotnet pack` in terminal.
+1. Verify the output you received:
 
-6. Move the `Microsoft.TeamsAI.1.0.0.nupkg` to the `LocalPkg/` folder within the sample folder.
+```bash
+Successfully created package "C:...\teams-ai\dotnet\packages\Microsoft.TeamsAI\Microsoft.TeamsAI\bin\Debug\Microsoft.TeamsAI.1.0.0.nupkg"
+```
 
-7. Now you can install the `Microsoft.TeamsAI` package from the Visual Studio's `Manage NuGet Packages` flow or by running `dotnet add package Microsoft.TeamsAI`.
+1. Move the `Microsoft.TeamsAI.1.0.0.nupkg` to the `LocalPkg/` folder within the sample folder you are testing.
+1. Navigate to `Tools > Nuget Package Manager > Manage Nuget Packages For Solution` and install `Microsoft.TeamsAI`.
+   > Alternatively, you can run `dotnet add package Microsoft.TeamsAI`.
 
 Now can you proceed to setting up the sample.
 
 ## Setting up a sample
 
-1. Clone the repository:
+1. If you have not yet, clone the repository:
 
 `git clone https://github.com/Microsoft/teams-ai.git`
 
-2. Navigate to the `teams-ai/dotnet/samples` folder, pick a sample (ex. `01.a.echoBot`) and open the `.sln` file. 
+2. Navigate to the `teams-ai/dotnet/samples` folder, pick a sample (ex. `01.a.echoBot`) and open the `.sln` file.
 
 By this point you should have your sample open in your IDE of choice.
 
-There are a few ways to get the application up and running. The latest way is using Teams toolkit with Visual Studio. However you can also set it up manually. You can find instructions for both below:
+There are a few ways to get the application up and running. The latest way is using Teams ToolKit with Visual Studio. However you can also set it up manually. You can find instructions for both below:
 
 <details open>
     <summary><h3> Using Teams Toolkit for Visual Studio </h3></summary>
@@ -72,21 +76,21 @@ There are a few ways to get the application up and running. The latest way is us
   - ![Teams Toolkit Installation](/dotnet/samples/assets/ttk-install.png)
 
 #### Steps
+
 1. Open the solution in Visual Studio. (For example `EchoBot.sln`).
    - Ensure that you set the appropriate config values (ex OpenAI API key). You can find specific instructions in the sample readme under the `Set up instructions` section.
 1. In the debug dropdown menu, select `Dev Tunnels > Create A Tunnel` (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select `Teams Toolkit > Prepare Teams App Dependencies`
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to. 
+1. Right-click your project and select `Teams Toolkit > Prepare Teams App Dependencies`
+1. If prompted, sign in with a Microsoft 365 account for the Teams organization you want
+   to install the app to.
 
-
->If you do not have permission to upload custom apps (sideloading), Teams Toolkit will 
-recommend creating and using a [Microsoft 365 Developer Program](https://developer.microsoft.com/en-us/microsoft-365/dev-program) account - 
-a free program to get your own dev environment sandbox that includes Teams.
+> If you do not have permission to upload custom apps (sideloading), Teams Toolkit will
+> recommend creating and using a [Microsoft 365 Developer Program](https://developer.microsoft.com/en-us/microsoft-365/dev-program) account -
+> a free program to get your own dev environment sandbox that includes Teams.
 
 4. Press F5, or select the `Debug > Start` Debugging menu in Visual Studio
 5. In the launched browser, select the Add button to load the app in Teams
-6. This should redirect you to a chat window with the bot. 
+6. This should redirect you to a chat window with the bot.
 </details>
 
 <details>
@@ -95,45 +99,50 @@ a free program to get your own dev environment sandbox that includes Teams.
 > Note these instructions are for running the sample on your local machine, the tunnelling solution is required because the Teams service needs to call into the bot.
 
 #### Additional requirements
+
 - [ngrok](https://ngrok.com/) or equivalent tunnelling solution
 
 #### Steps
-1) Run ngrok - point to port 5130
 
-    ```bash
-    ngrok http 5130 --host-header="localhost:5130"
-    ```
+1. Run ngrok - point to port 5130
 
-1) Provision Azure resources for the Bot
+   ```bash
+   ngrok http 5130 --host-header="localhost:5130"
+   ```
+
+1. Provision Azure resources for the Bot
 
    In Azure portal, create a [Azure Bot resource](https://docs.microsoft.com/azure/bot-service/bot-service-quickstart-registration).
-    - For bot handle, make up a name.
-    - Select "Use existing app registration" (Create the app registration in Azure Active Directory beforehand.)
-    - __*If you don't have an Azure account*__ create an [Azure free account here](https://azure.microsoft.com/free/)
-    
-   In the new Azure Bot resource in the Portal, 
-    - Ensure that you've [enabled the Teams Channel](https://learn.microsoft.com/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
-    - In Settings/Configuration/Messaging endpoint, enter the current `https` URL you were given by running ngrok. Append with the path `/api/messages`
 
-1) Open the sample's solution in your IDE.
+   - For bot handle, make up a name.
+   - Select "Use existing app registration" (Create the app registration in Azure Active Directory beforehand.)
+   - **_If you don't have an Azure account_** create an [Azure free account here](https://azure.microsoft.com/free/)
 
-1) Update the `appsettings.json` configuration for the bot to use the BotId, BotPassword generated in Step 2 (App Registration creation). (Note the Bot Password is referred to as the "client secret" in the azure portal and you can always create a new client secret anytime.)
+   In the new Azure Bot resource in the Portal,
 
-1) Run your bot, either from Visual Studio with `F5` or using `dotnet run` in the appropriate folder.
+   - Ensure that you've [enabled the Teams Channel](https://learn.microsoft.com/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
+   - In Settings/Configuration/Messaging endpoint, enter the current `https` URL you were given by running ngrok. Append with the path `/api/messages`
+
+1. Open the sample's solution in your IDE.
+
+1. Update the `appsettings.json` configuration for the bot to use the BotId, BotPassword generated in Step 2 (App Registration creation). (Note the Bot Password is referred to as the "client secret" in the azure portal and you can always create a new client secret anytime.)
+
+1. Run your bot, either from Visual Studio with `F5` or using `dotnet run` in the appropriate folder.
 
 <details>
     <summary>6. <b><em>This step is specific to Teams.</em></b></summary>
 
-- **Edit** the `manifest.json` contained in the  `appPackage` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) *everywhere* you see the place holder string `${{TEAMS_APP_ID}}` or `${{BOT_ID}}` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`).
+- **Edit** the `manifest.json` contained in the `appPackage` folder to replace your Microsoft App Id (that was created when you registered your bot earlier) _everywhere_ you see the place holder string `${{TEAMS_APP_ID}}` or `${{BOT_ID}}` (depending on the scenario the Microsoft App Id may occur multiple times in the `manifest.json`).
 - **Edit** the `manifest.json` for `validDomains` with base Url domain. E.g. if you are using ngrok it would be `https://1234.ngrok-free.app` then your domain-name will be `1234.ngrok-free.app`.
 - **Zip** up the contents of the `appPackage` folder to create a `manifest.zip` (Make sure that zip file does not contains any subfolder otherwise you will get error while uploading your .zip package)
 - **Upload** the `manifest.zip` to Teams (In Teams Apps/Manage your apps click "Upload an app". Browse to and Open the .zip file. At the next dialog, click the Add button.)
-Add the app to personal/team/groupChat scope (Supported scopes)
-    </details>
+  Add the app to personal/team/groupChat scope (Supported scopes)
+  </details>
 
 </details>
 
 ## List of Samples
+
 Follow the above instructions to run the C# .NET samples. Here's a list of the samples:
 
 ### Basic Conversational Experience
@@ -195,11 +204,12 @@ A conversational bot for Microsoft Teams, designed as an AI assistant of the Ult
 This sample showcases the incredible capabilities of language models and the concept of user intent. Challenge your skills as the human player and try to guess a secret within 20 questions, while the AI-powered bot answers your queries about the secret.
 
 ## Miscellanous Resources
+
 In this section you can find miscellanous instructions.
 
 ### Deploy to Azure
 
-You can also deploy the samples to Azure, both manually or using Teams Toolkit. 
+You can also deploy the samples to Azure, both manually or using Teams Toolkit.
 
 Use the "Teams Toolkit" > "Provision in the Cloud...", "Teams Toolkit" > "Deploy to the Cloud" from project right-click menu, or from the CLI with `teamsfx provision` and `teamsfx deploy`. [Visit the documentation](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) for more info on hosting your app in Azure with Teams Toolkit.
 

--- a/dotnet/samples/README.md
+++ b/dotnet/samples/README.md
@@ -13,8 +13,8 @@ In this folder you will find various examples showcasing the different capabilit
 
 There are two paths to get the package. Please do one of the following, not both.
 
-<details>
-    <summary><h4>Option 1: Install package via GitHub package manager</h4></summary>
+<ul><li><details>
+<summary><h4>Option 1: Install package via GitHub package manager</h4></summary>
 
 Follow the instructions below to generate the `.nukpg` NuGet package file of the library to locally consume within the sample:
 
@@ -31,7 +31,8 @@ Follow the instructions below to generate the `.nukpg` NuGet package file of the
 
 ❕❕ If you followed the above directions, you do not need to do Option 2 below. [Skip to building your sample](#setting-up-a-sample)
 
-</details><details> <!-- done to minimize whitespace between blocks -->
+</details></li>
+<li><details> <!-- done to minimize whitespace between blocks -->
     <summary><h4>Option 2: Install Package via local build</h4></summary>
 
 1. Clone the repository and verify you are on `main` branch:
@@ -50,6 +51,8 @@ Successfully created package "C:...\teams-ai\dotnet\packages\Microsoft.TeamsAI\M
 1. Navigate to `Tools > Nuget Package Manager > Manage Nuget Packages For Solution` and install `Microsoft.TeamsAI`.
    > Alternatively, you can run `dotnet add package Microsoft.TeamsAI`.
    </details>
+   </li>
+   </ul>
 
 Now you may proceed with setting up the sample.
 

--- a/dotnet/samples/README.md
+++ b/dotnet/samples/README.md
@@ -16,14 +16,14 @@ There are two paths to get the package. Please do one of the following, not both
 <details>
     <summary><h4>Option 1: Install package via GitHub package manager</h4></summary>
 
-The development versions of the library might not be available on NuGet's public registry. Follow the instructions below to generate the `.nukpg` NuGet package file of the library to locally consume within the sample:
+Follow the instructions below to generate the `.nukpg` NuGet package file of the library to locally consume within the sample:
 
 1. Clone the repository and verify you are on `main` branch:
 
 `git clone https://github.com/Microsoft/teams-ai.git`
 
 1. Generate a [Personal Github Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with the `package:read` permission.
-1. Update the `Nuget.Config` file with your Github username and your new access token as the password.
+1. Update the `Nuget.Config` file of the sample you are testing with your Github username and your new access token as the password.
    ![Nuget.Config](./assets/screenshot-1.png)
 1. Navigate to `Tools > Nuget Package Manager > Manage Nuget Packages For Solution` and install `Microsoft.TeamsAI`.
 
@@ -31,9 +31,7 @@ The development versions of the library might not be available on NuGet's public
 
 ❕❕ If you followed the above directions, you do not need to do Option 2 below. [Skip to building your sample](#setting-up-a-sample)
 
-</details>
-
-<details>
+</details><details> <!-- done to minimize whitespace between blocks -->
     <summary><h4>Option 2: Install Package via local build</h4></summary>
 
 1. Clone the repository and verify you are on `main` branch:

--- a/js/.nycrc
+++ b/js/.nycrc
@@ -1,8 +1,8 @@
 {
-    "extension": [".js"],
-    "include": ["lib/**/*.js"],
+    "extension": [".ts"],
+    "include": ["packages/**/src/**/*.ts", "lib/**/*.js"],
     "exclude": ["**/node_modules/**", "**/tests/**", "**/coverage/**", "**/*.d.ts", "**/*.spec.ts"],
-    "reporter": ["html"],
+    "reporter": ["html", "text"],
     "all": true,
     "cache": true
 }

--- a/js/.vscode/settings.json
+++ b/js/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.tabSize": 4,
+    "editor.wordWrap": "on",
+    "eslint.enable": true,
+    "eslint.workingDirectories": ["./packages", "./samples"],
+    "hints.no-inline-styles": "off" // Removes warnings for coverage report files
+}

--- a/js/package.json
+++ b/js/package.json
@@ -17,7 +17,7 @@
         "package": "wsrun -e -t -l --if is-not-private --bin yarn pack",
         "test": "yarn tsc -b packages/teams-ai && npx mocha -r ts-node/register packages/teams-ai/src/**/*.spec.ts",
         "test:mocha": "nyc --silent mocha --require ts-node/register \"./packages/teams-ai/src/*.spec.ts\" --exit --check-leaks",
-        "test:nyc:report": "nyc report"
+        "test:nyc:report": "npx rimraf coverage && nyc report"
     },
     "devDependencies": {
         "@azure/logger": "^1.0.2",

--- a/js/packages/teams-ai/src/AzureOpenAIPlanner.ts
+++ b/js/packages/teams-ai/src/AzureOpenAIPlanner.ts
@@ -16,6 +16,10 @@ import { TurnState } from './TurnState';
  */
 export interface AzureOpenAIPlannerOptions extends OpenAIPlannerOptions {
     /**
+     * The default model to use. This should be the model deployment name, not the model
+     */
+    defaultModel: string;
+    /**
      * Endpoint for your Azure OpenAI deployment.
      */
     endpoint: string;

--- a/js/packages/teams-ai/src/ConversationHistory.spec.ts
+++ b/js/packages/teams-ai/src/ConversationHistory.spec.ts
@@ -58,8 +58,6 @@ describe('ConversationHistory', () => {
             ConversationHistory.clear(state);
         });
 
-        // TODO: (Discussion) Should it actually throw an error if there is no "conversation" member?
-        // It seems unnecessarily strict for an operation that clears the state...
         it('should throw an Error if state has no "conversation" member', () => {
             const state: TurnState = {};
 
@@ -245,7 +243,7 @@ describe('ConversationHistory', () => {
             assert.equal(lastLine, expectedLastLine);
         });
 
-        // TODO: (Discussion) When history exists, but no SAY or DO exist in the last line, replacing the entire line with `${assistantPrefix}${newResponse}` doesn't ensure that SAY is included in newResponse.
+        // Just a note, since this behavior will change in the short-term.
         // This behavior doesn't follow the same behavior as when a SAY or DO is already found in the last line.
         // We need to decide if the newResponse should always have `SAY ` prefixed or not.
         it.skip('should replace entire last line if no SAY or DO found', () => {

--- a/js/packages/teams-ai/src/ConversationHistory.spec.ts
+++ b/js/packages/teams-ai/src/ConversationHistory.spec.ts
@@ -58,9 +58,9 @@ describe('ConversationHistory', () => {
             ConversationHistory.clear(state);
         });
 
-        // TODO: Should it actually throw an error if there is no "conversation" member?
+        // TODO: (Discussion) Should it actually throw an error if there is no "conversation" member?
         // It seems unnecessarily strict for an operation that clears the state...
-        it.skip('should throw an Error if state has no "conversation" member', () => {
+        it('should throw an Error if state has no "conversation" member', () => {
             const state: TurnState = {};
 
             assert.throws(() => ConversationHistory.clear(state));
@@ -245,7 +245,7 @@ describe('ConversationHistory', () => {
             assert.equal(lastLine, expectedLastLine);
         });
 
-        // TODO: When history exists, but no SAY or DO exist in the last line, replacing the entire line with `${assistantPrefix}${newResponse}` doesn't ensure that SAY is included in newResponse.
+        // TODO: (Discussion) When history exists, but no SAY or DO exist in the last line, replacing the entire line with `${assistantPrefix}${newResponse}` doesn't ensure that SAY is included in newResponse.
         // This behavior doesn't follow the same behavior as when a SAY or DO is already found in the last line.
         // We need to decide if the newResponse should always have `SAY ` prefixed or not.
         it.skip('should replace entire last line if no SAY or DO found', () => {


### PR DESCRIPTION
1. Resolves #424 (as a stop-gap between updates)
    1. Add information for `defaultModel` in   `AzureOpenAIPlannerOptions` so users know what deployment/model name to use.
    2. This is a mitigation until #394 is resolved.
1. #54 
    1. Minor cleanup of test scripts
    2. !! Add questions for discussion on `ConversationHistory` implementation for `clear()` behavior and `replaceLastSay()`
1. (no work item) Update `dotnet/samples/README.md` for clarity