### PR TITLE
[repo] chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+* @microsoft/teams-ai-admins @microsoft/teams-ai-devs @microsoft/teams-ai-maintainer
+
+# JS
+/js @corinagum @Stevenic
+
+# .NET
+/dotnet @singhk97
+
+# Python
+/python @aacebo
+
+# TTK
+**/teamsapp.yml @microsoft/teams-ai-devs
+**/teamsapp.local.yml @microsoft/teams-ai-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @microsoft/teams-ai-admins @microsoft/teams-ai-devs @microsoft/teams-ai-maintainer
+* @microsoft/teams-ai-admins @microsoft/teams-ai-maintainer
 
 # JS
 /js @corinagum @Stevenic

--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,6 +1,0 @@
-@microsoft/teams-ai-admins @microsoft/teams-ai-devs
-
-#TTK
-teamsapp.yml @blackchaoyi @therealjohn @microsoft/teams-ai-devs
-teamsapp.local.yml @blackchaoyi @therealjohn @microsoft/teams-ai-devs
-/getting-started


### PR DESCRIPTION
#minor

- remove `.md` file, currently `CODEOWNERS.md` is not being picked up by github because the file should not be a markdown file.
- add codeowners for different languages

![image](https://github.com/microsoft/teams-ai/assets/44811138/aaf8be6d-a101-41ad-9d66-de80a87346ff)
