### PR TITLE
[C#] fix: check channel id "msteams" for teams-specific events

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -537,11 +537,13 @@ namespace Microsoft.TeamsAI.Tests.Application
                 {
                     EventType = "teamRenamed"
                 },
-                Name = "1"
+                Name = "1",
+                ChannelId = "msteams"
             };
             var activity2 = new Activity
             {
-                Type = ActivityTypes.ConversationUpdate
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelId = "msteams"
             };
             var activity3 = new Activity
             {
@@ -549,7 +551,8 @@ namespace Microsoft.TeamsAI.Tests.Application
                 ChannelData = new TeamsChannelData
                 {
                     EventType = "teamRenamed"
-                }
+                },
+                ChannelId = "msteams"
             };
 
             var adapter = new NotImplementedAdapter();
@@ -586,7 +589,8 @@ namespace Microsoft.TeamsAI.Tests.Application
             {
                 Type = ActivityTypes.ConversationUpdate,
                 MembersAdded = new List<ChannelAccount> { new() },
-                Name = "1"
+                Name = "1",
+                ChannelId = "msteams"
             };
             var activity2 = new Activity
             {
@@ -595,7 +599,8 @@ namespace Microsoft.TeamsAI.Tests.Application
                 {
                     EventType = "channelDeleted"
                 },
-                Name = "2"
+                Name = "2",
+                ChannelId = "msteams"
             };
             var activity3 = new Activity
             {
@@ -603,7 +608,8 @@ namespace Microsoft.TeamsAI.Tests.Application
                 ChannelData = new TeamsChannelData
                 {
                     EventType = "teamRenamed"
-                }
+                },
+                ChannelId = "msteams"
             };
 
             var adapter = new NotImplementedAdapter();
@@ -633,6 +639,65 @@ namespace Microsoft.TeamsAI.Tests.Application
             Assert.Equal(2, names.Count);
             Assert.Equal("1", names[0]);
             Assert.Equal("2", names[1]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_BypassNonTeamsEvent()
+        {
+            // Arrange
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                MembersAdded = new List<ChannelAccount> { new() },
+                Name = "1",
+                ChannelId = "msteams"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "channelDeleted"
+                },
+                Name = "2",
+                ChannelId = "directline"
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamRenamed"
+                },
+                ChannelId = "directline"
+            };
+
+            var adapter = new NotImplementedAdapter();
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(
+                new[] { ConversationUpdateEvents.TeamRenamed, ConversationUpdateEvents.ChannelDeleted, ConversationUpdateEvents.MembersAdded },
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(names);
+            Assert.Equal("1", names[0]);
         }
 
         [Fact]

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.TeamsAI.AI;
@@ -257,7 +258,8 @@ namespace Microsoft.TeamsAI
                 {
                     routeSelector = (context, _) => Task.FromResult
                     (
-                        string.Equals(context.Activity?.Type, ActivityTypes.ConversationUpdate, StringComparison.OrdinalIgnoreCase)
+                        string.Equals(context.Activity?.ChannelId, Channels.Msteams)
+                        && string.Equals(context.Activity?.Type, ActivityTypes.ConversationUpdate, StringComparison.OrdinalIgnoreCase)
                         && string.Equals(context.Activity?.GetChannelData<TeamsChannelData>()?.EventType, conversationUpdateEvent)
                     );
                     break;


### PR DESCRIPTION
## Linked issues

#minor (avoid closing issue)
associated: #744

## Details

Check channel id "msteams" for teams-specific events

#### Change details

```csharp
// add check
string.Equals(context.Activity?.ChannelId, Channels.Msteams)
```

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
