### PR TITLE
[C#] refactor: use AOAI as default LLM in samples

### DIFF
--- a/dotnet/samples/04.ai.a.teamsChefBot/README.md
+++ b/dotnet/samples/04.ai.a.teamsChefBot/README.md
@@ -66,12 +66,15 @@ All the samples in for the C# .NET SDK can be set up in the same way. You can fi
 
 Note that, this sample requires AI service so you need one more pre-step before Local Debug (F5).
 
-1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
 
     ```json
-      "OpenAI": {
-        "ApiKey": "<your-openai-api-key>"
-      },
+      "Azure": {
+        "OpenAIApiKey": "<your-azure-openai-api-key>",
+        "OpenAIEndpoint": "<your-azure-openai-endpoint>",
+        "ContentSafetyApiKey": "<your-azure-content-safety-api-key>",
+        "ContentSafetyEndpoint": "<your-azure-content-safety-endpoint>"
+      }
     ```
 
 ## Interacting with the bot
@@ -88,37 +91,7 @@ You can use Teams Toolkit for Visual Studio or CLI to host the bot in Azure. The
 
 You can find deployment instructions [here](../README.md#deploy-to-azure).
 
-Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the OpenAI Key:
-
-1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
-
-The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
-
-## Use Azure OpenAI
-
-Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI as AI service.
-
-**As prerequisites**
-
-1. Prepare your own Azure OpenAI service and Azure AI Content Safety service.
-1. Modify source code `Program.cs`, comment out the "*#Use OpenAI*" part, and uncomment the "*#Use Azure OpenAI and Azure Content Safety*" part.
-
-**For debugging (F5)**
-
-1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
-
-    ```json
-      "Azure": {
-        "OpenAIApiKey": "<your-azure-openai-api-key>",
-        "OpenAIEndpoint": "<your-azure-openai-endpoint>",
-        "ContentSafetyApiKey": "<your-azure-content-safety-api-key>",
-        "ContentSafetyEndpoint": "<your-azure-content-safety-endpoint>"
-      }
-    ```
-
-**For deployment to Azure**
-
-To configure the Azure resources to have Azure OpenAI environment variables:
+Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the Azure OpenAI Key and other settings:
 
 1. In `./env/.env.dev.user` file, paste your Azure OpenAI related variables.
 
@@ -128,6 +101,33 @@ To configure the Azure resources to have Azure OpenAI environment variables:
     SECRET_AZURE_CONTENT_SAFETY_API_KEY=
     SECRET_AZURE_CONTENT_SAFETY_ENDPOINT=
     ```
+
+The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
+
+## Use OpenAI
+
+Above steps use Azure OpenAI as AI service, optionally, you can also use OpenAI as AI service.
+
+**As prerequisites**
+
+1. Prepare your own OpenAI service.
+1. Modify source code `Program.cs`, comment out the "*#Use Azure OpenAI and Azure Content Safety*" part, and uncomment the "*#Use OpenAI*" part.
+
+**For debugging (F5)**
+
+1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+
+    ```json
+      "OpenAI": {
+        "ApiKey": "<your-openai-api-key>"
+      },
+    ```
+
+**For deployment to Azure**
+
+To configure the Azure resources to have OpenAI environment variables:
+
+1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
 
 ## Further reading
 

--- a/dotnet/samples/04.ai.a.teamsChefBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.a.teamsChefBot/appsettings.Development.json
@@ -8,13 +8,13 @@
   "AllowedHosts": "*",
   "BOT_ID": "${botId}",
   "BOT_PASSWORD": "${botPassword}",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": "",
     "ContentSafetyApiKey": "",
     "ContentSafetyEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.a.teamsChefBot/appsettings.json
+++ b/dotnet/samples/04.ai.a.teamsChefBot/appsettings.json
@@ -8,13 +8,13 @@
   "AllowedHosts": "*",
   "BOT_ID": "${botId}",
   "BOT_PASSWORD": "${botPassword}",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": "",
     "ContentSafetyApiKey": "",
     "ContentSafetyEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.a.teamsChefBot/env/.env.dev.user
+++ b/dotnet/samples/04.ai.a.teamsChefBot/env/.env.dev.user
@@ -4,11 +4,11 @@
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
 
-# OpenAI settings
-SECRET_OPENAI_API_KEY=<openai-api-key>
-
 # Azure OpenAI settings
 SECRET_AZURE_OPENAI_API_KEY=<azure-openai-api-key>
 SECRET_AZURE_OPENAI_ENDPOINT=<azure-openai-endpoint>
 SECRET_AZURE_CONTENT_SAFETY_API_KEY=<azure-content-safety-api-key>
 SECRET_AZURE_CONTENT_SAFETY_ENDPOINT=<azure-content-safety-endpoint>
+
+# OpenAI settings
+SECRET_OPENAI_API_KEY=<openai-api-key>

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/README.md
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/README.md
@@ -38,12 +38,15 @@ All the samples in for the C# .NET SDK can be set up in the same way. You can fi
 
 Note that, this sample requires AI service so you need one more pre-step before Local Debug (F5).
 
-1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
 
     ```json
-      "OpenAI": {
-        "ApiKey": "<your-openai-api-key>"
-      },
+      "Azure": {
+        "OpenAIApiKey": "<your-azure-openai-api-key>",
+        "OpenAIEndpoint": "<your-azure-openai-endpoint>",
+        "ContentSafetyApiKey": "<your-azure-content-safety-api-key>",
+        "ContentSafetyEndpoint": "<your-azure-content-safety-endpoint>"
+      }
     ```
 
 ## Interacting with the Message Extension
@@ -68,37 +71,7 @@ You can use Teams Toolkit for Visual Studio or CLI to host the bot in Azure. The
 
 You can find deployment instructions [here](../README.md#deploy-to-azure).
 
-Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the OpenAI Key:
-
-1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
-
-The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
-
-## Use Azure OpenAI
-
-Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI as AI service.
-
-**As prerequisites**
-
-1. Prepare your own Azure OpenAI service and Azure AI Content Safety service.
-1. Modify source code `Program.cs`, comment out the "*#Use OpenAI*" part, and uncomment the "*#Use Azure OpenAI and Azure Content Safety*" part.
-
-**For Local Debug (F5) with Teams Toolkit for Visual Studio**
-
-1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
-
-    ```json
-      "Azure": {
-        "OpenAIApiKey": "<your-azure-openai-api-key>",
-        "OpenAIEndpoint": "<your-azure-openai-endpoint>",
-        "ContentSafetyApiKey": "<your-azure-content-safety-api-key>",
-        "ContentSafetyEndpoint": "<your-azure-content-safety-endpoint>"
-      }
-    ```
-
-**For Deploy to Azure with Teams Toolkit for Visual Studio**
-
-To configure the Azure resources to have Azure OpenAI environment variables:
+Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the Azure OpenAI Key and other settings:
 
 1. In `./env/.env.dev.user` file, paste your Azure OpenAI related variables.
 
@@ -108,6 +81,33 @@ To configure the Azure resources to have Azure OpenAI environment variables:
     SECRET_AZURE_CONTENT_SAFETY_API_KEY=
     SECRET_AZURE_CONTENT_SAFETY_ENDPOINT=
     ```
+
+The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
+
+## Use OpenAI
+
+Above steps use Azure OpenAI as AI service, optionally, you can also use OpenAI as AI service.
+
+**As prerequisites**
+
+1. Prepare your own OpenAI service.
+1. Modify source code `Program.cs`, comment out the "*#Use Azure OpenAI and Azure Content Safety*" part, and uncomment the "*#Use OpenAI*" part.
+
+**For Local Debug (F5) with Teams Toolkit for Visual Studio**
+
+1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+
+    ```json
+      "OpenAI": {
+        "ApiKey": "<your-openai-api-key>"
+      },
+    ```
+
+**For Deploy to Azure with Teams Toolkit for Visual Studio**
+
+To configure the Azure resources to have OpenAI environment variables:
+
+1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
 
 ## Further reading
 

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/appsettings.Development.json
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/appsettings.Development.json
@@ -9,13 +9,13 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": "",
     "ContentSafetyApiKey": "",
     "ContentSafetyEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/appsettings.json
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/appsettings.json
@@ -9,13 +9,13 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": "",
     "ContentSafetyApiKey": "",
     "ContentSafetyEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/env/.env.dev.user
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/env/.env.dev.user
@@ -4,11 +4,11 @@
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
 
-# OpenAI settings
-SECRET_OPENAI_API_KEY=<openai-api-key>
-
 # Azure OpenAI settings
 SECRET_AZURE_OPENAI_API_KEY=<azure-openai-api-key>
 SECRET_AZURE_OPENAI_ENDPOINT=<azure-openai-endpoint>
 SECRET_AZURE_CONTENT_SAFETY_API_KEY=<azure-content-safety-api-key>
 SECRET_AZURE_CONTENT_SAFETY_ENDPOINT=<azure-content-safety-endpoint>
+
+# OpenAI settings
+SECRET_OPENAI_API_KEY=<openai-api-key>

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/README.md
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/README.md
@@ -42,12 +42,13 @@ All the samples for the C# .NET SDK can be set up in the same way: You can find 
 
 Note that, this sample requires AI service so you need one more pre-step before Local Debug (F5).
 
-1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
 
     ```json
-      "OpenAI": {
-        "ApiKey": "<your-openai-api-key>"
-      },
+      "Azure": {
+        "OpenAIApiKey": "<your-azure-openai-api-key>",
+        "OpenAIEndpoint": "<your-azure-openai-endpoint>"
+      }
     ```
 
 ## Interacting with the Bot
@@ -68,12 +69,41 @@ You can use Teams Toolkit for Visual Studio or CLI to host the bot in Azure. The
 
 You can find deployment instructions [here](../README.md).
 
-Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the OpenAI Key:
+Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the Azure OpenAI Key and other settings:
 
-1. In `./env/.env.dev.user` file, paste your OpenAI API Key to the environment variable `SECRET_OPENAI_KEY=`.
+1. In `./env/.env.dev.user` file, paste your Azure OpenAI related variables.
+
+    ```bash
+    SECRET_AZURE_OPENAI_API_KEY=
+    SECRET_AZURE_OPENAI_ENDPOINT=
+    ```
 
 The SECRET_ prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
 
+## Use OpenAI
+
+Above steps use Azure OpenAI as AI service, optionally, you can also use OpenAI as AI service.
+
+**As prerequisites**
+
+1. Prepare your own OpenAI service.
+1. Modify source code `Program.cs`, comment out the "*#Use Azure OpenAI*" part, and uncomment the "*#Use OpenAI*" part.
+
+**For Local Debug (F5) with Teams Toolkit for Visual Studio**
+
+1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+
+    ```json
+      "OpenAI": {
+        "ApiKey": "<your-openai-api-key>"
+      },
+    ```
+
+**For Deploy to Azure with Teams Toolkit for Visual Studio**
+
+To configure the Azure resources to have OpenAI environment variables:
+
+1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
 
 ## Further reading
 

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/appsettings.Development.json
@@ -9,13 +9,11 @@
 	"AllowedHosts": "*",
 	"BOT_ID": "$botId$",
 	"BOT_PASSWORD": "$bot-password$",
-	"OpenAI": {
-		"ApiKey": ""
-	},
 	"Azure": {
 		"OpenAIApiKey": "",
-		"OpenAIEndpoint": "",
-		"ContentSafetyApiKey": "",
-		"ContentSafetyEndpoint": ""
+		"OpenAIEndpoint": ""
+	},
+	"OpenAI": {
+		"ApiKey": ""
 	}
 }

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/appsettings.json
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/appsettings.json
@@ -9,13 +9,11 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
-    "OpenAIEndpoint": "",
-    "ContentSafetyApiKey": "",
-    "ContentSafetyEndpoint": ""
+    "OpenAIEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/infra/azure.bicep
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/infra/azure.bicep
@@ -10,6 +10,18 @@ param botAadAppClientId string
 @description('Required by Bot Framework package in your bot project')
 param botAadAppClientSecret string
 
+@secure()
+@description('The OpenAI API Key to be added to App Service Settings')
+param openAIApiKey string
+
+@secure()
+@description('The Azure OpenAI API Key to be added to App Service Settings')
+param azureOpenAIApiKey string
+
+@secure()
+@description('The Azure OpenAI Endpoint to be added to App Service Settings')
+param azureOpenAIEndpoint string
+
 param webAppSKU string
 
 @maxLength(42)
@@ -55,6 +67,19 @@ resource webApp 'Microsoft.Web/sites@2021-02-01' = {
         {
           name: 'BOT_PASSWORD'
           value: botAadAppClientSecret
+        }
+        // ASP.NET Core treats double underscore (__) as colon (:) to support hierarchical keys
+        {
+          name: 'OpenAI__ApiKey'
+          value: openAIApiKey
+        }
+        {
+          name: 'Azure__OpenAIApiKey'
+          value: azureOpenAIApiKey
+        }
+        {
+          name: 'Azure__OpenAIEndpoint'
+          value: azureOpenAIEndpoint
         }
       ]
       ftpsState: 'FtpsOnly'

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/infra/azure.parameters.json
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/infra/azure.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
       "resourceBaseName": {
-        "value": "commandbot${{RESOURCE_SUFFIX}}"
+        "value": "bot${{RESOURCE_SUFFIX}}"
       },
       "botAadAppClientId": {
         "value": "${{BOT_ID}}"
@@ -16,6 +16,15 @@
       },
       "botDisplayName": {
         "value": "LightBot"
+      },
+      "openAIApiKey": {
+        "value": "${{SECRET_OPENAI_API_KEY}}"
+      },
+      "azureOpenAIApiKey": {
+        "value": "${{SECRET_AZURE_OPENAI_API_KEY}}"
+      },
+      "azureOpenAIEndpoint": {
+        "value": "${{SECRET_AZURE_OPENAI_ENDPOINT}}"
       }
     }
   }

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/Program.cs
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/Program.cs
@@ -32,42 +32,7 @@ builder.Services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>()!);
 
 builder.Services.AddSingleton<IStorage, MemoryStorage>();
 
