### PR TITLE
[repo] chore: Remove ':' from PR keywords requirement when bumping packages

### DIFF
--- a/.github/workflows/pr-style.yml
+++ b/.github/workflows/pr-style.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           require_issue: "true"
           skip_authors: "dependabot"
-          title_prefixes: " [repo] chore:, [repo] docs:, [repo] fix:, [JS] bump:, [JS] chore:, [JS] docs:, [JS] feat:, [JS] fix:, [JS] port:, [JS] refactor:, [C#] bump:, [C#] chore:, [C#] docs:, [C#] feat:, [C#] fix:, [C#] port:, [C#] refactor:, [PY] bump:, [PY] chore:, [PY] docs:, [PY] feat:, [PY] fix:, [PY] port:, [PY] refactor:"
+          title_prefixes: " [repo] chore:, [repo] docs:, [repo] fix:, [JS] bump, [JS] chore:, [JS] docs:, [JS] feat:, [JS] fix:, [JS] port:, [JS] refactor:, [C#] bump, [C#] chore:, [C#] docs:, [C#] feat:, [C#] fix:, [C#] port:, [C#] refactor:, [PY] bump, [PY] chore:, [PY] docs:, [PY] feat:, [PY] fix:, [PY] port:, [PY] refactor:"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ signed CLA, we'll review the request.
 
 1. All PRs must indicate what programming language they are for in the title with a prefix of [JS], [C#] [PY], or [repo].
 1. All PRs must be prepended with one of the following keywords:
-   - _'bump:'_ - indicates a change to the version number of the package
+   - _'bump'_ - indicates a change to the version number of the package
+     - note: ':' was removed since dependabot automatically starts all PR titles with 'bump'
    - _'chore:'_ - indicates a change to the build process or auxiliary tools
    - _'docs:'_ - indicates a change to the documentation
    - _'feat:'_ - indicates a new feature


### PR DESCRIPTION
#minor

## Details

Remove ":" from keyword requirement on PRs for bumping packages. 
This is done to reduce overhead for `dependabot` PRs, which always have 'bump' in the title anyway.