### PR TITLE
[JS] fix: parameter passing in Message Extensions handleOnButtonClicked was confusingly named

### DIFF
--- a/js/packages/teams-ai/src/MessageExtensions.spec.ts
+++ b/js/packages/teams-ai/src/MessageExtensions.spec.ts
@@ -534,10 +534,10 @@ describe('MessageExtensions', () => {
             });
             activity.channelId = 'msteams';
 
-            mockApp.messageExtensions.handleOnButtonClicked(async (context: TurnContext, _state, button) => {
-                assert.equal(button.title, 'Query button');
-                assert.equal(button.displayText, 'Yes');
-                assert.equal(button.value, 'Yes');
+            mockApp.messageExtensions.handleOnButtonClicked(async (context: TurnContext, _state, data) => {
+                assert.equal(data.title, 'Query button');
+                assert.equal(data.displayText, 'Yes');
+                assert.equal(data.value, 'Yes');
             });
 
             await adapter.processActivity(activity, async (context) => {

--- a/js/packages/teams-ai/src/MessageExtensions.ts
+++ b/js/packages/teams-ai/src/MessageExtensions.ts
@@ -650,11 +650,11 @@ export class MessageExtensions<TState extends TurnState> {
      * @param {(context: TurnContext, state: TState, data: TData) => Promise<void>} handler Function defined by the developer to call when the command is received.
      * @param {TurnContext} handler.context Context for the current turn of conversation with the user.
      * @param {TState} handler.state Current state of the turn.
-     * @param {TData} handler.settings The configuration settings that was submitted.
+     * @param {TData} handler.data The data that was submitted.
      * @returns {Application<TState>} The application for chaining purposes.
      */
     public handleOnButtonClicked<TData extends Record<string, any>>(
-        handler: (context: TurnContext, state: TState, settings: TData) => Promise<void>
+        handler: (context: TurnContext, state: TState, data: TData) => Promise<void>
     ): Application<TState> {
         // Define static route selector
         const selector = (context: TurnContext) =>


### PR DESCRIPTION
## Linked issues

#minor

## Details

`messageExtensions.handleOnButtonClicked` had third parameter named `settings` which is a copy-paste error. This updates it to `data`.


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
