### PR TITLE
fix: not using tokenizer in ConversationHistory.to_str()

### DIFF
--- a/python/packages/ai/teams/ai/state/conversation_history.py
+++ b/python/packages/ai/teams/ai/state/conversation_history.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 import tiktoken
 
@@ -78,7 +78,24 @@ class ConversationHistory(List[Message]):
 
         return -1
 
-    def to_str(self, max_tokens: int, token_encoding: str, delim="\n") -> str:
+    def to_str(
+        self, max_tokens: int, token_encoding: Literal["cl100k_base", "p50k_base"], delim="\n"
+    ) -> str:
+        """
+        Returns a string representation of the conversation history.
+        The string is limited to the specified number of tokens.
+
+        Args:
+            max_tokens (int): The maximum number of tokens to return.
+            token_encoding (str): The token encoding to use. Available values are:
+                                  "cl100k_base" for gpt-4 and gpt-3.5-turbo,
+                                  "p50k_base" for text-davinci-002 and text-davinci-003.
+            delim (str): The delimiter to use between lines. Defaults to "\n".
+
+        Returns:
+            str: The string representation of the conversation history.
+        """
+
         value = ""
         encoding = tiktoken.get_encoding(token_encoding)
 

--- a/python/packages/ai/teams/ai/state/conversation_history.py
+++ b/python/packages/ai/teams/ai/state/conversation_history.py
@@ -5,6 +5,8 @@ Licensed under the MIT License.
 
 from typing import List, Optional
 
+import tiktoken
+
 from .message import Message, MessageRole
 from .state_error import StateError
 
@@ -76,13 +78,17 @@ class ConversationHistory(List[Message]):
 
         return -1
 
-    def to_str(self, max_tokens: int, delim="\n") -> str:
+    def to_str(self, max_tokens: int, token_encoding: str, delim="\n") -> str:
         value = ""
+        encoding = tiktoken.get_encoding(token_encoding)
 
+        text_tokens = 0
         for item in self:
             line = f"[{item.role}]: {item.content}{delim}"
 
-            if len(value) + len(line) > max_tokens:
+            line_tokens = len(encoding.encode(line))
+            text_tokens = text_tokens + line_tokens
+            if text_tokens > max_tokens:
                 break
 
             value += line


### PR DESCRIPTION
The `to_str` function does not use a tokenizer, so the calculation of used tokens will be inaccurate. This PR uses the recommended tokenizer to encode and calculate the total tokens.

@aacebo I'm not sure whether it's on purpose to just use `len()`. If yes, you can close this PR directly without merge.