### PR TITLE
[PY] feat: add type annotation for decorators to support mypy

### DIFF
--- a/python/packages/ai/teams/adaptive_cards/adaptive_cards.py
+++ b/python/packages/ai/teams/adaptive_cards/adaptive_cards.py
@@ -35,7 +35,12 @@ class AdaptiveCards(Generic[StateT]):
         self._route_registry = route_registry
         self._action_submit_filter = action_submit_filter
 
-    def action_execute(self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]):
+    def action_execute(
+        self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, dict], Awaitable[Union[str, dict]]]],
+        Callable[[TurnContext, StateT, dict], Awaitable[Union[str, dict]]],
+    ]:
         """
         Adds a route for handling Adaptive Card Action.Execute events.
         This method can be used as either a decorator or a method.
@@ -77,7 +82,9 @@ class AdaptiveCards(Generic[StateT]):
 
             return False
 
-        def __call__(func: Callable[[TurnContext, StateT, dict], Awaitable[Union[str, dict]]]):
+        def __call__(
+            func: Callable[[TurnContext, StateT, dict], Awaitable[Union[str, dict]]]
+        ) -> Callable[[TurnContext, StateT, dict], Awaitable[Union[str, dict]]]:
             async def __handler__(context: TurnContext, state: StateT) -> bool:
                 result = await func(context, state, context.activity.value["action"]["data"])
                 if context.turn_state.get(ActivityTypes.invoke_response) is None:
@@ -105,7 +112,12 @@ class AdaptiveCards(Generic[StateT]):
 
         return __call__
 
-    def action_submit(self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]):
+    def action_submit(
+        self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, dict], Awaitable[None]]],
+        Callable[[TurnContext, StateT, dict], Awaitable[None]],
+    ]:
         """
         Adds a route for handling Adaptive Card Action.Submit events.
         This method can be used as either a decorator or a method.
@@ -146,7 +158,9 @@ class AdaptiveCards(Generic[StateT]):
 
             return False
 
-        def __call__(func: Callable[[TurnContext, StateT, dict], Awaitable[None]]):
+        def __call__(
+            func: Callable[[TurnContext, StateT, dict], Awaitable[None]]
+        ) -> Callable[[TurnContext, StateT, dict], Awaitable[None]]:
             async def __handler__(context: TurnContext, state: StateT) -> bool:
                 await func(context, state, context.activity.value)
                 return True
@@ -156,7 +170,20 @@ class AdaptiveCards(Generic[StateT]):
 
         return __call__
 
-    def search(self, dataset: Union[str, Pattern[str], Callable[[TurnContext], bool]]):
+    def search(
+        self, dataset: Union[str, Pattern[str], Callable[[TurnContext], bool]]
+    ) -> Callable[
+        [
+            Callable[
+                [TurnContext, StateT, Query[AdaptiveCardsSearchParams]],
+                Awaitable[List[AdaptiveCardsSearchResult]],
+            ]
+        ],
+        Callable[
+            [TurnContext, StateT, Query[AdaptiveCardsSearchParams]],
+            Awaitable[List[AdaptiveCardsSearchResult]],
+        ],
+    ]:
         """
         Adds a route for handling Adaptive Card search events. This method can be used as either
         a decorator or a method.
@@ -202,7 +229,10 @@ class AdaptiveCards(Generic[StateT]):
                 [TurnContext, StateT, Query[AdaptiveCardsSearchParams]],
                 Awaitable[List[AdaptiveCardsSearchResult]],
             ]
-        ):
+        ) -> Callable[
+            [TurnContext, StateT, Query[AdaptiveCardsSearchParams]],
+            Awaitable[List[AdaptiveCardsSearchResult]],
+        ]:
             async def __handler__(context: TurnContext, state: StateT) -> bool:
                 params = context.activity.value
                 # Flatten search parameters

--- a/python/packages/ai/teams/ai/ai.py
+++ b/python/packages/ai/teams/ai/ai.py
@@ -67,7 +67,9 @@ class AI(Generic[StateT]):
             ),
         }
 
-    def action(self, name: Optional[str] = None, *, allow_overrides=False):
+    def action(
+        self, name: Optional[str] = None, *, allow_overrides=False
+    ) -> Callable[[ActionHandler[StateT]], ActionHandler[StateT]]:
         """
         Registers a new action event listener. This method can be used as either
         a decorator or a method.
