### PR TITLE
[C#] feat: handles message update/delete events

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/AdaptiveCardsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/AdaptiveCardsTests.cs
@@ -40,8 +40,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Status = 200,
                 Body = adaptiveCardInvokeResponseMock.Object
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             ActionExecuteHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
                 TestAdaptiveCardActionData actionData = Cast<TestAdaptiveCardActionData>(data);
@@ -50,7 +52,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnActionExecute("test-verb", handler);
+            app.AdaptiveCards.OnActionExecute("test-verb", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -89,15 +91,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "application/search"
             });
             var adaptiveCardInvokeResponseMock = new Mock<AdaptiveCardInvokeResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             ActionExecuteHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
                 return Task.FromResult(adaptiveCardInvokeResponseMock.Object);
             };
 
             // Act
-            adaptiveCards.OnActionExecute("test-verb", handler);
+            app.AdaptiveCards.OnActionExecute("test-verb", handler);
             await app.OnTurnAsync(turnContext1);
             await app.OnTurnAsync(turnContext2);
 
@@ -115,8 +119,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "application/search"
             });
             var adaptiveCardInvokeResponseMock = new Mock<AdaptiveCardInvokeResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -127,7 +133,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnActionExecute(routeSelector, handler);
+            app.AdaptiveCards.OnActionExecute(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -149,8 +155,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 }),
                 Recipient = new("test-id")
             });
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             var called = false;
             ActionSubmitHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
@@ -162,7 +170,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnActionSubmit("test-verb", handler);
+            app.AdaptiveCards.OnActionSubmit("test-verb", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -184,8 +192,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 }),
                 Recipient = new("test-id")
             });
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             var called = false;
             ActionSubmitHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
