### PR TITLE
[C#] Replace base Exception with more specific exception

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionHandlerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionHandlerTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.TeamsAI.Tests.AITests
 
             // Act
             IActionCollection<TestTurnState> actions = ImportActions<TestTurnState>(instance);
-            var exception = await Assert.ThrowsAsync<Exception>(async () => await actions[actionName].Handler.PerformAction(turnContext, turnState, entities, actionName));
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await actions[actionName].Handler.PerformAction(turnContext, turnState, entities, actionName));
 
             // Assert
             Assert.NotNull(exception);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/ActivityHandlerTests/ActivityHandlerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/ActivityHandlerTests/ActivityHandlerTests.cs
@@ -738,7 +738,7 @@ namespace Microsoft.TeamsAI.Tests.ActivityHandlerTests
             var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
 
             // Act
-            var exception = Assert.Throws<Exception>(() => new TestActivityHandler(new TestApplicationOptions
+            var exception = Assert.Throws<ArgumentException>(() => new TestActivityHandler(new TestApplicationOptions
             {
                 LongRunningMessages = true,
                 StartTypingTimer = false,

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AI.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AI.cs
@@ -103,7 +103,7 @@ namespace Microsoft.TeamsAI.AI
                 }
                 else
                 {
-                    throw new Exception($"Attempting to register an already existing action `{name}` that does not allow overrides.");
+                    throw new AIException($"Attempting to register an already existing action `{name}` that does not allow overrides.");
                 }
             }
 
@@ -143,7 +143,7 @@ namespace Microsoft.TeamsAI.AI
             HashSet<string> uniquenessCheck = new(from x in result select x.Name, StringComparer.OrdinalIgnoreCase);
             if (result.Count > uniquenessCheck.Count)
             {
-                throw new Exception("Function overloads are not supported, please differentiate function names");
+                throw new AIException("Function overloads are not supported, please differentiate function names");
             }
 
             // Register the actions

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionEntry.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionEntry.cs
@@ -41,12 +41,12 @@ namespace Microsoft.TeamsAI.AI.Action
         {
             if (methodSignature == null)
             {
-                throw new Exception("Method is null");
+                throw new ArgumentNullException(nameof(methodSignature), "Method is null");
             }
 
             if (methodContainerInstance == null)
             {
-                throw new Exception("Method container instance is null");
+                throw new ArgumentNullException(nameof(methodContainerInstance), "Method container instance is null");
             }
 
             ActionAttribute? actionAttribute = methodSignature
@@ -54,7 +54,7 @@ namespace Microsoft.TeamsAI.AI.Action
                 .Cast<ActionAttribute>()
                 .FirstOrDefault();
 
-            if (actionAttribute == null) 
+            if (actionAttribute == null)
             {
                 return null;
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TeamsAI.AI.Action
                 && _returnType != typeof(ValueTask)
                 && _returnType != typeof(ValueTask<bool>))
             {
-                throw new Exception($"Action method return type should be one of [void, bool, Task, Task<bool>, ValueTask, ValueTask<bool>]. Method name: {_method.Name}.");
+                throw new InvalidOperationException($"Action method return type should be one of [void, bool, Task, Task<bool>, ValueTask, ValueTask<bool>]. Method name: {_method.Name}.");
             }
 
             ParameterInfo[] parameters = _method.GetParameters();
@@ -47,7 +47,7 @@ namespace Microsoft.TeamsAI.AI.Action
                 }
                 else if (parameterAttributes.Count() > 1)
                 {
-                    throw new Exception($"Action method parameter should have no more than one parameter attribute. Method name: {_method.Name}. Parameter name: {parameter.Name}.");
+                    throw new InvalidOperationException($"Action method parameter should have no more than one parameter attribute. Method name: {_method.Name}. Parameter name: {parameter.Name}.");
                 }
                 else
                 {
@@ -124,7 +124,7 @@ namespace Microsoft.TeamsAI.AI.Action
                 }
                 else
                 {
-                    throw new Exception($"Action method return type should be one of [void, bool, Task, Task<bool>, ValueTask, ValueTask<bool>]. Method name: {_method.Name}.");
+                    throw new InvalidOperationException($"Action method return type should be one of [void, bool, Task, Task<bool>, ValueTask, ValueTask<bool>]. Method name: {_method.Name}.");
                 }
             }
             catch (TargetInvocationException ex)
@@ -144,7 +144,7 @@ namespace Microsoft.TeamsAI.AI.Action
         {
             if (!to.IsAssignableFrom(from))
             {
-                throw new Exception($"Cannot assign {from} to {to} of action method {method.Name}");
+                throw new InvalidOperationException($"Cannot assign {from} to {to} of action method {method.Name}");
             }
         }
     }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
@@ -61,12 +61,12 @@ namespace Microsoft.TeamsAI.AI.Action
 
             if (doCommandActionData.Handler == null)
             {
-                throw new Exception("Unexpected `data` object: Handler does not exist");
+                throw new ArgumentException("Unexpected `data` object: Handler does not exist");
             }
 
             if (doCommandActionData.PredictedDoCommand == null)
             {
-                throw new Exception("Unexpected `data` object: PredictedDoCommand does not exist");
+                throw new ArgumentException("Unexpected `data` object: PredictedDoCommand does not exist");
             }
 
             IActionHandler<TState> handler = doCommandActionData.Handler;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompt/PromptTemplateConfiguration.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompt/PromptTemplateConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.SemanticKernel.SemanticFunctions;
+using Microsoft.TeamsAI.Exceptions;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using static Microsoft.SemanticKernel.SemanticFunctions.PromptTemplateConfig;
@@ -192,7 +193,7 @@ namespace Microsoft.TeamsAI.AI.Prompt
 
             if (result == null)
             {
-                throw new Exception("Failed to deserialize prompt configuration JSON string");
+                throw new PromptManagerException("Failed to deserialize prompt configuration JSON string");
             }
 
             return result;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TeamsAI
             // Validate long running messages configuration
             if (Options.LongRunningMessages == true && (Options.Adapter == null || Options.BotAppId == null))
             {
-                throw new Exception("The ApplicationOptions.LongRunningMessages property is unavailable because no adapter or botAppId was configured.");
+                throw new ArgumentException("The ApplicationOptions.LongRunningMessages property is unavailable because no adapter or botAppId was configured.");
             }
 
         }