@@ -89,7 +91,7 @@ class AI(Generic[StateT]):
         are found `Default: False`
         """
 
-        def __call__(func: ActionHandler[StateT]):
+        def __call__(func: ActionHandler[StateT]) -> ActionHandler[StateT]:
             action_name = name
 
             if not action_name:
@@ -110,7 +112,12 @@ class AI(Generic[StateT]):
 
         return __call__
 
-    def function(self, name: Optional[str] = None, *, allow_overrides=False):
+    def function(
+        self, name: Optional[str] = None, *, allow_overrides=False
+    ) -> Callable[
+        [Callable[[TurnContext, StateT], Awaitable[Any]]],
+        Callable[[TurnContext, StateT], Awaitable[Any]],
+    ]:
         """
         Registers a new prompt function event listener. This method can be used as either
         a decorator or a method.
@@ -132,7 +139,9 @@ class AI(Generic[StateT]):
         are found `Default: False`
         """
 
-        def __call__(func: Callable[[TurnContext, StateT], Awaitable[Any]]):
+        def __call__(
+            func: Callable[[TurnContext, StateT], Awaitable[Any]]
+        ) -> Callable[[TurnContext, StateT], Awaitable[Any]]:
             func_name = name
 
             if not func_name:

--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -119,20 +119,22 @@ class Application(Bot, Generic[StateT]):
         return self._message_extensions
 
     @property
-    def adaptive_cards(self) -> AdaptiveCards:
+    def adaptive_cards(self) -> AdaptiveCards[StateT]:
         """
         Access the application's adaptive cards functionalities.
         """
         return self._adaptive_card
 
     @property
-    def task_modules(self) -> TaskModules:
+    def task_modules(self) -> TaskModules[StateT]:
         """
         Access the application's task modules functionalities.
         """
         return self._task_modules
 
-    def activity(self, type: ActivityType):
+    def activity(
+        self, type: ActivityType
+    ) -> Callable[[RouteHandler[StateT]], RouteHandler[StateT]]:
         """
         Registers a new activity event listener. This method can be used as either
         a decorator or a method.
@@ -155,13 +157,15 @@ class Application(Bot, Generic[StateT]):
         def __selector__(context: TurnContext):
             return type == str(context.activity.type)
 