@@ -197,7 +207,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnActionSubmit("not-test-verb", handler);
+            app.AdaptiveCards.OnActionSubmit("not-test-verb", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -215,8 +225,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Text = "test-text",
                 Recipient = new("test-id")
             });
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -227,7 +239,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnActionSubmit(routeSelector, handler);
+            app.AdaptiveCards.OnActionSubmit(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -277,8 +289,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                     }
                 }
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             SearchHandler<TestTurnState> handler = (turnContext, turnState, query, cancellationToken) =>
             {
                 Assert.Equal("test-query", query.Parameters.QueryText);
@@ -287,7 +301,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnSearch("test-dataset", handler);
+            app.AdaptiveCards.OnSearch("test-dataset", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -327,8 +341,10 @@ namespace Microsoft.TeamsAI.Tests.Application
             {
                 new("test-title", "test-value")
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             SearchHandler<TestTurnState> handler = (turnContext, turnState, query, cancellationToken) =>
             {
                 Assert.Equal("test-query", query.Parameters.QueryText);
@@ -337,7 +353,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnSearch("not-test-dataset", handler);
+            app.AdaptiveCards.OnSearch("not-test-dataset", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -358,8 +374,10 @@ namespace Microsoft.TeamsAI.Tests.Application
             {
                 new("test-title", "test-value")
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var adaptiveCards = new AdaptiveCards<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -372,7 +390,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            adaptiveCards.OnSearch(routeSelector, handler);
+            app.AdaptiveCards.OnSearch(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -855,6 +855,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             var app = new Application<TestTurnState, TestTurnStateManager>(new()
             {
                 RemoveRecipientMention = false,
+                StartTypingTimer = false
             });
             var names = new List<string>();
             app.OnMessageEdit((turnContext, _, _) =>
@@ -907,6 +908,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             var app = new Application<TestTurnState, TestTurnStateManager>(new()
             {
                 RemoveRecipientMention = false,
+                StartTypingTimer = false
             });
             var names = new List<string>();
             app.OnMessageUndelete((turnContext, _, _) =>
@@ -959,6 +961,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             var app = new Application<TestTurnState, TestTurnStateManager>(new()
             {
                 RemoveRecipientMention = false,
+                StartTypingTimer = false
             });
             var names = new List<string>();
             app.OnMessageDelete((turnContext, _, _) =>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.TeamsAI.Tests.TestUtils;
@@ -818,6 +819,162 @@ namespace Microsoft.TeamsAI.Tests.Application
             Assert.Equal("hello a", texts[0]);
             Assert.Equal("welcome", texts[1]);
             Assert.Equal("hello world", texts[2]);
+        }
+
+        [Fact]
+        public async Task Test_OnMessageEdit()
+        {
+            // Arrange
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelId = Channels.Msteams,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "editMessage"
+                },
+                Name = "1"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelId = Channels.Msteams,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "softDeleteMessage"
+                }
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Message
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+            });
+            var names = new List<string>();
+            app.OnMessageEdit((turnContext, _, _) =>
+            {
+                names.Add(turnContext.Activity.Name);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(names);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnMessageUnDelete()
+        {
+            // Arrange
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelId = Channels.Msteams,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "undeleteMessage"
+                },
+                Name = "1"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelId = Channels.Msteams,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "softDeleteMessage"
+                }
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Message
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+            });
+            var names = new List<string>();
+            app.OnMessageUndelete((turnContext, _, _) =>
+            {
+                names.Add(turnContext.Activity.Name);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(names);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnMessageDelete()
+        {
+            // Arrange
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.MessageDelete,
+                ChannelId = Channels.Msteams,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "softDeleteMessage"
+                },
+                Name = "1"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.MessageDelete,
+                ChannelId = Channels.Msteams,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "unknown"
+                }
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Message
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+            });
+            var names = new List<string>();
+            app.OnMessageDelete((turnContext, _, _) =>
+            {
+                names.Add(turnContext.Activity.Name);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(names);
+            Assert.Equal("1", names[0]);
         }
 
         [Fact]

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MessageExtensionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MessageExtensionsTests.cs
@@ -41,8 +41,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Status = 200,
                 Body = actionResponseMock.Object
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             SubmitActionHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
                 MessageExtensionActionData actionData = Cast<MessageExtensionActionData>(data);
@@ -52,7 +54,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnSubmitAction("test-command", handler);
+            app.MessageExtensions.OnSubmitAction("test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -87,8 +89,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 })
             });
             var actionResponseMock = new Mock<MessagingExtensionActionResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             SubmitActionHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
                 MessageExtensionActionData actionData = Cast<MessageExtensionActionData>(data);
@@ -98,7 +102,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnSubmitAction("not-test-command", handler);
+            app.MessageExtensions.OnSubmitAction("not-test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -115,8 +119,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "composeExtension/fetchTask"
             });
             var actionResponseMock = new Mock<MessagingExtensionActionResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -127,7 +133,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnSubmitAction(routeSelector, handler);
+            app.MessageExtensions.OnSubmitAction(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -166,8 +172,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Status = 200,
                 Body = actionResponseMock.Object
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             BotMessagePreviewEditHandler<TestTurnState> handler = (turnContext, turnState, activityPreview, cancellationToken) =>
             {
                 Assert.Equivalent(activity, activityPreview);
@@ -175,7 +183,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnBotMessagePreviewEdit("test-command", handler);
+            app.MessageExtensions.OnBotMessagePreviewEdit("test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -212,8 +220,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 }, new JsonSerializer() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore })
             });
             var actionResponseMock = new Mock<MessagingExtensionActionResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             BotMessagePreviewEditHandler<TestTurnState> handler = (turnContext, turnState, activityPreview, cancellationToken) =>
             {
                 Assert.Equivalent(activity, activityPreview);
@@ -221,7 +231,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnBotMessagePreviewEdit("test-command", handler);
+            app.MessageExtensions.OnBotMessagePreviewEdit("test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -238,8 +248,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "composeExtension/fetchTask"
             });
             var actionResponseMock = new Mock<MessagingExtensionActionResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -250,7 +262,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnBotMessagePreviewEdit(routeSelector, handler);
+            app.MessageExtensions.OnBotMessagePreviewEdit(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -288,8 +300,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Status = 200,
                 Body = new MessagingExtensionActionResponse()
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             BotMessagePreviewSendHandler<TestTurnState> handler = (turnContext, turnState, activityPreview, cancellationToken) =>
             {
                 Assert.Equivalent(activity, activityPreview);
@@ -297,7 +311,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnBotMessagePreviewSend("test-command", handler);
+            app.MessageExtensions.OnBotMessagePreviewSend("test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -333,8 +347,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                     botActivityPreview = new List<Activity> { activity }
                 }, new JsonSerializer() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore })
             });
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             BotMessagePreviewSendHandler<TestTurnState> handler = (turnContext, turnState, activityPreview, cancellationToken) =>
             {
                 Assert.Equivalent(activity, activityPreview);
@@ -342,7 +358,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnBotMessagePreviewSend("test-command", handler);
+            app.MessageExtensions.OnBotMessagePreviewSend("test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -358,8 +374,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Type = ActivityTypes.Invoke,
                 Name = "composeExtension/fetchTask"
             });
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -370,7 +388,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnBotMessagePreviewSend(routeSelector, handler);
+            app.MessageExtensions.OnBotMessagePreviewSend(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -402,15 +420,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Status = 200,
                 Body = taskModuleResponseMock.Object
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             FetchTaskHandler<TestTurnState> handler = (turnContext, turnState, cancellationToken) =>
             {
                 return Task.FromResult(taskModuleResponseMock.Object);
             };
 
             // Act
-            messageExtensions.OnFetchTask("test-command", handler);
+            app.MessageExtensions.OnFetchTask("test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -440,15 +460,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 })
             });
             var taskModuleResponseMock = new Mock<TaskModuleResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             FetchTaskHandler<TestTurnState> handler = (turnContext, turnState, cancellationToken) =>
             {
                 return Task.FromResult(taskModuleResponseMock.Object);
             };
 
             // Act
-            messageExtensions.OnFetchTask("not-test-command", handler);
+            app.MessageExtensions.OnFetchTask("not-test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -465,8 +487,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "composeExtension/submitAction"
             });
             var taskModuleResponseMock = new Mock<TaskModuleResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -477,7 +501,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnFetchTask(routeSelector, handler);
+            app.MessageExtensions.OnFetchTask(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -521,8 +545,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                     ComposeExtension = messagingExtensionResultMock.Object
                 }
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             QueryHandler<TestTurnState> handler = (turnContext, turnState, query, cancellationToken) =>
             {
                 Assert.Equal(1, query.Parameters.Count);
@@ -533,7 +559,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnQuery("test-command", handler);
+            app.MessageExtensions.OnQuery("test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -572,8 +598,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 })
             });
             var messagingExtensionResultMock = new Mock<MessagingExtensionResult>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             QueryHandler<TestTurnState> handler = (turnContext, turnState, query, cancellationToken) =>
             {
                 Assert.Equal(1, query.Parameters.Count);
@@ -584,7 +612,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnQuery("not-test-command", handler);
+            app.MessageExtensions.OnQuery("not-test-command", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -601,8 +629,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "composeExtension/selectItem"
             });
             var messagingExtensionResultMock = new Mock<MessagingExtensionResult>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -613,7 +643,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnQuery(routeSelector, handler);
+            app.MessageExtensions.OnQuery(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -645,15 +675,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                     ComposeExtension = messagingExtensionResultMock.Object
                 }
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             SelectItemHandler<TestTurnState> handler = (turnContext, turnState, item, cancellationToken) =>
             {
                 return Task.FromResult(messagingExtensionResultMock.Object);
             };
 
             // Act
-            messageExtensions.OnSelectItem(handler);
+            app.MessageExtensions.OnSelectItem(handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -688,15 +720,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                     ComposeExtension = messagingExtensionResultMock.Object
                 }
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             SelectItemHandler<TestTurnState> handler = (turnContext, turnState, item, cancellationToken) =>
             {
                 return Task.FromResult(messagingExtensionResultMock.Object);
             };
 
             // Act
-            messageExtensions.OnSelectItem(handler);
+            app.MessageExtensions.OnSelectItem(handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -731,8 +765,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                     ComposeExtension = messagingExtensionResultMock.Object
                 }
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             QueryLinkHandler<TestTurnState> handler = (turnContext, turnState, url, cancellationToken) =>
             {
                 Assert.Equal("test-url", url);
@@ -740,7 +776,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnQueryLink(handler);
+            app.MessageExtensions.OnQueryLink(handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -766,15 +802,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "composeExtension/query"
             });
             var messagingExtensionResultMock = new Mock<MessagingExtensionResult>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             QueryLinkHandler<TestTurnState> handler = (turnContext, turnState, url, cancellationToken) =>
             {
                 return Task.FromResult(messagingExtensionResultMock.Object);
             };
 
             // Act
-            messageExtensions.OnQueryLink(handler);
+            app.MessageExtensions.OnQueryLink(handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -809,8 +847,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                     ComposeExtension = messagingExtensionResultMock.Object
                 }
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             QueryLinkHandler<TestTurnState> handler = (turnContext, turnState, url, cancellationToken) =>
             {
                 Assert.Equal("test-url", url);
@@ -818,7 +858,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            messageExtensions.OnAnonymousQueryLink(handler);
+            app.MessageExtensions.OnAnonymousQueryLink(handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -844,15 +884,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "composeExtension/query"
             });
             var messagingExtensionResultMock = new Mock<MessagingExtensionResult>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var messageExtensions = new MessageExtensions<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             QueryLinkHandler<TestTurnState> handler = (turnContext, turnState, url, cancellationToken) =>
             {
                 return Task.FromResult(messagingExtensionResultMock.Object);
             };
 
             // Act
-            messageExtensions.OnAnonymousQueryLink(handler);
+            app.MessageExtensions.OnAnonymousQueryLink(handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TaskModulesTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TaskModulesTests.cs
@@ -42,15 +42,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Status = 200,
                 Body = taskModuleResponseMock.Object
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var taskModules = new TaskModules<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             FetchHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
                 return Task.FromResult(taskModuleResponseMock.Object);
             };
 
             // Act
-            taskModules.OnFetch("test-verb", handler);
+            app.TaskModules.OnFetch("test-verb", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -87,15 +89,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 })
             });
             var taskModuleResponseMock = new Mock<TaskModuleResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var taskModules = new TaskModules<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             FetchHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
                 return Task.FromResult(taskModuleResponseMock.Object);
             };
 
             // Act
