### PR TITLE
Make json serializer options object a singleton instance

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateEntryTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateEntryTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.TeamsAI.State;
+
+namespace Microsoft.TeamsAI.Tests.StateTests
+{
+    public class TurnStateEntryTests
+    {
+        [Fact]
+        public void Test_Delete_EntryIsDeleted()
+        {
+            // Arrange
+            TurnStateEntry<string> entry = new("key", new string("string"));
+
+            // Act
+            entry.Delete();
+
+            // Assert
+            Assert.True(entry.IsDeleted);
+        }
+
+        [Fact]
+        public void Test_ComputeHash_FromDictionary()
+        {
+            // Arrange
+            StateBase map = new();
+            map["key1"] = "value1";
+
+            // Act
+            string hash = TurnStateEntry<StateBase>.ComputeHash(map);
+
+            // Assert
+            Assert.Equal("{\"key1\":\"value1\"}", hash);
+        }
+
+        [Fact]
+        public void Test_HasChanged_IsChanged()
+        {
+            // Arrange
+            StateBase map = new();
+            map["key1"] = "value1";
+            TurnStateEntry<StateBase> entry = new(map);
+
+            // Act
+            map["key1"] = "value2";
+
+            // Assert
+            Assert.True(entry.HasChanged);
+        }
+
+        [Fact]
+        public void Test_HasChanged_NotChanged()
+        {
+            // Arrange
+            StateBase map = new();
+            map["key1"] = "value1";
+            TurnStateEntry<StateBase> entry = new(map);
+
+            // Act
+            map["key1"] = "value1";
+
+            // Assert
+            Assert.False(entry.HasChanged);
+        }
+
+        [Fact]
+        public void Test_Value_GetsValue()
+        {
+            // Arrange
+            StateBase map = new();
+            TurnStateEntry<StateBase> entry = new(map);
+
+            // Act
+            StateBase value = entry.Value;
+
+            // Assert
+            Assert.Equal(value, map);
+        }
+
+        [Fact]
+        public void Test_Value_RestoreDeletedEntry()
+        {
+            // Arrange
+            StateBase map = new();
+            TurnStateEntry<StateBase> entry = new(map);
+            entry.Delete(); // Should be deleted
+
+            // Act - accessing deleted entry value should undelete entry
+            StateBase _ = entry.Value;
+
+            // Assert
+            Assert.False(entry.IsDeleted);
+        }
+
+        [Fact]
+        public void Test_Replace_ReplacesEntryValue()
+        {
+            // Arrange
+            TurnStateEntry<string> entry = new("string 1");
+            entry.Delete(); // Should be deleted
+
+            // Act - accessing deleted entry value should undelete entry
+            entry.Replace("string 2");
+
+            // Assert
+            Assert.Equal("string 2", entry.Value);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AzureContentSafety/AzureContentSafetyClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AzureContentSafety/AzureContentSafetyClient.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TeamsAI.AI.AzureContentSafety
         private readonly HttpClient _httpClient;
         private readonly ILogger? _logger;
         private readonly AzureContentSafetyClientOptions _options;
-        private static readonly JsonSerializerOptions s_options = new()
+        private static readonly JsonSerializerOptions _serializerOptions = new()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
@@ -42,7 +42,7 @@ namespace Microsoft.TeamsAI.AI.AzureContentSafety
             try
             {
                 using HttpContent content = new StringContent(
-                    JsonSerializer.Serialize(request, s_options),
+                    JsonSerializer.Serialize(request, _serializerOptions),
                     Encoding.UTF8,
                     "application/json"
                 );

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AzureContentSafety/AzureContentSafetyClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AzureContentSafety/AzureContentSafetyClient.cs
@@ -19,6 +19,10 @@ namespace Microsoft.TeamsAI.AI.AzureContentSafety
         private readonly HttpClient _httpClient;
         private readonly ILogger? _logger;
         private readonly AzureContentSafetyClientOptions _options;
+        private static readonly JsonSerializerOptions s_options = new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
 
         public AzureContentSafetyClient(AzureContentSafetyClientOptions options, ILogger? logger = null, HttpClient? httpClient = null)
         {
@@ -38,10 +42,7 @@ namespace Microsoft.TeamsAI.AI.AzureContentSafety
             try
             {
                 using HttpContent content = new StringContent(
-                    JsonSerializer.Serialize(request, new JsonSerializerOptions()
-                    {
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                    }),
+                    JsonSerializer.Serialize(request, s_options),
                     Encoding.UTF8,
                     "application/json"
                 );

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
@@ -21,6 +21,10 @@ namespace Microsoft.TeamsAI.OpenAI
         private HttpClient _httpClient;
         private ILogger? _logger;
         private OpenAIClientOptions _options;
+        private static readonly JsonSerializerOptions s_options = new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
 
         public OpenAIClient(OpenAIClientOptions options, ILogger? logger = null, HttpClient? httpClient = null)
         {
@@ -45,10 +49,7 @@ namespace Microsoft.TeamsAI.OpenAI
                     {
                         model = model,
                         input = text
-                    }, new JsonSerializerOptions()
-                    {
-                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                    }),
+                    }, s_options),
                     Encoding.UTF8,
                     "application/json"
                 );

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
@@ -21,7 +21,7 @@ namespace Microsoft.TeamsAI.OpenAI
         private HttpClient _httpClient;
         private ILogger? _logger;
         private OpenAIClientOptions _options;
-        private static readonly JsonSerializerOptions s_options = new()
+        private static readonly JsonSerializerOptions _serializerOptions = new()
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
@@ -49,7 +49,7 @@ namespace Microsoft.TeamsAI.OpenAI
                     {
                         model = model,
                         input = text
-                    }, s_options),
+                    }, _serializerOptions),
                     Encoding.UTF8,
                     "application/json"
                 );

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnStateEntry.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnStateEntry.cs
@@ -7,6 +7,7 @@ namespace Microsoft.TeamsAI.State
     {
         private TValue _value;
         private string _hash;
+        private static readonly JsonSerializerOptions s_options = new() { MaxDepth = 64 };
 
         /// <summary>
         /// Constructs the turn state entry.
@@ -77,7 +78,7 @@ namespace Microsoft.TeamsAI.State
         {
             Verify.ParamNotNull(obj);
 
-            return JsonSerializer.Serialize(obj, new JsonSerializerOptions() { MaxDepth = 64 });
+            return JsonSerializer.Serialize(obj, s_options);
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnStateEntry.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnStateEntry.cs
@@ -1,13 +1,16 @@
 ﻿using Microsoft.TeamsAI.Utilities;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 
+[assembly: InternalsVisibleTo("Microsoft.TeamsAI.Tests")]
 namespace Microsoft.TeamsAI.State
 {
+
     public class TurnStateEntry<TValue> : IReadOnlyEntry<TValue> where TValue : class
     {
         private TValue _value;
         private string _hash;
-        private static readonly JsonSerializerOptions s_options = new() { MaxDepth = 64 };
+        private static readonly JsonSerializerOptions _serializerOptions = new() { MaxDepth = 64 };
 
         /// <summary>
         /// Constructs the turn state entry.
@@ -78,7 +81,7 @@ namespace Microsoft.TeamsAI.State
         {
             Verify.ParamNotNull(obj);
 
-            return JsonSerializer.Serialize(obj, s_options);
+            return JsonSerializer.Serialize(obj, _serializerOptions);
         }
     }
 }


### PR DESCRIPTION
#414  made all instances of `JsonSerializerOptions` as singleton by making it a private static property in the class where it is used. This is for performance reasons. 

[Article on performance difference](https://www.meziantou.net/avoid-performance-issue-with-jsonserializer-by-reusing-the-same-instance-of-json.htm)