### PR TITLE
[C#] feat: seal/internalize non-essential classes

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AIHistoryOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AIHistoryOptions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.TeamsAI.AI
     /// <summary>
     /// Options for the AI system.
     /// </summary>
-    public class AIHistoryOptions
+    public sealed class AIHistoryOptions
     {
         /// <summary>
         /// Whether the AI system should track conversation history.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionEntry.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionEntry.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TeamsAI.AI.Action
     /// Represents an action.
     /// </summary>
     /// <typeparam name="TState"></typeparam>
-    public class ActionEntry<TState> where TState : ITurnState<StateBase, StateBase, TempState>
+    public sealed class ActionEntry<TState> where TState : ITurnState<StateBase, StateBase, TempState>
     {
         /// <summary>
         /// The action name.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DoCommandActionData.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DoCommandActionData.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TeamsAI.AI.Action
     /// The data for default DO command action handler.
     /// </summary>
     /// <typeparam name="TState">Type of turn state.</typeparam>
-    public class DoCommandActionData<TState> where TState : ITurnState<StateBase, StateBase, TempState>
+    internal sealed class DoCommandActionData<TState> where TState : ITurnState<StateBase, StateBase, TempState>
     {
         /// <summary>
         /// The predicted DO command.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/ModerationResponse.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/ModerationResponse.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TeamsAI.AI.Moderator
     public class ModerationResult
     {
         /// <summary>
-        /// The OpenAI categories and whether they were flaggged or not.
+        /// The OpenAI categories and whether they were flagged or not.
         /// </summary>
         [JsonPropertyName("categories")]
         public ModerationCategoriesFlagged? CategoriesFlagged { get; set; }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TeamsAI.AI.OpenAI
     /// <summary>
     /// The client to make calls to OpenAI's API
     /// </summary>
-    public class OpenAIClient
+    internal sealed class OpenAIClient
     {
         private const string HttpUserAgent = "Microsoft Teams AI";
         private const string OpenAIModerationEndpoint = "https://api.openai.com/v1/moderations";
@@ -46,7 +46,7 @@ namespace Microsoft.TeamsAI.AI.OpenAI
         /// <param name="model">The moderation model to use.</param>
         /// <returns>The moderation result from the API call.</returns>
         /// <exception cref="HttpOperationException" />
-        public virtual async Task<ModerationResponse> ExecuteTextModeration(string text, string? model)
+        public async Task<ModerationResponse> ExecuteTextModeration(string text, string? model)
         {
             try
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
@@ -8,12 +9,14 @@ using Microsoft.TeamsAI.AI.Moderator;
 using Microsoft.TeamsAI.Exceptions;
 using Microsoft.TeamsAI.Utilities;
 
+// For Unit Tests - so the Moq framework can mock internal classes
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 namespace Microsoft.TeamsAI.AI.OpenAI
 {
     /// <summary>
     /// The client to make calls to OpenAI's API
     /// </summary>
-    internal sealed class OpenAIClient
+    internal class OpenAIClient
     {
         private const string HttpUserAgent = "Microsoft Teams AI";
         private const string OpenAIModerationEndpoint = "https://api.openai.com/v1/moderations";
@@ -46,7 +49,7 @@ namespace Microsoft.TeamsAI.AI.OpenAI
         /// <param name="model">The moderation model to use.</param>
         /// <returns>The moderation result from the API call.</returns>
         /// <exception cref="HttpOperationException" />
-        public async Task<ModerationResponse> ExecuteTextModeration(string text, string? model)
+        public virtual async Task<ModerationResponse> ExecuteTextModeration(string text, string? model)
         {
             try
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClientOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClientOptions.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Options for the OpenAI client.
     /// </summary>
-    internal sealed class OpenAIClientOptions
+    internal class OpenAIClientOptions
     {
         /// <summary>
         /// OpenAI API key.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClientOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClientOptions.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Options for the OpenAI client.
     /// </summary>
-    public class OpenAIClientOptions
+    internal sealed class OpenAIClientOptions
     {
         /// <summary>
         /// OpenAI API key.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planner/ParsedCommandResult.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planner/ParsedCommandResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.TeamsAI.AI.Planner
 {
-    internal class ParsedCommandResult
+    internal sealed class ParsedCommandResult
     {
         public int Length { get; set; }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompt/SKFunctionWrapper.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompt/SKFunctionWrapper.cs
@@ -6,7 +6,7 @@ using Microsoft.TeamsAI.State;
 
 namespace Microsoft.TeamsAI.AI.Prompt
 {
-    internal class SKFunctionWrapper<TState> : ISKFunction where TState : ITurnState<StateBase, StateBase, TempState>
+    internal sealed class SKFunctionWrapper<TState> : ISKFunction where TState : ITurnState<StateBase, StateBase, TempState>
     {
         // TODO: This is a hack around to get the default skill name from SK's internal implementation. We need to fix this.
         public const string DefaultSkill = "_GLOBAL_FUNCTIONS_";

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompt/TemplateFunctionEntry.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompt/TemplateFunctionEntry.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TeamsAI.AI.Prompt
     /// <returns>A string that is injected in the prompt template.</returns>
     public delegate Task<string> PromptFunction<TState>(ITurnContext turnContext, TState turnState) where TState : ITurnState<StateBase, StateBase, TempState>;
 
-    internal class TemplateFunctionEntry<TState> where TState : ITurnState<StateBase, StateBase, TempState>
+    internal sealed class TemplateFunctionEntry<TState> where TState : ITurnState<StateBase, StateBase, TempState>
     {
         internal PromptFunction<TState> Handler;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Exceptions/HttpOperationException.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Exceptions/HttpOperationException.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TeamsAI.Exceptions
     /// <summary>
     /// Exception thrown when an HTTP operation fails.
     /// </summary>
-    public class HttpOperationException : Exception
+    public sealed class HttpOperationException : Exception
     {
         /// <summary>
         /// HTTP status code.


### PR DESCRIPTION
## Linked issues

closes: #531  (issue number)

## Details

Provide a list of your changes here. If you are fixing a bug, please provide steps to reproduce the bug.

Internalized
- OpenAIClient: We don't expect end users to use our open ai client to directly call the api. They should use other existing libraries for this.
- OpenAIClientOptions: Part of the OpenAI client
- DoCommandActionData: a helper class

Sealed
- A bunch of classes we don't expect the end user to extend.


The motivation behind aggressively sealing/internalizing classes is to prevent end users from relying on components we don't explicitly expect them using. Eg. The OpenAIClient's sole purpose is to service the OpenAIModerator, even though end users can use it to directly call the API. 

If there's a legitimate reason or customer ask to unseal/publicize a class then we can easily do that without break anything. Doing the opposite is a big no-no as it is a breaking change.

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