-        def __call__(func: RouteHandler[StateT]):
+        def __call__(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             self._routes.append(Route[StateT](__selector__, func))
             return func
 
         return __call__
 
-    def message(self, select: Union[str, Pattern[str]]):
+    def message(
+        self, select: Union[str, Pattern[str]]
+    ) -> Callable[[RouteHandler[StateT]], RouteHandler[StateT]]:
         """
         Registers a new message activity event listener. This method can be used as either
         a decorator or a method.
@@ -193,13 +197,15 @@ class Application(Bot, Generic[StateT]):
             i = context.activity.text.find(select)
             return i > -1
 
-        def __call__(func: RouteHandler[StateT]):
+        def __call__(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             self._routes.append(Route[StateT](__selector__, func))
             return func
 
         return __call__
 
-    def conversation_update(self, type: ConversationUpdateType):
+    def conversation_update(
+        self, type: ConversationUpdateType
+    ) -> Callable[[RouteHandler[StateT]], RouteHandler[StateT]]:
         """
         Registers a new message activity event listener. This method can be used as either
         a decorator or a method.
@@ -239,13 +245,13 @@ class Application(Bot, Generic[StateT]):
 
             return False
 
-        def __call__(func: RouteHandler[StateT]):
+        def __call__(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             self._routes.append(Route[StateT](__selector__, func))
             return func
 
         return __call__
 
-    def before_turn(self, func: RouteHandler[StateT]):
+    def before_turn(self, func: RouteHandler[StateT]) -> RouteHandler[StateT]:
         """
         Registers a new event listener that will be executed before turns.
         This method can be used as either a decorator or a method and
@@ -266,7 +272,7 @@ class Application(Bot, Generic[StateT]):
         self._before_turn.append(func)
         return func
 
-    def after_turn(self, func: RouteHandler[StateT]):
+    def after_turn(self, func: RouteHandler[StateT]) -> RouteHandler[StateT]:
         """
         Registers a new event listener that will be executed after turns.
         This method can be used as either a decorator or a method and
@@ -287,7 +293,9 @@ class Application(Bot, Generic[StateT]):
         self._after_turn.append(func)
         return func
 
-    def error(self, func: Callable[[TurnContext, Exception], Awaitable[None]]):
+    def error(
+        self, func: Callable[[TurnContext, Exception], Awaitable[None]]
+    ) -> Callable[[TurnContext, Exception], Awaitable[None]]:
         """
         Registers an error handler that will be called anytime
         the app throws an Exception

--- a/python/packages/ai/teams/message_extensions.py
+++ b/python/packages/ai/teams/message_extensions.py
@@ -47,7 +47,18 @@ class MessageExtensions(Generic[StateT]):
     def __init__(self, routes: List[Route[StateT]]) -> None:
         self._routes = routes
 
-    def query(self, command_id: Union[str, Pattern[str]]):
+    def query(
+        self, command_id: Union[str, Pattern[str]]
+    ) -> Callable[
+        [
+            Callable[
+                [TurnContext, StateT, MessagingExtensionQuery], Awaitable[MessagingExtensionResult]
+            ]
+        ],
+        Callable[
+            [TurnContext, StateT, MessagingExtensionQuery], Awaitable[MessagingExtensionResult]
+        ],
+    ]:
         """
         Registers a handler that implements a Search based Message Extension.
 
@@ -80,7 +91,10 @@ class MessageExtensions(Generic[StateT]):
                 [TurnContext, StateT, MessagingExtensionQuery],
                 Awaitable[MessagingExtensionResult],
             ]
-        ):
+        ) -> Callable[
+            [TurnContext, StateT, MessagingExtensionQuery],
+            Awaitable[MessagingExtensionResult],
+        ]:
             async def __invoke__(context: TurnContext, state: StateT):
                 if not context.activity.value:
                     return False
@@ -98,7 +112,12 @@ class MessageExtensions(Generic[StateT]):
 
         return __call__
 
-    def query_link(self, command_id: Union[str, Pattern[str]]):
+    def query_link(
+        self, command_id: Union[str, Pattern[str]]
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, str], Awaitable[MessagingExtensionResult]]],
+        Callable[[TurnContext, StateT, str], Awaitable[MessagingExtensionResult]],
+    ]:
         """
         Registers a handler that implements a Link Unfurling based Message Extension.
 
@@ -131,7 +150,7 @@ class MessageExtensions(Generic[StateT]):
                 [TurnContext, StateT, str],
                 Awaitable[MessagingExtensionResult],
             ]
-        ):
+        ) -> Callable[[TurnContext, StateT, str], Awaitable[MessagingExtensionResult],]:
             async def __invoke__(context: TurnContext, state: StateT):
                 if not context.activity.value:
                     return False
@@ -153,7 +172,12 @@ class MessageExtensions(Generic[StateT]):
 
         return __call__
 
-    def anonymous_query_link(self, command_id: Union[str, Pattern[str]]):
+    def anonymous_query_link(
+        self, command_id: Union[str, Pattern[str]]
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, str], Awaitable[MessagingExtensionResult]]],
+        Callable[[TurnContext, StateT, str], Awaitable[MessagingExtensionResult]],
+    ]:
         """
         Registers a handler for a command that performs anonymous link unfurling.
 