-            taskModules.OnFetch("test-verb", handler);
+            app.TaskModules.OnFetch("test-verb", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -112,8 +116,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "task/fetch"
             });
             var taskModuleResponseMock = new Mock<TaskModuleResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var taskModules = new TaskModules<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -124,7 +130,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            taskModules.OnFetch(routeSelector, handler);
+            app.TaskModules.OnFetch(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert
@@ -163,15 +169,17 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Status = 200,
                 Body = taskModuleResponseMock.Object
             };
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var taskModules = new TaskModules<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             SubmitHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
                 return Task.FromResult(taskModuleResponseMock.Object);
             };
 
             // Act
-            taskModules.OnSubmit("test-verb", handler);
+            app.TaskModules.OnSubmit("test-verb", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -208,8 +216,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 })
             });
             var taskModuleResponseMock = new Mock<TaskModuleResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var taskModules = new TaskModules<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
 
             SubmitHandler<TestTurnState> handler = (turnContext, turnState, data, cancellationToken) =>
             {
@@ -217,7 +227,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            taskModules.OnSubmit("test-verb", handler);
+            app.TaskModules.OnSubmit("test-verb", handler);
             await app.OnTurnAsync(turnContext);
 
             // Assert
@@ -234,8 +244,10 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Name = "task/submit"
             });
             var taskModuleResponseMock = new Mock<TaskModuleResponse>();
