### PR TITLE
[PY] fix: add azure client and disable moderation in azure planner

### DIFF
--- a/python/packages/ai/.pylintrc
+++ b/python/packages/ai/.pylintrc
@@ -444,7 +444,8 @@ disable=raw-checker-failed,
         redefined-builtin,
         too-many-public-methods,
         too-many-return-statements,
-        too-many-boolean-expressions
+        too-many-boolean-expressions,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/python/packages/ai/teams/ai/ai.py
+++ b/python/packages/ai/teams/ai/ai.py
@@ -58,7 +58,7 @@ class AI(Generic[StateT]):
                 ActionTypes.FLAGGED_OUTPUT, True, self._on_flagged_output
             ),
             ActionTypes.RATE_LIMITED: ActionEntry(
-                ActionTypes.PLAN_READY, True, self._on_plan_ready
+                ActionTypes.RATE_LIMITED, True, self._on_rate_limited
             ),
             ActionTypes.PLAN_READY: ActionEntry(ActionTypes.PLAN_READY, True, self._on_plan_ready),
             ActionTypes.DO_COMMAND: ActionEntry(ActionTypes.DO_COMMAND, True, self._on_do_command),

--- a/python/packages/ai/teams/ai/models/azure_openai/client/__init__.py
+++ b/python/packages/ai/teams/ai/models/azure_openai/client/__init__.py
@@ -1,0 +1,6 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from .azure_openai_client import AzureOpenAIClient

--- a/python/packages/ai/teams/ai/models/azure_openai/client/azure_openai_client.py
+++ b/python/packages/ai/teams/ai/models/azure_openai/client/azure_openai_client.py
@@ -3,47 +3,38 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Union
 
 from aiohttp import ClientResponseError, ClientSession
 
-from .openai_client_error import OpenAIClientError
-from .openai_client_response import OpenAIClientResponse
-from .schemas import CreateModerationResponse
+from teams.ai.models.openai import (
+    CreateModerationResponse,
+    OpenAIClient,
+    OpenAIClientError,
+    OpenAIClientResponse,
+)
 
 
-class OpenAIClient:
+class AzureOpenAIClient(OpenAIClient):
     """
-    OpenAI Http Client
+    Azure OpenAI Http Client
     """
 
-    _api_key: str
-    _organization: Optional[str]
-    _base_url: str
+    _api_version: str
 
     @property
     def _headers(self) -> Dict[str, str]:
         headers = {
             "Content-Type": "application/json",
             "User-Agent": "Microsoft Teams Conversational AI SDK",
-            "Authorization": f"Bearer {self._api_key}",
+            "Ocp-Apim-Subscription-Key": self._api_key,
         }
-
-        if self._organization:
-            headers["OpenAI-Organization"] = self._organization
 
         return headers
 
-    def __init__(
-        self,
-        api_key: str,
-        *,
-        organization: Optional[str] = None,
-        base_url: str = "https://api.openai.com",
-    ) -> None:
-        self._api_key = api_key
-        self._organization = organization
-        self._base_url = base_url
+    def __init__(self, api_key: str, *, base_url: str, api_version: str = "2022-12-01") -> None:
+        super().__init__(api_key, base_url=base_url)
+        self._api_version = api_version
 
     async def create_moderation(
         self,
@@ -58,7 +49,10 @@ class OpenAIClient:
             headers=self._headers,
         ) as session:
             try:
-                res = await session.post("/v1/moderations", json={"input": input, "model": model})
+                res = await session.post(
+                    f"/contentsafety/text:analyze?api-version={self._api_version}",
+                    json={"text": input},
+                )
                 data = await res.json()
 
                 if res.status >= 400:

--- a/python/packages/ai/teams/ai/models/azure_openai/planner.py
+++ b/python/packages/ai/teams/ai/models/azure_openai/planner.py
@@ -3,21 +3,47 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from typing import Optional
+
 from semantic_kernel.connectors.ai.open_ai import (
     AzureChatCompletion,
     AzureTextCompletion,
 )
 
+from botbuilder.core import TurnContext
+
+from teams.ai.state import TurnState
+from teams.ai.prompts import PromptTemplate
 from teams.ai.models.openai import OpenAIPlanner
+from teams.ai.planner import Plan
 
+from .client import AzureOpenAIClient
 from .planner_options import AzureOpenAIPlannerOptions
-
 
 class AzureOpenAIPlanner(OpenAIPlanner):
     _options: AzureOpenAIPlannerOptions
+    _client: AzureOpenAIClient
 
     def __init__(self, options: AzureOpenAIPlannerOptions):
         super().__init__(options)
+        self._options = options
+        self._client = AzureOpenAIClient(self._options.api_key, base_url=options.endpoint)
+
+    async def review_prompt(
+        self,
+        _context: TurnContext,
+        _state: TurnState,
+        _prompt: PromptTemplate,
+    ) -> Optional[Plan]:
+        return None
+
+    async def review_plan(
+        self,
+        _context: TurnContext,
+        _state: TurnState,
+        plan: Plan,
+    ) -> Plan:
+        return plan
 
     def _add_text_completion_service(self) -> None:
         self._sk.add_text_completion_service(


### PR DESCRIPTION
## Linked issues

closes: https://github.com/microsoft/teams-ai/issues/622

## Details

- add azure openai client for content safety
- temporarily disable azure openai moderation methods to unblock chefbot

![image (4)](https://github.com/microsoft/teams-ai/assets/44811138/7e4d55dd-4fba-442f-8e7a-3088cf2522d4)

