### PR TITLE
Support sending no result from taskModule.submit

### DIFF
--- a/js/packages/teams-ai/src/TaskModules.ts
+++ b/js/packages/teams-ai/src/TaskModules.ts
@@ -159,6 +159,10 @@ export class TaskModules<TState extends TurnState> {
 
                     // Call handler and then check to see if an invoke response has already been added
                     const result = await handler(context, state, context.activity.value?.data ?? {});
+                    
+                    // if result is null or undefined, this indicates no response should be sent 
+                    if (!result) return;
+
                     if (!context.turnState.get(INVOKE_RESPONSE_KEY)) {
                         // Format invoke response
                         let response: TaskModuleResponse | undefined = undefined;


### PR DESCRIPTION
## Linked issues

closes: #635

## Details

Provide a list of your changes here. If you are fixing a bug, please provide steps to reproduce the bug.

- Return `null` or `undefined` from `taskModule.submit` without having done anything strictly with context and it will show an error "Unable to reach app" even though the intention was to close the app 

#### Change details

If developer returns `null` or `undefined` from `taskModule.submit` then no response is given, allowing a task module to close without showing an error window

### Additional information

[A PR to go with my issue ](https://github.com/microsoft/teams-ai/issues/635)

Here is a screenshot of the error with the current code:

<img width="314" alt="CleanShot 2023-09-27 at 22 12 17@2x" src="https://github.com/microsoft/teams-ai/assets/9315568/3f701119-d61d-40f1-8a9f-d675f4048d93">

My code: 
```javascript
bot.taskModules.submit(
  'submit',
  async (context, state, data) => {
    await handleTeamsTaskModuleSubmit(context, data);
    // context.turnState.set(INVOKE_RESPONSE_KEY, { status: 200 });
    return null;
  },
);
```

If I uncomment the `context.turnState.set` line then I am able to close the task module without the error, preserving previous behaviour