@@ -70,7 +70,7 @@ namespace Microsoft.TeamsAI
             {
                 if (_ai == null)
                 {
-                    throw new Exception("The Application.AI property is unavailable because no AI options were configured.");
+                    throw new ArgumentException("The Application.AI property is unavailable because no AI options were configured.");
                 }
 
                 return _ai;
@@ -1324,7 +1324,7 @@ namespace Microsoft.TeamsAI
                 invokeValue = obj.ToObject<SearchInvokeValue>();
                 if (invokeValue == null)
                 {
-                    throw new Exception();
+                    throw new InvalidOperationException("Value property is not valid for search.");
                 }
             }
             catch (Exception ex)
@@ -1388,7 +1388,7 @@ namespace Microsoft.TeamsAI
                 invokeValue = obj.ToObject<AdaptiveCardInvokeValue>();
                 if (invokeValue == null)
                 {
-                    throw new Exception();
+                    throw new InvalidOperationException("Value property is not properly formed.");
                 }
             }
             catch (Exception ex)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.TeamsAI
 
         private async void SendTypingActivity(object state)
         {
-            ITurnContext turnContext = state as ITurnContext ?? throw new Exception("Unexpected failure of casting object TurnContext");
+            ITurnContext turnContext = state as ITurnContext ?? throw new ArgumentException("Unexpected failure of casting object TurnContext");
 
             try
             {


### PR DESCRIPTION
Resolve https://github.com/microsoft/teams-ai/issues/416
- For argument check, throw `ArgumentException` or `ArgumentNullException`
- For `AI` methods, throw `AIException`
- For Prompt, throw `PromptManagerException`
- For other runtime unexpected behavior, throw `InvalidOperationException`