-            var app = new Application<TestTurnState, TestTurnStateManager>(new());
-            var taskModules = new TaskModules<TestTurnState, TestTurnStateManager>(app);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                StartTypingTimer = false
+            });
             RouteSelector routeSelector = (turnContext, cancellationToken) =>
             {
                 return Task.FromResult(true);
@@ -246,7 +258,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             };
 
             // Act
-            taskModules.OnSubmit(routeSelector, handler);
+            app.TaskModules.OnSubmit(routeSelector, handler);
             var exception = await Assert.ThrowsAsync<TeamsAIException>(async () => await app.OnTurnAsync(turnContext));
 
             // Assert

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.TeamsAI.AI;
@@ -385,6 +386,69 @@ namespace Microsoft.TeamsAI
                     OnMessage(routeSelector, handler);
                 }
             }
+            return this;
+        }
+
+        /// <summary>
+        /// Handles message edit events.
+        /// </summary>
+        /// <param name="handler">Function to call when the event is triggered.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnMessageEdit(RouteHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (turnContext, cancellationToken) =>
+            {
+                TeamsChannelData teamsChannelData;
+                return Task.FromResult(
+                    string.Equals(turnContext.Activity.Type, ActivityTypes.MessageUpdate, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(turnContext.Activity.ChannelId, Channels.Msteams)
+                    && (teamsChannelData = turnContext.Activity.GetChannelData<TeamsChannelData>()) != null
+                    && string.Equals(teamsChannelData.EventType, "editMessage"));
+            };
+            AddRoute(routeSelector, handler, isInvokeRoute: false);
+            return this;
+        }
+
+        /// <summary>
+        /// Handles message undo soft delete events.
+        /// </summary>
+        /// <param name="handler">Function to call when the event is triggered.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnMessageUndelete(RouteHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (turnContext, cancellationToken) =>
+            {
+                TeamsChannelData teamsChannelData;
+                return Task.FromResult(
+                    string.Equals(turnContext.Activity.Type, ActivityTypes.MessageUpdate, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(turnContext.Activity.ChannelId, Channels.Msteams)
+                    && (teamsChannelData = turnContext.Activity.GetChannelData<TeamsChannelData>()) != null
+                    && string.Equals(teamsChannelData.EventType, "undeleteMessage"));
+            };
+            AddRoute(routeSelector, handler, isInvokeRoute: false);
+            return this;
+        }
+
+        /// <summary>
+        /// Handles message soft delete events.
+        /// </summary>
+        /// <param name="handler">Function to call when the event is triggered.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnMessageDelete(RouteHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (turnContext, cancellationToken) =>
+            {
+                TeamsChannelData teamsChannelData;
+                return Task.FromResult(
+                    string.Equals(turnContext.Activity.Type, ActivityTypes.MessageDelete, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(turnContext.Activity.ChannelId, Channels.Msteams)
+                    && (teamsChannelData = turnContext.Activity.GetChannelData<TeamsChannelData>()) != null
+                    && string.Equals(teamsChannelData.EventType, "softDeleteMessage"));
+            };
+            AddRoute(routeSelector, handler, isInvokeRoute: false);
             return this;
         }
 


### PR DESCRIPTION
## Linked issues

closes: #761 

## Details

#### Change details

- messageUpdate - editMessage
- messageUpdate - undeleteMessage
- messageDelete - softDeleteMessage

Reference: https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs#L903

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
