### PR TITLE
[C#] fix: normalize line endings to fix Plan tests failing

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PlanTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PlanTests.cs
@@ -15,9 +15,10 @@ namespace Microsoft.TeamsAI.Tests.AITests
   ""type"": ""plan"",
   ""commands"": []
 }";
+            expectedPlanJson = expectedPlanJson.ReplaceLineEndings();
 
             // Act
-            string planJson = plan.ToJsonString();
+            string planJson = plan.ToJsonString().ReplaceLineEndings();
 
             // Assert
             Assert.Equal(expectedPlanJson, planJson);
@@ -47,9 +48,10 @@ namespace Microsoft.TeamsAI.Tests.AITests
     }
   ]
 }";
+            expectedPlanJson = expectedPlanJson.ReplaceLineEndings();
 
             // Act
-            string planJson = plan.ToJsonString();
+            string planJson = plan.ToJsonString().ReplaceLineEndings();
 
             // Assert
             Assert.Equal(expectedPlanJson, planJson);


### PR DESCRIPTION
## Linked issues

fixes: #505 

## Details

This is a patch to failing Plan tests

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