@@ -184,7 +208,7 @@ class MessageExtensions(Generic[StateT]):
 
         def __call__(
             func: Callable[[TurnContext, StateT, str], Awaitable[MessagingExtensionResult]]
-        ):
+        ) -> Callable[[TurnContext, StateT, str], Awaitable[MessagingExtensionResult]]:
             async def __invoke__(context: TurnContext, state: StateT):
                 if not context.activity.value:
                     return False
@@ -206,7 +230,20 @@ class MessageExtensions(Generic[StateT]):
 
         return __call__
 
-    def message_preview(self, command_id: Union[str, Pattern[str]], action: MessagePreviewAction):
+    def message_preview(
+        self, command_id: Union[str, Pattern[str]], action: MessagePreviewAction
+    ) -> Callable[
+        [
+            Callable[
+                [TurnContext, StateT, Activity],
+                Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
+            ]
+        ],
+        Callable[
+            [TurnContext, StateT, Activity],
+            Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
+        ],
+    ]:
         """
         Registers a handler to process an action of a message that's being
         previewed by the user prior to sending.
@@ -256,7 +293,10 @@ class MessageExtensions(Generic[StateT]):
                 [TurnContext, StateT, Activity],
                 Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
             ]
-        ):
+        ) -> Callable[
+            [TurnContext, StateT, Activity],
+            Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
+        ]:
             async def __invoke__(context: TurnContext, state: StateT):
                 if not context.activity.value:
                     return False
@@ -281,7 +321,12 @@ class MessageExtensions(Generic[StateT]):
 
         return __call__
 
-    def fetch_task(self, command_id: Union[str, Pattern[str]]):
+    def fetch_task(
+        self, command_id: Union[str, Pattern[str]]
+    ) -> Callable[
+        [Callable[[TurnContext, StateT], Awaitable[Union[TaskModuleTaskInfo, str]]]],
+        Callable[[TurnContext, StateT], Awaitable[Union[TaskModuleTaskInfo, str]]],
+    ]:
         """
         Registers a handler to process the initial fetch task for an
         Action based message extension.
@@ -315,7 +360,7 @@ class MessageExtensions(Generic[StateT]):
                 [TurnContext, StateT],
                 Awaitable[Union[TaskModuleTaskInfo, str]],
             ]
-        ):
+        ) -> Callable[[TurnContext, StateT], Awaitable[Union[TaskModuleTaskInfo, str]],]:
             async def __invoke__(context: TurnContext, state: StateT):
                 res = await func(context, state)
                 await self._invoke_task_response(context, res)
@@ -326,7 +371,12 @@ class MessageExtensions(Generic[StateT]):
 
         return __call__
 
-    def select_item(self):
+    def select_item(
+        self,
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, Any], Awaitable[MessagingExtensionResult]]],
+        Callable[[TurnContext, StateT, Any], Awaitable[MessagingExtensionResult]],
+    ]:
         """
         Registers a handler that implements the logic to handle the
         tap actions for items returned by a Search based message extension.
@@ -356,7 +406,7 @@ class MessageExtensions(Generic[StateT]):
                 [TurnContext, StateT, Any],
                 Awaitable[MessagingExtensionResult],
             ]
-        ):
+        ) -> Callable[[TurnContext, StateT, Any], Awaitable[MessagingExtensionResult],]:
             async def __invoke__(context: TurnContext, state: StateT):
                 res = await func(context, state, context.activity.value)
                 await self._invoke_action_response(context, res)
@@ -367,7 +417,20 @@ class MessageExtensions(Generic[StateT]):
 
         return __call__
 
-    def submit_action(self, command_id: Union[str, Pattern[str]]):
+    def submit_action(
+        self, command_id: Union[str, Pattern[str]]
+    ) -> Callable[
+        [
+            Callable[
+                [TurnContext, StateT, Any],
+                Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
+            ]
+        ],
+        Callable[
+            [TurnContext, StateT, Any],
+            Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
+        ],
+    ]:
         """
         Registers a handler that implements the submit action for an
         Action based Message Extension.