-#region Use OpenAI
-if (config.OpenAI == null || string.IsNullOrEmpty(config.OpenAI.ApiKey))
-{
-    throw new Exception("Missing OpenAI configuration.");
-}
-
-builder.Services.AddSingleton(_ => new OpenAIPlannerOptions(config.OpenAI.ApiKey, "text-davinci-003")
-{
-    LogRequests = true
-});
-
-// Create the Application.
-builder.Services.AddTransient<IBot, ListBotApplication>(sp =>
-{
-    ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
-
-    PromptManager<ListState> promptManager = new("./Prompts");
-
-    OpenAIPlanner<ListState> planner = new(sp.GetService<OpenAIPlannerOptions>()!, loggerFactory);
-
-    ApplicationOptions<ListState, ListStateManager> applicationOptions = new()
-    {
-        AI = new AIOptions<ListState>(planner, promptManager)
-        {
-            Prompt = "Chat"
-        },
-        Storage = sp.GetService<IStorage>(),
-        LoggerFactory = loggerFactory,
-    };
-
-    return new ListBotApplication(applicationOptions);
-});
-#endregion
-
 #region Use Azure OpenAI
-/**
 if (config.Azure == null
     || string.IsNullOrEmpty(config.Azure.OpenAIApiKey)
     || string.IsNullOrEmpty(config.Azure.OpenAIEndpoint))
@@ -88,6 +53,41 @@ builder.Services.AddTransient<IBot, ListBotApplication>(sp =>
     PromptManager<ListState> promptManager = new("./Prompts");
 
     AzureOpenAIPlanner<ListState> planner = new(sp.GetService<AzureOpenAIPlannerOptions>()!, loggerFactory);
+
+    ApplicationOptions<ListState, ListStateManager> applicationOptions = new()
+    {
+        AI = new AIOptions<ListState>(planner, promptManager)
+        {
+            Prompt = "Chat"
+        },
+        Storage = sp.GetService<IStorage>(),
+        LoggerFactory = loggerFactory,
+    };
+
+    return new ListBotApplication(applicationOptions);
+});
+#endregion
+
+#region Use OpenAI
+/**
+if (config.OpenAI == null || string.IsNullOrEmpty(config.OpenAI.ApiKey))
+{
+    throw new Exception("Missing OpenAI configuration.");
+}
+
+builder.Services.AddSingleton(_ => new OpenAIPlannerOptions(config.OpenAI.ApiKey, "text-davinci-003")
+{
+    LogRequests = true
+});
+
+// Create the Application.
+builder.Services.AddTransient<IBot, ListBotApplication>(sp =>
+{
+    ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
+
+    PromptManager<ListState> promptManager = new("./Prompts");
+
+    OpenAIPlanner<ListState> planner = new(sp.GetService<OpenAIPlannerOptions>()!, loggerFactory);
 
     ApplicationOptions<ListState, ListStateManager> applicationOptions = new()
     {

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/README.md
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/README.md
@@ -96,12 +96,13 @@ All the samples in for the C# .NET SDK can be set up in the same way. You can fi
 
 Note that, this sample requires AI service so you need one more pre-step before Local Debug (F5).
 
-1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
 
     ```json
-      "OpenAI": {
-        "ApiKey": "<your-openai-api-key>"
-      },
+      "Azure": {
+        "OpenAIApiKey": "<your-azure-openai-api-key>",
+        "OpenAIEndpoint": "<your-azure-openai-endpoint>"
+      }
     ```
 
 ## Interacting with the bot
@@ -116,35 +117,7 @@ You can use Teams Toolkit for Visual Studio or CLI to host the bot in Azure. The
 
 You can find deployment instructions [here](../README.md#deploy-to-azure).
 
-Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the OpenAI Key:
-
-1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
-
-The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
-
-## Use Azure OpenAI
-
-Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI as AI service.
-
-**As prerequisites**
-
-1. Prepare your own Azure OpenAI service.
-1. Modify source code `Program.cs`, comment out the "*#Use OpenAI*" part, and uncomment the "*#Use Azure OpenAI*" part.
-
-**For debugging (F5)**
-
-1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
-
-    ```json
-      "Azure": {
-        "OpenAIApiKey": "<your-azure-openai-api-key>",
-        "OpenAIEndpoint": "<your-azure-openai-endpoint>"
-      }
-    ```
-
-**For deployment to Azure**
-
-To configure the Azure resources to have Azure OpenAI environment variables:
+Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the Azure OpenAI Key and other settings:
 
 1. In `./env/.env.dev.user` file, paste your Azure OpenAI related variables.
 
@@ -152,6 +125,33 @@ To configure the Azure resources to have Azure OpenAI environment variables:
     SECRET_AZURE_OPENAI_API_KEY=
     SECRET_AZURE_OPENAI_ENDPOINT=
     ```
+
+The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
+
+## Use OpenAI
+
+Above steps use Azure OpenAI as AI service, optionally, you can also use OpenAI as AI service.
+
+**As prerequisites**
+
+1. Prepare your own OpenAI service.
+1. Modify source code `Program.cs`, comment out the "*#Use Azure OpenAI*" part, and uncomment the "*#Use OpenAI*" part.
+
+**For debugging (F5)**
+
+1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+
+    ```json
+      "OpenAI": {
+        "ApiKey": "<your-openai-api-key>"
+      },
+    ```
+
+**For deployment to Azure**
+
+To configure the Azure resources to have OpenAI environment variables:
+
+1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
 
 ## Further reading
 

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/appsettings.Development.json
@@ -8,11 +8,11 @@
   "AllowedHosts": "*",
   "BOT_ID": "${botId}",
   "BOT_PASSWORD": "${botPassword}",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/appsettings.json
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/appsettings.json
@@ -8,11 +8,11 @@
   "AllowedHosts": "*",
   "BOT_ID": "${botId}",
   "BOT_PASSWORD": "${botPassword}",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/env/.env.dev.user
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/env/.env.dev.user
@@ -4,9 +4,9 @@
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
 
-# OpenAI settings
-SECRET_OPENAI_API_KEY=<openai-api-key>
-
 # Azure OpenAI settings
 SECRET_AZURE_OPENAI_API_KEY=<azure-openai-api-key>
 SECRET_AZURE_OPENAI_ENDPOINT=<azure-openai-endpoint>
+
+# OpenAI settings
+SECRET_OPENAI_API_KEY=<openai-api-key>

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/Program.cs
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/Program.cs
@@ -34,44 +34,8 @@ builder.Services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>()!);
 // Create singleton instances for bot application
 builder.Services.AddSingleton<IStorage, MemoryStorage>();
 
-#region Use OpenAI
-// Use OpenAI
-if (config.OpenAI == null || string.IsNullOrEmpty(config.OpenAI.ApiKey))
-{
-    throw new ArgumentException("Missing OpenAI configuration.");
-}
-builder.Services.AddSingleton<OpenAIPlannerOptions>(_ => new(config.OpenAI.ApiKey, "text-davinci-003"));
-
-// Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-builder.Services.AddTransient<IBot>(sp =>
-{
-    // Create loggers
-    ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
-
-    // Create OpenAIPlanner
-    IPlanner<DevOpsState> planner = new OpenAIPlanner<DevOpsState>(
-        sp.GetService<OpenAIPlannerOptions>()!,
-        loggerFactory);
-
-    // Create Application
-    AIOptions<DevOpsState> aiOptions = new(
-        planner: planner,
-        promptManager: new PromptManager<DevOpsState>("./Prompts"),
-        prompt: "Chat");
-    ApplicationOptions<DevOpsState, DevOpsStateManager> ApplicationOptions = new()
-    {
-        TurnStateManager = new DevOpsStateManager(),
-        Storage = sp.GetService<IStorage>(),
-        AI = aiOptions,
-        LoggerFactory = loggerFactory,
-    };
-    return new TeamsDevOpsBot(ApplicationOptions);
-});
-
-#endregion
-
 #region Use Azure OpenAI
-/** // Following code is for using Azure OpenAI
+// Following code is for using Azure OpenAI
 if (config.Azure == null
     || string.IsNullOrEmpty(config.Azure.OpenAIApiKey)
     || string.IsNullOrEmpty(config.Azure.OpenAIEndpoint))
@@ -89,6 +53,41 @@ builder.Services.AddTransient<IBot>(sp =>
     // Create AzureOpenAIPlanner
     IPlanner<DevOpsState> planner = new AzureOpenAIPlanner<DevOpsState>(
         sp.GetService<AzureOpenAIPlannerOptions>()!,
+        loggerFactory);
+
+    // Create Application
+    AIOptions<DevOpsState> aiOptions = new(
+        planner: planner,
+        promptManager: new PromptManager<DevOpsState>("./Prompts"),
+        prompt: "Chat");
+    ApplicationOptions<DevOpsState, DevOpsStateManager> ApplicationOptions = new()
+    {
+        TurnStateManager = new DevOpsStateManager(),
+        Storage = sp.GetService<IStorage>(),
+        AI = aiOptions,
+        LoggerFactory = loggerFactory,
+    };
+    return new TeamsDevOpsBot(ApplicationOptions);
+});
+#endregion
+
+#region Use OpenAI
+/** // Use OpenAI
+if (config.OpenAI == null || string.IsNullOrEmpty(config.OpenAI.ApiKey))
+{
+    throw new ArgumentException("Missing OpenAI configuration.");
+}
+builder.Services.AddSingleton<OpenAIPlannerOptions>(_ => new(config.OpenAI.ApiKey, "text-davinci-003"));
+
+// Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
+builder.Services.AddTransient<IBot>(sp =>
+{
+    // Create loggers
+    ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
+
+    // Create OpenAIPlanner
+    IPlanner<DevOpsState> planner = new OpenAIPlanner<DevOpsState>(
+        sp.GetService<OpenAIPlannerOptions>()!,
         loggerFactory);
 
     // Create Application

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/README.md
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/README.md
@@ -65,12 +65,13 @@ All the samples in for the C# .NET SDK can be set up in the same way. You can fi
 
 Note that, this sample requires AI service so you need one more pre-step before Local Debug (F5).
 
-1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
 
     ```json
-      "OpenAI": {
-        "ApiKey": "<your-openai-api-key>"
-      },
+      "Azure": {
+        "OpenAIApiKey": "<your-azure-openai-api-key>",
+        "OpenAIEndpoint": "<your-azure-openai-endpoint>"
+      }
     ```
 
 ## Interacting with the Bot
@@ -95,35 +96,7 @@ You can use Teams Toolkit for Visual Studio or CLI to host the bot in Azure. The
 
 You can find deployment instructions [here](../README.md#deploy-to-azure).
 
-Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the OpenAI Key:
-
-1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
-
-The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
-
-## Use Azure OpenAI
-
-Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI as AI service.
-
-**As prerequisites**
-
-1. Prepare your own Azure OpenAI service.
-1. Modify source code `Program.cs`, comment out the "*#Use OpenAI*" part, and uncomment the "*#Use Azure OpenAI*" part.
-
-**For Local Debug (F5) with Teams Toolkit for Visual Studio**
-
-1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
-
-    ```json
-      "Azure": {
-        "OpenAIApiKey": "<your-azure-openai-api-key>",
-        "OpenAIEndpoint": "<your-azure-openai-endpoint>"
-      }
-    ```
-
-**For Deploy to Azure with Teams Toolkit for Visual Studio**
-
-To configure the Azure resources to have Azure OpenAI environment variables:
+Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the Azure OpenAI Key and other settings:
 
 1. In `./env/.env.dev.user` file, paste your Azure OpenAI related variables.
 
@@ -131,6 +104,33 @@ To configure the Azure resources to have Azure OpenAI environment variables:
     SECRET_AZURE_OPENAI_API_KEY=
     SECRET_AZURE_OPENAI_ENDPOINT=
     ```
+
+The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
+
+## Use OpenAI
+
+Above steps use Azure OpenAI as AI service, optionally, you can also use OpenAI as AI service.
+
+**As prerequisites**
+
+1. Prepare your own OpenAI service.
+1. Modify source code `Program.cs`, comment out the "*#Use Azure OpenAI*" part, and uncomment the "*#Use OpenAI*" part.
+
+**For Local Debug (F5) with Teams Toolkit for Visual Studio**
+
+1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+
+    ```json
+      "OpenAI": {
+        "ApiKey": "<your-openai-api-key>"
+      },
+    ```
+
+**For Deploy to Azure with Teams Toolkit for Visual Studio**
+
+To configure the Azure resources to have OpenAI environment variables:
+
+1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
 
 ## Further reading
 

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/appsettings.Development.json
@@ -9,11 +9,11 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/appsettings.json
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/appsettings.json
@@ -9,11 +9,11 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/env/.env.dev.user
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/env/.env.dev.user
@@ -4,9 +4,9 @@
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
 
-# OpenAI settings
-SECRET_OPENAI_API_KEY=<openai-api-key>
-
 # Azure OpenAI settings
 SECRET_AZURE_OPENAI_API_KEY=<azure-openai-api-key>
 SECRET_AZURE_OPENAI_ENDPOINT=<azure-openai-endpoint>
+
+# OpenAI settings
+SECRET_OPENAI_API_KEY=<openai-api-key>

--- a/dotnet/samples/04.e.twentyQuestions/Program.cs
+++ b/dotnet/samples/04.e.twentyQuestions/Program.cs
@@ -33,8 +33,57 @@ builder.Services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>()!);
 // Create singleton instances for bot application
 builder.Services.AddSingleton<IStorage, MemoryStorage>();
 
+#region Use Azure OpenAI and Azure Content Safety
+// Following code is for using Azure OpenAI and Azure Content Safety
+if (config.Azure == null
+    || string.IsNullOrEmpty(config.Azure.OpenAIApiKey) 
+    || string.IsNullOrEmpty(config.Azure.OpenAIEndpoint)
+    || string.IsNullOrEmpty(config.Azure.ContentSafetyApiKey)
+    || string.IsNullOrEmpty(config.Azure.ContentSafetyEndpoint))
+{
+    throw new Exception("Missing Azure configuration.");
+}
+builder.Services.AddSingleton<AzureOpenAIPlannerOptions>(_ => new(config.Azure.OpenAIApiKey, "text-davinci-003", config.Azure.OpenAIEndpoint));
+builder.Services.AddSingleton<AzureContentSafetyModeratorOptions>(_ => new(config.Azure.ContentSafetyApiKey, config.Azure.ContentSafetyEndpoint, ModerationType.Both));
+
+// Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
+builder.Services.AddTransient<IBot>(sp =>
+{
+    // Create loggers
+    ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
+
+    // Create AzureOpenAIPlanner
+    IPlanner<GameState> planner = new AzureOpenAIPlanner<GameState>(
+        sp.GetService<AzureOpenAIPlannerOptions>()!,
+        loggerFactory);
+
+    // Create AzureContentSafetyModerator
+    IModerator<GameState> moderator = new AzureContentSafetyModerator<GameState>(sp.GetService<AzureContentSafetyModeratorOptions>()!);
+
+    // Create Application
+    AIHistoryOptions aiHistoryOptions = new()
+    {
+        AssistantHistoryType = AssistantHistoryType.Text
+    };
+    AIOptions<GameState> aiOptions = new(
+        planner: planner,
+        promptManager: new PromptManager<GameState>("./Prompts"),
+        moderator: moderator,
+        prompt: "Chat",
+        history: aiHistoryOptions);
+    ApplicationOptions<GameState, GameStateManager> ApplicationOptions = new()
+    {
+        TurnStateManager = new GameStateManager(),
+        Storage = sp.GetService<IStorage>(),
+        AI = aiOptions,
+        LoggerFactory = loggerFactory,        
+    };
+    return new GameBot(ApplicationOptions);
+});
+#endregion
+
 #region Use OpenAI
-// Use OpenAI
+/** // Use OpenAI
 if (config.OpenAI == null || string.IsNullOrEmpty(config.OpenAI.ApiKey))
 {
     throw new Exception("Missing OpenAI configuration.");
@@ -79,55 +128,6 @@ builder.Services.AddTransient<IBot>(sp =>
         Storage = sp.GetService<IStorage>(),
         AI = aiOptions,
         LoggerFactory = loggerFactory,
-    };
-    return new GameBot(ApplicationOptions);
-});
-#endregion
-
-#region Use Azure OpenAI and Azure Content Safety
-/** // Following code is for using Azure OpenAI and Azure Content Safety
-if (config.Azure == null
-    || string.IsNullOrEmpty(config.Azure.OpenAIApiKey) 
-    || string.IsNullOrEmpty(config.Azure.OpenAIEndpoint)
-    || string.IsNullOrEmpty(config.Azure.ContentSafetyApiKey)
-    || string.IsNullOrEmpty(config.Azure.ContentSafetyEndpoint))
-{
-    throw new Exception("Missing Azure configuration.");
-}
-builder.Services.AddSingleton<AzureOpenAIPlannerOptions>(_ => new(config.Azure.OpenAIApiKey, "text-davinci-003", config.Azure.OpenAIEndpoint));
-builder.Services.AddSingleton<AzureContentSafetyModeratorOptions>(_ => new(config.Azure.ContentSafetyApiKey, config.Azure.ContentSafetyEndpoint, ModerationType.Both));
-
-// Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-builder.Services.AddTransient<IBot>(sp =>
-{
-    // Create loggers
-    ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
-
-    // Create AzureOpenAIPlanner
-    IPlanner<GameState> planner = new AzureOpenAIPlanner<GameState>(
-        sp.GetService<AzureOpenAIPlannerOptions>()!,
-        loggerFactory);
-
-    // Create AzureContentSafetyModerator
-    IModerator<GameState> moderator = new AzureContentSafetyModerator<GameState>(sp.GetService<AzureContentSafetyModeratorOptions>()!);
-
-    // Create Application
-    AIHistoryOptions aiHistoryOptions = new()
-    {
-        AssistantHistoryType = AssistantHistoryType.Text
-    };
-    AIOptions<GameState> aiOptions = new(
-        planner: planner,
-        promptManager: new PromptManager<GameState>("./Prompts"),
-        moderator: moderator,
-        prompt: "Chat",
-        history: aiHistoryOptions);
-    ApplicationOptions<GameState, GameStateManager> ApplicationOptions = new()
-    {
-        TurnStateManager = new GameStateManager(),
-        Storage = sp.GetService<IStorage>(),
-        AI = aiOptions,
-        LoggerFactory = loggerFactory,        
     };
     return new GameBot(ApplicationOptions);
 });

--- a/dotnet/samples/04.e.twentyQuestions/README.md
+++ b/dotnet/samples/04.e.twentyQuestions/README.md
@@ -44,12 +44,15 @@ All the samples in for the C# .NET SDK can be set up in the same way. You can fi
 
 Note that, this sample requires AI service so you need one more pre-step before Local Debug (F5).
 
-1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
 
     ```json
-      "OpenAI": {
-        "ApiKey": "<your-openai-api-key>"
-      },
+      "Azure": {
+        "OpenAIApiKey": "<your-azure-openai-api-key>",
+        "OpenAIEndpoint": "<your-azure-openai-endpoint>",
+        "ContentSafetyApiKey": "<your-azure-content-safety-api-key>",
+        "ContentSafetyEndpoint": "<your-azure-content-safety-endpoint>"
+      }
     ```
 
 ## Interacting with the Bot
@@ -70,37 +73,7 @@ You can use Teams Toolkit for Visual Studio or CLI to host the bot in Azure. The
 
 You can find deployment instructions [here](../README.md#deploy-to-azure).
 
-Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the OpenAI Key:
-
-1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
-
-The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
-
-## Use Azure OpenAI
-
-Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI as AI service.
-
-**As prerequisites**
-
-1. Prepare your own Azure OpenAI service and Azure AI Content Safety service.
-1. Modify source code `Program.cs`, comment out the "*#Use OpenAI*" part, and uncomment the "*#Use Azure OpenAI and Azure Content Safety*" part.
-
-**For Local Debug (F5) with Teams Toolkit for Visual Studio**
-
-1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
-
-    ```json
-      "Azure": {
-        "OpenAIApiKey": "<your-azure-openai-api-key>",
-        "OpenAIEndpoint": "<your-azure-openai-endpoint>",
-        "ContentSafetyApiKey": "<your-azure-content-safety-api-key>",
-        "ContentSafetyEndpoint": "<your-azure-content-safety-endpoint>"
-      }
-    ```
-
-**For Deploy to Azure with Teams Toolkit for Visual Studio**
-
-To configure the Azure resources to have Azure OpenAI environment variables:
+Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the Azure OpenAI Key and other settings:
 
 1. In `./env/.env.dev.user` file, paste your Azure OpenAI related variables.
 
@@ -110,6 +83,33 @@ To configure the Azure resources to have Azure OpenAI environment variables:
     SECRET_AZURE_CONTENT_SAFETY_API_KEY=
     SECRET_AZURE_CONTENT_SAFETY_ENDPOINT=
     ```
+
+The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
+
+## Use OpenAI
+
+Above steps use Azure OpenAI as AI service, optionally, you can also use OpenAI as AI service.
+
+**As prerequisites**
+
+1. Prepare your own OpenAI service.
+1. Modify source code `Program.cs`, comment out the "*#Use Azure OpenAI and Azure Content Safety*" part, and uncomment the "*#Use OpenAI*" part.
+
+**For Local Debug (F5) with Teams Toolkit for Visual Studio**
+
+1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+
+    ```json
+      "OpenAI": {
+        "ApiKey": "<your-openai-api-key>"
+      },
+    ```
+
+**For Deploy to Azure with Teams Toolkit for Visual Studio**
+
+To configure the Azure resources to have OpenAI environment variables:
+
+1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
 
 ## Further reading
 

--- a/dotnet/samples/04.e.twentyQuestions/appsettings.Development.json
+++ b/dotnet/samples/04.e.twentyQuestions/appsettings.Development.json
@@ -9,13 +9,13 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": "",
     "ContentSafetyApiKey": "",
     "ContentSafetyEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.e.twentyQuestions/appsettings.json
+++ b/dotnet/samples/04.e.twentyQuestions/appsettings.json
@@ -9,13 +9,13 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": "",
     "ContentSafetyApiKey": "",
     "ContentSafetyEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.e.twentyQuestions/env/.env.dev.user
+++ b/dotnet/samples/04.e.twentyQuestions/env/.env.dev.user
@@ -4,11 +4,11 @@
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
 
-# OpenAI settings
-SECRET_OPENAI_API_KEY=<openai-api-key>
-
 # Azure OpenAI settings
 SECRET_AZURE_OPENAI_API_KEY=<azure-openai-api-key>
 SECRET_AZURE_OPENAI_ENDPOINT=<azure-openai-endpoint>
 SECRET_AZURE_CONTENT_SAFETY_API_KEY=<azure-content-safety-api-key>
 SECRET_AZURE_CONTENT_SAFETY_ENDPOINT=<azure-content-safety-endpoint>
+
+# OpenAI settings
+SECRET_OPENAI_API_KEY=<openai-api-key>

--- a/dotnet/samples/04.q.questBot/Program.cs
+++ b/dotnet/samples/04.q.questBot/Program.cs
@@ -35,13 +35,15 @@ builder.Services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>()!);
 // Create singleton instances for bot application
 builder.Services.AddSingleton<IStorage, LastWriterWinsMemoryStore>();
 
-#region Use OpenAI
-// Use OpenAI
-if (config.OpenAI == null || string.IsNullOrEmpty(config.OpenAI.ApiKey))
+#region Use Azure OpenAI
+// Following code is for using Azure OpenAI
+if (config.Azure == null
+    || string.IsNullOrEmpty(config.Azure.OpenAIApiKey)
+    || string.IsNullOrEmpty(config.Azure.OpenAIEndpoint))
 {
-    throw new ArgumentException("Missing OpenAI configuration.");
+    throw new ArgumentException("Missing Azure configuration.");
 }
-builder.Services.AddSingleton<OpenAIPlannerOptions>(_ => new(config.OpenAI.ApiKey, "gpt-3.5-turbo"));
+builder.Services.AddSingleton<AzureOpenAIPlannerOptions>(_ => new(config.Azure.OpenAIApiKey, "gpt-35-turbo", config.Azure.OpenAIEndpoint));
 
 // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
 builder.Services.AddTransient<IBot>(sp =>
@@ -49,10 +51,10 @@ builder.Services.AddTransient<IBot>(sp =>
     // Create loggers
     ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
 
-    // Create OpenAIPlanner
-    IPlanner<QuestState> planner = new OpenAIPlanner<QuestState>(
-        sp.GetService<OpenAIPlannerOptions>()!,
-        loggerFactory.CreateLogger<OpenAIPlanner<QuestState>>());
+    // Create AzureOpenAIPlanner
+    IPlanner<QuestState> planner = new AzureOpenAIPlanner<QuestState>(
+        sp.GetService<AzureOpenAIPlannerOptions>()!,
+        loggerFactory.CreateLogger<AzureOpenAIPlanner<QuestState>>());
 
     // Create Application
     AIOptions<QuestState> aiOptions = new(
@@ -75,18 +77,15 @@ builder.Services.AddTransient<IBot>(sp =>
     };
     return new TeamsQuestBot(ApplicationOptions);
 });
-
 #endregion
 
-#region Use Azure OpenAI
-/** // Following code is for using Azure OpenAI
-if (config.Azure == null
-    || string.IsNullOrEmpty(config.Azure.OpenAIApiKey)
-    || string.IsNullOrEmpty(config.Azure.OpenAIEndpoint))
+#region Use OpenAI
+/** // Use OpenAI
+if (config.OpenAI == null || string.IsNullOrEmpty(config.OpenAI.ApiKey))
 {
-    throw new ArgumentException("Missing Azure configuration.");
+    throw new ArgumentException("Missing OpenAI configuration.");
 }
-builder.Services.AddSingleton<AzureOpenAIPlannerOptions>(_ => new(config.Azure.OpenAIApiKey, "gpt-35-turbo", config.Azure.OpenAIEndpoint));
+builder.Services.AddSingleton<OpenAIPlannerOptions>(_ => new(config.OpenAI.ApiKey, "gpt-3.5-turbo"));
 
 // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
 builder.Services.AddTransient<IBot>(sp =>
@@ -94,10 +93,10 @@ builder.Services.AddTransient<IBot>(sp =>
     // Create loggers
     ILoggerFactory loggerFactory = sp.GetService<ILoggerFactory>()!;
 
-    // Create AzureOpenAIPlanner
-    IPlanner<QuestState> planner = new AzureOpenAIPlanner<QuestState>(
-        sp.GetService<AzureOpenAIPlannerOptions>()!,
-        loggerFactory.CreateLogger<AzureOpenAIPlanner<QuestState>>());
+    // Create OpenAIPlanner
+    IPlanner<QuestState> planner = new OpenAIPlanner<QuestState>(
+        sp.GetService<OpenAIPlannerOptions>()!,
+        loggerFactory.CreateLogger<OpenAIPlanner<QuestState>>());
 
     // Create Application
     AIOptions<QuestState> aiOptions = new(

--- a/dotnet/samples/04.q.questBot/README.md
+++ b/dotnet/samples/04.q.questBot/README.md
@@ -44,12 +44,13 @@ All the samples in for the C# .NET SDK can be set up in the same way. You can fi
 
 Note that, this sample requires AI service so you need one more pre-step before Local Debug (F5).
 
-1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
 
     ```json
-      "OpenAI": {
-        "ApiKey": "<your-openai-api-key>"
-      },
+      "Azure": {
+        "OpenAIApiKey": "<your-azure-openai-api-key>",
+        "OpenAIEndpoint": "<your-azure-openai-endpoint>"
+      }
     ```
 
 ## Interacting with the Bot
@@ -70,35 +71,7 @@ You can use Teams Toolkit for Visual Studio or CLI to host the bot in Azure. The
 
 You can find deployment instructions [here](../README.md#deploy-to-azure).
 
-Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the OpenAI Key:
-
-1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
-
-The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
-
-## Use Azure OpenAI
-
-Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI as AI service.
-
-**As prerequisites**
-
-1. Prepare your own Azure OpenAI service and Azure AI Content Safety service.
-1. Modify source code `Program.cs`, comment out the "*#Use OpenAI*" part, and uncomment the "*#Use Azure OpenAI and Azure Content Safety*" part.
-
-**For Local Debug (F5) with Teams Toolkit for Visual Studio**
-
-1. Set your Azure OpenAI related settings to *appsettings.Development.json*.
-
-    ```json
-      "Azure": {
-        "OpenAIApiKey": "<your-azure-openai-api-key>",
-        "OpenAIEndpoint": "<your-azure-openai-endpoint>"
-      }
-    ```
-
-**For Deploy to Azure with Teams Toolkit for Visual Studio**
-
-To configure the Azure resources to have Azure OpenAI environment variables:
+Note that, this sample requires AI service so you need one more pre-step before deploy to Azure. To configure the Azure resources to have an environment variable for the Azure OpenAI Key and other settings:
 
 1. In `./env/.env.dev.user` file, paste your Azure OpenAI related variables.
 
@@ -106,6 +79,33 @@ To configure the Azure resources to have Azure OpenAI environment variables:
     SECRET_AZURE_OPENAI_API_KEY=
     SECRET_AZURE_OPENAI_ENDPOINT=
     ```
+
+The `SECRET_` prefix is a convention used by Teams Toolkit to mask the value in any logging output and is optional.
+
+## Use OpenAI
+
+Above steps use Azure OpenAI as AI service, optionally, you can also use OpenAI as AI service.
+
+**As prerequisites**
+
+1. Prepare your own OpenAI service.
+1. Modify source code `Program.cs`, comment out the "*#Use Azure OpenAI*" part, and uncomment the "*#Use OpenAI*" part.
+
+**For Local Debug (F5) with Teams Toolkit for Visual Studio**
+
+1. Set your [OpenAI API Key](https://openai.com/api/) to *appsettings.Development.json*.
+
+    ```json
+      "OpenAI": {
+        "ApiKey": "<your-openai-api-key>"
+      },
+    ```
+
+**For Deploy to Azure with Teams Toolkit for Visual Studio**
+
+To configure the Azure resources to have OpenAI environment variables:
+
+1. In `./env/.env.dev.user` file, paste your [OpenAI API Key](https://openai.com/api/) to the environment variable `SECRET_OPENAI_KEY=`.
 
 ## Further reading
 

--- a/dotnet/samples/04.q.questBot/appsettings.Development.json
+++ b/dotnet/samples/04.q.questBot/appsettings.Development.json
@@ -9,11 +9,11 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.q.questBot/appsettings.json
+++ b/dotnet/samples/04.q.questBot/appsettings.json
@@ -9,11 +9,11 @@
   "AllowedHosts": "*",
   "BOT_ID": "$botId$",
   "BOT_PASSWORD": "$bot-password$",
-  "OpenAI": {
-    "ApiKey": ""
-  },
   "Azure": {
     "OpenAIApiKey": "",
     "OpenAIEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/dotnet/samples/04.q.questBot/env/.env.dev.user
+++ b/dotnet/samples/04.q.questBot/env/.env.dev.user
@@ -4,9 +4,9 @@
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
 
-# OpenAI settings
-SECRET_OPENAI_API_KEY=<openai-api-key>
-
 # Azure OpenAI settings
 SECRET_AZURE_OPENAI_API_KEY=<azure-openai-api-key>
 SECRET_AZURE_OPENAI_ENDPOINT=<azure-openai-endpoint>
+
+# OpenAI settings
+SECRET_OPENAI_API_KEY=<openai-api-key>

--- a/dotnet/samples/README.md
+++ b/dotnet/samples/README.md
@@ -81,7 +81,7 @@ There are a few ways to get the application up and running. The latest way is us
 #### Steps
 
 1. Open the solution in Visual Studio. (For example `EchoBot.sln`).
-   - Ensure that you set the appropriate config values (ex OpenAI API key). You can find specific instructions in the sample readme under the `Set up instructions` section.
+   - Ensure that you set the appropriate config values (ex Azure OpenAI API key). You can find specific instructions in the sample readme under the `Set up instructions` section.
 1. In the debug dropdown menu, select `Dev Tunnels > Create A Tunnel` (set authentication type to Public) or select an existing public dev tunnel
 1. Right-click your project and select `Teams Toolkit > Prepare Teams App Dependencies`
 1. If prompted, sign in with a Microsoft 365 account for the Teams organization you want


### PR DESCRIPTION
## Linked issues

closes: #532

## Details

Update all c# samples to use AOAI as default LLM, include local debug (f5) and deploy to azure.

#### Change details
For all c# samples
- Update `Program.cs` to use AOAI by default
- Update `README.md` to use AOAI as the first option
- Update other related env and setting files

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
