### PR TITLE
[C#] feat: Add handling to missing ConversationUpdate events

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.TeamsAI.Tests.TestUtils;
@@ -527,6 +528,391 @@ namespace Microsoft.TeamsAI.Tests.Application
         }
 
         [Fact]
+        public async Task Test_OnConversationUpdate_ChannelCreated()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "channelCreated",
+                    Channel = new ChannelInfo(),
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.ChannelCreated,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_ChannelRenamed()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "channelRenamed",
+                    Channel = new ChannelInfo(),
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.ChannelRenamed,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_ChannelDeleted()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "channelDeleted",
+                    Channel = new ChannelInfo(),
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.ChannelDeleted,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_ChannelRestored()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "channelRestored",
+                    Channel = new ChannelInfo(),
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.ChannelRestored,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_TeamRenamed()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamRenamed",
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.TeamRenamed,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_TeamDeleted()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamDeleted",
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.TeamDeleted,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_TeamHardDeleted()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamHardDeleted",
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.TeamHardDeleted,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_TeamArchived()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamArchived",
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.TeamArchived,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_TeamUnarchived()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamUnarchived",
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.TeamUnarchived,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConversationUpdate_TeamRestored()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamRestored",
+                    Team = new TeamInfo(),
+                },
+                Name = "1",
+                ChannelId = Channels.Msteams,
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConversationUpdate(ConversationUpdateEvents.TeamRestored,
+                (context, _, _) =>
+                {
+                    names.Add(context.Activity.Name);
+                    return Task.CompletedTask;
+                });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(1, names.Count);
+            Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
         public async Task Test_OnConversationUpdate_SingleEvent()
         {
             // Arrange
@@ -535,9 +921,11 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Type = ActivityTypes.ConversationUpdate,
                 ChannelData = new TeamsChannelData
                 {
-                    EventType = "teamRenamed"
+                    EventType = "teamRenamed",
+                    Team = new TeamInfo(),
                 },
-                Name = "1"
+                Name = "1",
+                ChannelId = Channels.Msteams,
             };
             var activity2 = new Activity
             {
@@ -551,7 +939,6 @@ namespace Microsoft.TeamsAI.Tests.Application
                     EventType = "teamRenamed"
                 }
             };
-
             var adapter = new NotImplementedAdapter();
             var turnContext1 = new TurnContext(adapter, activity1);
             var turnContext2 = new TurnContext(adapter, activity2);
@@ -593,9 +980,12 @@ namespace Microsoft.TeamsAI.Tests.Application
                 Type = ActivityTypes.ConversationUpdate,
                 ChannelData = new TeamsChannelData
                 {
-                    EventType = "channelDeleted"
+                    EventType = "channelDeleted",
+                    Channel = new ChannelInfo(),
+                    Team = new TeamInfo(),
                 },
-                Name = "2"
+                Name = "2",
+                ChannelId = Channels.Msteams,
             };
             var activity3 = new Activity
             {
@@ -605,7 +995,6 @@ namespace Microsoft.TeamsAI.Tests.Application
                     EventType = "teamRenamed"
                 }
             };
-
             var adapter = new NotImplementedAdapter();
             var turnContext1 = new TurnContext(adapter, activity1);
             var turnContext2 = new TurnContext(adapter, activity2);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.TeamsAI.AI;
@@ -233,6 +234,21 @@ namespace Microsoft.TeamsAI
             RouteSelector routeSelector;
             switch (conversationUpdateEvent)
             {
+                case ConversationUpdateEvents.ChannelCreated:
+                case ConversationUpdateEvents.ChannelDeleted:
+                case ConversationUpdateEvents.ChannelRenamed:
+                case ConversationUpdateEvents.ChannelRestored:
+                {
+                    routeSelector = (context, _) => Task.FromResult
+                    (
+                        string.Equals(context.Activity?.ChannelId, Channels.Msteams)
+                        && string.Equals(context.Activity?.Type, ActivityTypes.ConversationUpdate, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(context.Activity?.GetChannelData<TeamsChannelData>()?.EventType, conversationUpdateEvent)
+                        && context.Activity?.GetChannelData<TeamsChannelData>()?.Channel != null
+                        && context.Activity?.GetChannelData<TeamsChannelData>()?.Team != null
+                    );
+                    break;
+                }
                 case ConversationUpdateEvents.MembersAdded:
                 {
                     routeSelector = (context, _) => Task.FromResult
@@ -250,6 +266,22 @@ namespace Microsoft.TeamsAI
                         string.Equals(context.Activity?.Type, ActivityTypes.ConversationUpdate, StringComparison.OrdinalIgnoreCase)
                         && context.Activity?.MembersRemoved != null
                         && context.Activity.MembersRemoved.Count > 0
+                    );
+                    break;
+                }
+                case ConversationUpdateEvents.TeamRenamed:
+                case ConversationUpdateEvents.TeamDeleted:
+                case ConversationUpdateEvents.TeamHardDeleted:
+                case ConversationUpdateEvents.TeamArchived:
+                case ConversationUpdateEvents.TeamUnarchived:
+                case ConversationUpdateEvents.TeamRestored:
+                {
+                    routeSelector = (context, _) => Task.FromResult
+                    (
+                        string.Equals(context.Activity?.ChannelId, Channels.Msteams)
+                        && string.Equals(context.Activity?.Type, ActivityTypes.ConversationUpdate, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(context.Activity?.GetChannelData<TeamsChannelData>()?.EventType, conversationUpdateEvent)
+                        && context.Activity?.GetChannelData<TeamsChannelData>()?.Team != null
                     );
                     break;
                 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ConversationUpdateEvents.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ConversationUpdateEvents.cs
@@ -59,5 +59,20 @@
         /// TeamRestored event
         /// </summary>
         public const string TeamRestored = "teamRestored";
+
+        /// <summary>
+        /// TeamHardDeleted event
+        /// </summary>
+        public const string TeamHardDeleted = "teamHardDeleted";
+
+        /// <summary>
+        /// TopicName event 
+        /// </summary>
+        public const string TopicName = "topicName";
+
+        /// <summary>
+        /// HistoryDisclosed event
+        /// </summary>
+        public const string HistoryDisclosed = "historyDisclosed";
     }
 }


### PR DESCRIPTION
## Linked issues

closes: #610 
associated: #708 

## Details

Provide handling for all ConversationUpdate events (previously, only `membersAdded` and `membersRemoved`).

#### Change details
- Added missing ConversationUpdate events - `teamHardDeleted`, `topicName` and `historyDisclosed`
- Added routing for missing channel and team activity events 
- Added associated tests for these routes

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes