### PR TITLE
[JS] fix: #741 #744 Fix task modules bug in JS and add filtering for teams channel events

### DIFF
--- a/js/packages/teams-ai/src/Application.spec.ts
+++ b/js/packages/teams-ai/src/Application.spec.ts
@@ -200,7 +200,27 @@ describe('Application', () => {
             mockApp = new Application({ adapter });
         });
 
-        it('should route to an instantiated conversationUpdate handler', async () => {
+        it('should route to an instantiated conversationUpdate handler when channelId is Teams', async () => {
+            let handlerCalled = false;
+            mockApp.conversationUpdate('membersAdded', async (context, _state) => {
+                handlerCalled = true;
+                assert.equal(context.activity.membersAdded && context.activity.membersAdded.length, 2);
+            });
+
+            const activity = createTestConversationUpdate();
+            activity.channelId = 'msteams';
+            activity.membersAdded = [
+                { id: '123', name: 'Member One' },
+                { id: '42', name: "Don't Panic" }
+            ];
+
+            await adapter.processActivity(activity, async (context) => {
+                await mockApp.run(context);
+                assert.equal(handlerCalled, true);
+            });
+        });
+
+        it('should route to an instantiated conversationUpdate handler when channelId is not defined', async () => {
             let handlerCalled = false;
             mockApp.conversationUpdate('membersAdded', async (context, _state) => {
                 handlerCalled = true;
@@ -256,7 +276,7 @@ describe('Application', () => {
                 });
 
                 const activity = createTestConversationUpdate(channelData);
-
+                activity.channelId = 'msteams';
                 await adapter.processActivity(activity, async (context) => {
                     await mockApp.run(context);
                     assert.equal(handlerCalled, true);
@@ -269,6 +289,7 @@ describe('Application', () => {
             const team = { id: 'mockTeamId' };
             const channel = { id: 'mockChannelId' };
             const activity = createTestConversationUpdate({ channel, eventType: 'channelCreated', team });
+            activity.channelId = 'msteams';
 
             mockApp.conversationUpdate('channelCreated', async (context, _state) => {
                 handlerCalled = true;

--- a/js/packages/teams-ai/src/Application.ts
+++ b/js/packages/teams-ai/src/Application.ts
@@ -134,7 +134,9 @@ export type ConversationUpdateEvents =
     | 'teamHardDeleted'
     | 'teamArchived'
     | 'teamUnarchived'
-    | 'teamRestored';
+    | 'teamRestored'
+    | 'topicName'
+    | 'historyDisclosed';
 
 /**
  * Function for handling an incoming request.
@@ -912,7 +914,8 @@ function createConversationUpdateSelector(event: ConversationUpdateEvents): Rout
              */
             return (context: TurnContext) => {
                 return Promise.resolve(
-                    context?.activity?.type == ActivityTypes.ConversationUpdate &&
+                    context?.activity?.channelId === 'msteams' &&
+                        context?.activity?.type == ActivityTypes.ConversationUpdate &&
                         context?.activity?.channelData?.eventType == event &&
                         context?.activity?.channelData?.channel &&
                         context.activity.channelData?.team
@@ -954,7 +957,8 @@ function createConversationUpdateSelector(event: ConversationUpdateEvents): Rout
              */
             return (context: TurnContext) => {
                 return Promise.resolve(
-                    context?.activity?.type == ActivityTypes.ConversationUpdate &&
+                    context?.activity?.channelId === 'msteams' &&
+                        context?.activity?.type == ActivityTypes.ConversationUpdate &&
                         context?.activity?.channelData?.eventType == event &&
                         context?.activity?.channelData?.team
                 );
@@ -1039,6 +1043,7 @@ function createMessageReactionSelector(event: MessageReactionEvents): RouteSelec
             };
     }
 }
+// channelData: eventype of editMessage
 
 /**
  * @private

--- a/js/packages/teams-ai/src/MessageExtensions.spec.ts
+++ b/js/packages/teams-ai/src/MessageExtensions.spec.ts
@@ -71,7 +71,7 @@ describe('MessageExtensions', () => {
             const activity = createTestInvoke(ANONYMOUS_QUERY_LINK_INVOKE_NAME, {
                 url: 'https://www.youtube.com/watch?v=971YIvosuUk&ab_channel=MicrosoftDeveloper'
             });
-
+            activity.channelId = 'msteams';
             // Set up the anonymousQueryLink handler
             mockApp.messageExtensions.anonymousQueryLink(async () => {
                 return {
@@ -129,6 +129,7 @@ describe('MessageExtensions', () => {
     describe(`${CONFIGURE_SETTINGS}`, () => {
         it('should return InvokeResponse with status code 200 with the configure setting invoke name', async () => {
             const activity = createTestInvoke(CONFIGURE_SETTINGS, { theme: 'dark' });
+            activity.channelId = 'msteams';
 
             mockApp.messageExtensions.configureSettings(async (context: TurnContext, _state, value) => {
                 assert.equal(value.theme, 'dark');
@@ -146,6 +147,7 @@ describe('MessageExtensions', () => {
     describe(`${FETCH_TASK_INVOKE_NAME}`, () => {
         it('should return InvokeResponse with status code 200 with the task invoke card', async () => {
             const activity = createTestInvoke(FETCH_TASK_INVOKE_NAME, { commandId: 'showTaskModule' });
+            activity.channelId = 'msteams';
 
             mockApp.messageExtensions.fetchTask('showTaskModule', async (context: TurnContext, _state) => {
                 return {
@@ -198,6 +200,7 @@ describe('MessageExtensions', () => {
 
         it('should return InvokeResponse with status code 200 with a string message', async () => {
             const activity = createTestInvoke(FETCH_TASK_INVOKE_NAME, { commandId: 'showMessage' });
+            activity.channelId = 'msteams';
 
             mockApp.messageExtensions.fetchTask('showMessage', async (context: TurnContext, _state) => {
                 return 'Fetch task string';
@@ -223,16 +226,22 @@ describe('MessageExtensions', () => {
             const activity = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'showTaskModule'
             });
+            activity.channelId = 'msteams';
             const regexp = new RegExp(/show$/, 'i');
             const activity2 = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'Show'
             });
+            activity2.channelId = 'msteams';
+
             const activity3 = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'show task module'
             });
+            activity3.channelId = 'msteams';
+
             const activity4 = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'show task'
             });
+            activity4.channelId = 'msteams';
 
             mockApp.messageExtensions.fetchTask(
                 [
@@ -314,6 +323,8 @@ describe('MessageExtensions', () => {
                     formField3: 'formField3_value'
                 }
             });
+            activity.channelId = 'msteams';
+
             mockApp.messageExtensions.submitAction('giveKudos', async (context: TurnContext, _state, value) => {
                 return {
                     type: 'result',
@@ -376,6 +387,8 @@ describe('MessageExtensions', () => {
                 botActivityPreview: [1],
                 botMessagePreviewAction: 'send'
             });
+            activity.channelId = 'msteams';
+
             mockApp.messageExtensions.botMessagePreviewSend(
                 'Create Preview',
                 async (context: TurnContext, _state, previewActivity) => {
@@ -397,6 +410,8 @@ describe('MessageExtensions', () => {
                 botActivityPreview: [1],
                 botMessagePreviewAction: 'edit'
             });
+            activity.channelId = 'msteams';
+
             mockApp.messageExtensions.botMessagePreviewEdit(
                 'Create Preview',
                 async (context: TurnContext, _state, previewActivity) => {
@@ -420,11 +435,14 @@ describe('MessageExtensions', () => {
                 botActivityPreview: ['create preview'],
                 botMessagePreviewAction: 'send'
             });
+            activity.channelId = 'msteams';
+
             const activity2 = createTestInvoke(SUBMIT_ACTION_INVOKE_NAME, {
                 commandId: 'preview',
                 botActivityPreview: ['preview'],
                 botMessagePreviewAction: 'send'
             });
+            activity2.channelId = 'msteams';
 
             mockApp.messageExtensions.botMessagePreviewSend(
                 ['create preview', 'preview'],
@@ -453,6 +471,7 @@ describe('MessageExtensions', () => {
                 botActivityPreview: [1],
                 botMessagePreviewAction: 'edit'
             });
+            activity.channelId = 'msteams';
 
             mockApp.messageExtensions.botMessagePreviewSend(
                 async (context) => {
@@ -476,6 +495,8 @@ describe('MessageExtensions', () => {
     describe(`${QUERY_INVOKE_NAME}`, () => {
         it('should return InvokeResponse with status code 200 with the query invoke name', async () => {
             const activity = createTestInvoke(QUERY_INVOKE_NAME, { commandId: 'showQuery' });
+            activity.channelId = 'msteams';
+
             interface MyParams {}
 
             mockApp.messageExtensions.query(
@@ -511,6 +532,7 @@ describe('MessageExtensions', () => {
                 displayText: 'Yes',
                 value: 'Yes'
             });
+            activity.channelId = 'msteams';
 
             mockApp.messageExtensions.handleOnButtonClicked(async (context: TurnContext, _state, button) => {
                 assert.equal(button.title, 'Query button');
@@ -532,6 +554,7 @@ describe('MessageExtensions', () => {
             const activity = createTestInvoke(QUERY_LINK_INVOKE_NAME, {
                 url: 'https://www.youtube.com/watch?v=971YIvosuUk&ab_channel=MicrosoftDeveloper'
             });
+            activity.channelId = 'msteams';
 
             // Set up the queryLink handler
             mockApp.messageExtensions.queryLink(async () => {
@@ -590,6 +613,7 @@ describe('MessageExtensions', () => {
     describe(`${QUERY_SETTING_URL}`, async () => {
         it('should return InvokeResponse with status code 200 when querySettingUrl is invoked', async () => {
             const activity = createTestInvoke(QUERY_SETTING_URL, {});
+            activity.channelId = 'msteams';
 
             mockApp.messageExtensions.queryUrlSetting(async (context: TurnContext, _state) => {
                 return {
@@ -632,6 +656,7 @@ describe('MessageExtensions', () => {
                 ],
                 type: 'result'
             });
+            activity.channelId = 'msteams';
 
             // Set up the selectItem handler
             mockApp.messageExtensions.selectItem(async (_context, _state, item) => {

--- a/js/packages/teams-ai/src/MessageExtensions.ts
+++ b/js/packages/teams-ai/src/MessageExtensions.ts
@@ -99,7 +99,8 @@ export class MessageExtensions<TState extends TurnState> {
     ): Application<TState> {
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.type == ActivityTypes.Invoke &&
+                context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.type == ActivityTypes.Invoke &&
                     context?.activity.name === ANONYMOUS_QUERY_LINK_INVOKE_NAME
             );
         this._app.addRoute(
@@ -152,20 +153,26 @@ export class MessageExtensions<TState extends TurnState> {
             this._app.addRoute(
                 selector,
                 async (context, state) => {
-                    // Insure that we're in an invoke as expected
-                    if (
-                        context?.activity?.type !== ActivityTypes.Invoke ||
-                        context?.activity?.name !== SUBMIT_ACTION_INVOKE_NAME ||
-                        context?.activity?.value?.botMessagePreviewAction !== 'edit'
-                    ) {
-                        throw new Error(
-                            `Unexpected MessageExtensions.botMessagePreviewEdit() triggered for activity type: ${context?.activity?.type}`
-                        );
-                    }
+                    if (context?.activity?.channelId === 'msteams') {
+                        // Insure that we're in an invoke as expected
+                        if (
+                            context?.activity?.type !== ActivityTypes.Invoke ||
+                            context?.activity?.name !== SUBMIT_ACTION_INVOKE_NAME ||
+                            context?.activity?.value?.botMessagePreviewAction !== 'edit'
+                        ) {
+                            throw new Error(
+                                `Unexpected MessageExtensions.botMessagePreviewEdit() triggered for activity type: ${context?.activity?.type}`
+                            );
+                        }
 
-                    // Call handler and then check to see if an invoke response has already been added
-                    const result = await handler(context, state, context.activity.value?.botActivityPreview[0] ?? {});
-                    await this.returnSubmitActionResponse(context, result);
+                        // Call handler and then check to see if an invoke response has already been added
+                        const result = await handler(
+                            context,
+                            state,
+                            context.activity.value?.botActivityPreview[0] ?? {}
+                        );
+                        await this.returnSubmitActionResponse(context, result);
+                    }
                 },
                 true
             );
@@ -198,6 +205,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
+                        context?.activity?.channelId !== 'msteams' ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== SUBMIT_ACTION_INVOKE_NAME ||
                         context?.activity?.value?.botMessagePreviewAction !== 'send'
@@ -246,6 +254,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
+                        context?.activity?.channelId !== 'msteams' ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== FETCH_TASK_INVOKE_NAME
                     ) {
@@ -314,6 +323,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
+                        context?.activity?.channelId !== 'msteams' ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== QUERY_INVOKE_NAME
                     ) {
@@ -371,7 +381,9 @@ export class MessageExtensions<TState extends TurnState> {
     ): Application<TState> {
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.type == ActivityTypes.Invoke && context?.activity.name === QUERY_LINK_INVOKE_NAME
+                context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.type == ActivityTypes.Invoke &&
+                    context?.activity.name === QUERY_LINK_INVOKE_NAME
             );
 
         this._app.addRoute(
@@ -419,7 +431,9 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.type == ActivityTypes.Invoke && context?.activity.name === SELECT_ITEM_INVOKE_NAME
+                context.activity.channelId === 'msteams' &&
+                    context?.activity?.type == ActivityTypes.Invoke &&
+                    context?.activity.name === SELECT_ITEM_INVOKE_NAME
             );
 
         // Add route
@@ -472,6 +486,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
+                        context?.activity?.channelId !== 'msteams' ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== SUBMIT_ACTION_INVOKE_NAME
                     ) {
@@ -500,7 +515,7 @@ export class MessageExtensions<TState extends TurnState> {
         context: TurnContext,
         result: MessagingExtensionResult | TaskModuleTaskInfo | string | null | undefined
     ): Promise<void> {
-        if (!context.turnState.get(INVOKE_RESPONSE_KEY)) {
+        if (context?.activity?.channelId === 'msteams' && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
             // Format invoke response
             let response: MessagingExtensionActionResponse;
             if (typeof result == 'string') {
@@ -556,7 +571,9 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.type == ActivityTypes.Invoke && context?.activity.name === QUERY_SETTING_URL
+                context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.type == ActivityTypes.Invoke &&
+                    context?.activity.name === QUERY_SETTING_URL
             );
 
         // Add route
@@ -598,7 +615,9 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.type == ActivityTypes.Invoke && context?.activity.name === CONFIGURE_SETTINGS
+                context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.type == ActivityTypes.Invoke &&
+                    context?.activity.name === CONFIGURE_SETTINGS
             );
 
         // Add route
@@ -640,7 +659,9 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.type == ActivityTypes.Invoke && context?.activity.name === QUERY_CARD_BUTTON_CLICKED
+                context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.type == ActivityTypes.Invoke &&
+                    context?.activity.name === QUERY_CARD_BUTTON_CLICKED
             );
 
         // Add route
@@ -685,6 +706,7 @@ function createTaskSelector(
             const isInvoke = context?.activity?.type == ActivityTypes.Invoke && context?.activity?.name == invokeName;
             if (
                 isInvoke &&
+                context?.activity?.channelId === 'msteams' &&
                 typeof context?.activity?.value?.commandId == 'string' &&
                 matchesPreviewAction(context.activity, botMessagePreviewAction)
             ) {
@@ -699,6 +721,7 @@ function createTaskSelector(
             const isInvoke = context?.activity?.type == ActivityTypes.Invoke && context?.activity?.name == invokeName;
             return Promise.resolve(
                 isInvoke &&
+                    context?.activity?.channelId === 'msteams' &&
                     context?.activity?.value?.commandId === commandId &&
                     matchesPreviewAction(context.activity, botMessagePreviewAction)
             );

--- a/js/packages/teams-ai/src/TaskModules.ts
+++ b/js/packages/teams-ai/src/TaskModules.ts
@@ -222,8 +222,7 @@ function createTaskSelector(
                 isInvoke &&
                 typeof data == 'object' &&
                 // eslint-disable-next-line security/detect-object-injection
-                typeof data[filterField] == 'string' &&
-                Object.keys(data).length === 1 // Ensure that data only contains the filterField property
+                typeof data[filterField] == 'string'
             ) {
                 // eslint-disable-next-line security/detect-object-injection
                 return Promise.resolve(verb.test(data[filterField]));
@@ -238,7 +237,7 @@ function createTaskSelector(
             const data = context?.activity?.value?.data;
             return Promise.resolve(
                 // eslint-disable-next-line security/detect-object-injection
-                isInvoke && typeof data == 'object' && data[filterField] == verb && Object.keys(data).length === 1 // Ensure that data only contains the filterField property
+                isInvoke && typeof data == 'object' && data[filterField] == verb
             );
         };
     }


### PR DESCRIPTION
## Linked issues

closes: #741
other: #744

## Details
- Fixes a task module bug I introduced that @lilyydu caught -- thanks Lily!
- For Teams-only events, make sure that `channelId` is verified

Provide a list of your changes here. If you are fixing a bug, please provide steps to reproduce the bug.

#### Change details

**code snippets**:
```typescript
        case 'teamRenamed':
        case 'teamDeleted':
        case 'teamHardDeleted':
        case 'teamArchived':
        case 'teamUnarchived':
        case 'teamRestored':
            /**
             * @param {TurnContext} context The context object for the current turn of conversation.
             * @returns {Promise<boolean>} A Promise that resolves to a boolean indicating whether the activity is a conversation update event related to teams.
             */
            return (context: TurnContext) => {
                return Promise.resolve(
                    context?.activity?.channelId === 'msteams' && // this change here
                        context?.activity?.type == ActivityTypes.ConversationUpdate &&
                        context?.activity?.channelData?.eventType == event &&
                        context?.activity?.channelData?.team
                );
            };
```
## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