@@ -401,7 +464,10 @@ class MessageExtensions(Generic[StateT]):
                 [TurnContext, StateT, Any],
                 Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
             ]
-        ):
+        ) -> Callable[
+            [TurnContext, StateT, Any],
+            Awaitable[Union[MessagingExtensionResult, TaskModuleTaskInfo, str, None]],
+        ]:
             async def __invoke__(context: TurnContext, state: StateT):
                 if not context.activity.value:
                     return False

--- a/python/packages/ai/teams/task_modules/task_modules.py
+++ b/python/packages/ai/teams/task_modules/task_modules.py
@@ -32,7 +32,12 @@ class TaskModules(Generic[StateT]):
         self._route_registry = route_registry
         self._task_data_filter = task_data_filter
 
-    def fetch(self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]):
+    def fetch(
+        self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str]]]],
+        Callable[[TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str]]],
+    ]:
         """
         Adds a route for handling the initial fetch of the task module.
         This method can be used as either a decorator or a method.
@@ -60,7 +65,7 @@ class TaskModules(Generic[StateT]):
 
         def __call__(
             func: Callable[[TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str]]]
-        ):
+        ) -> Callable[[TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str]]]:
             async def __handler__(context: TurnContext, state: StateT) -> bool:
                 # the selector already ensures data exists
                 result = await func(context, state, context.activity.value["data"])
@@ -73,7 +78,12 @@ class TaskModules(Generic[StateT]):
         return __call__
 
     # TODO: Ported the code first. Need more discussion on the functionality.
-    def submit(self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]):
+    def submit(
+        self, verb: Union[str, Pattern[str], Callable[[TurnContext], bool]]
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str, None]]]],
+        Callable[[TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str, None]]],
+    ]:
         """
         Adds a route for handling the submission of a task module.
         This method can be used as either a decorator or a method.
@@ -103,7 +113,7 @@ class TaskModules(Generic[StateT]):
             func: Callable[
                 [TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str, None]]
             ]
-        ):
+        ) -> Callable[[TurnContext, StateT, dict], Awaitable[Union[TaskModuleTaskInfo, str, None]]]:
             async def __handler__(context: TurnContext, state: StateT) -> bool:
                 # the selector already ensures data exists
                 result = await func(context, state, context.activity.value["data"])

--- a/python/samples/03.adaptiveCards.a.typeAheadBot/src/app.py
+++ b/python/samples/03.adaptiveCards.a.typeAheadBot/src/app.py
@@ -66,15 +66,13 @@ async def search_npm_package(
 
 
 @app.adaptive_cards.action_submit("DynamicSubmit")
-async def on_dynamic_submit(context: TurnContext, _state: TurnState, data) -> bool:
+async def on_dynamic_submit(context: TurnContext, _state: TurnState, data) -> None:
     await context.send_activity(f'Dynamically selected option is: {data["choiceSelect"]}')
-    return True
 
 
 @app.adaptive_cards.action_submit("StaticSubmit")
-async def on_static_submit(context: TurnContext, _state: TurnState, data) -> bool:
+async def on_static_submit(context: TurnContext, _state: TurnState, data) -> None:
     await context.send_activity(f'Statically selected option is: {data["choiceSelect"]}')
-    return True
 
 
 # Create API to receive messages from Teams


### PR DESCRIPTION
## Linked issues

closes: #565 

## Details

Add type annotation for decorator return value so mypy can get enough information to do type checking.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

