### PR TITLE
[C#] fix: fix missing built-in variables

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
@@ -153,16 +153,20 @@ namespace Microsoft.TeamsAI.Tests.AITests
                 Prompt = "Test"
             };
             var ai = new AI<TestTurnState>(options);
-            var turnContextMock = new Mock<ITurnContext>();
-            var turnState = new TestTurnState();
+            var turnContext = new TurnContext(new NotImplementedAdapter(), MessageFactory.Text("hello"));
+            var turnState = new TestTurnState
+            {
+                TempStateEntry = new TurnStateEntry<TempState>(new())
+            };
 
             // Act
-            var result = await ai.CompletePromptAsync(turnContextMock.Object, turnState, "Test", null, CancellationToken.None);
+            var result = await ai.CompletePromptAsync(turnContext, turnState, "Test", null, CancellationToken.None);
 
             // Assert
             Assert.Equal("Default", result);
             Assert.Equal(new string[] { "CompletePromptAsync" }, planner.Record.ToArray());
             Assert.Equal(new string[] { "RenderPrompt" }, promptManager.Record.ToArray());
+            Assert.Equal("hello", turnState.Temp?.Input);
         }
 
         [Fact]
@@ -176,17 +180,21 @@ namespace Microsoft.TeamsAI.Tests.AITests
                 Prompt = "Test"
             };
             var ai = new AI<TestTurnState>(options);
-            var turnContextMock = new Mock<ITurnContext>();
-            var turnState = new TestTurnState();
+            var turnContext = new TurnContext(new NotImplementedAdapter(), MessageFactory.Text("hello"));
+            var turnState = new TestTurnState
+            {
+                TempStateEntry = new TurnStateEntry<TempState>(new())
+            };
             var prompt = new PromptTemplate("Test", new());
 
             // Act
-            var result = await ai.CompletePromptAsync(turnContextMock.Object, turnState, prompt, null, CancellationToken.None);
+            var result = await ai.CompletePromptAsync(turnContext, turnState, prompt, null, CancellationToken.None);
 
             // Assert
             Assert.Equal("Default", result);
             Assert.Equal(new string[] { "CompletePromptAsync" }, planner.Record.ToArray());
             Assert.Equal(new string[] { "RenderPrompt" }, promptManager.Record.ToArray());
+            Assert.Equal("hello", turnState.Temp?.Input);
         }
 
         [Fact]

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AI.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AI.cs
@@ -332,6 +332,7 @@ namespace Microsoft.TeamsAI.AI
 
             // Configure options
             AIOptions<TState> aiOptions = _ConfigureOptions(options);
+            _SetTempStateValues(turnState, turnContext, aiOptions);
 
             // Render the prompt
             PromptTemplate renderedPrompt = await aiOptions.PromptManager.RenderPrompt(turnContext, turnState, promptTemplate);
@@ -357,6 +358,7 @@ namespace Microsoft.TeamsAI.AI
 
             // Configure options
             AIOptions<TState> aiOptions = _ConfigureOptions(options);
+            _SetTempStateValues(turnState, turnContext, aiOptions);
 
             // Render the prompt
             PromptTemplate renderedPrompt = await aiOptions.PromptManager.RenderPrompt(turnContext, turnState, name);


### PR DESCRIPTION
## Linked issues

Fixes #490

## Details

Fix the missing temp variables when calling `AI.CompletePromptAsync()`.

#### Change details

- Call `_SetTempStateValues` to set `input` and `history`
- Add unit test to cover this fix

**code snippets**:

**screenshots**:

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
