### PR TITLE
[C#] feat: handles config events 

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -1536,20 +1536,30 @@ namespace Microsoft.TeamsAI.Tests.Application
             var activity1 = new Activity
             {
                 Type = ActivityTypes.Invoke,
-                Name = "config/fetch"
+                Name = "config/fetch",
+                ChannelId = Channels.Msteams
             };
             var activity2 = new Activity
             {
                 Type = ActivityTypes.Invoke,
-                Name = "config/submit"
+                Name = "config/fetch",
+                ChannelId = Channels.Outlook
             };
             var activity3 = new Activity
             {
-                Type = ActivityTypes.Message
+                Type = ActivityTypes.Invoke,
+                Name = "config/submit",
+                ChannelId = Channels.Msteams
+            };
+            var activity4 = new Activity
+            {
+                Type = ActivityTypes.Message,
+                ChannelId = Channels.Msteams
             };
             var turnContext1 = new TurnContext(adapter, activity1);
             var turnContext2 = new TurnContext(adapter, activity2);
             var turnContext3 = new TurnContext(adapter, activity3);
+            var turnContext4 = new TurnContext(adapter, activity4);
             var configResponseMock = new Mock<ConfigResponseBase>();
             var expectedInvokeResponse = new InvokeResponse()
             {
@@ -1572,6 +1582,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             await app.OnTurnAsync(turnContext1);
             await app.OnTurnAsync(turnContext2);
             await app.OnTurnAsync(turnContext3);
+            await app.OnTurnAsync(turnContext4);
 
             // Assert
             Assert.Single(names);
@@ -1600,20 +1611,31 @@ namespace Microsoft.TeamsAI.Tests.Application
             {
                 Type = ActivityTypes.Invoke,
                 Name = "config/submit",
+                ChannelId = Channels.Msteams,
                 Value = JObject.FromObject(data)
             };
             var activity2 = new Activity
             {
                 Type = ActivityTypes.Invoke,
-                Name = "config/fetch"
+                Name = "config/submit",
+                ChannelId = Channels.Outlook,
+                Value = JObject.FromObject(data)
             };
             var activity3 = new Activity
             {
-                Type = ActivityTypes.Message
+                Type = ActivityTypes.Invoke,
+                Name = "config/fetch",
+                ChannelId = Channels.Msteams
+            };
+            var activity4 = new Activity
+            {
+                Type = ActivityTypes.Message,
+                ChannelId = Channels.Msteams
             };
             var turnContext1 = new TurnContext(adapter, activity1);
             var turnContext2 = new TurnContext(adapter, activity2);
             var turnContext3 = new TurnContext(adapter, activity3);
+            var turnContext4 = new TurnContext(adapter, activity4);
             var configResponseMock = new Mock<ConfigResponseBase>();
             var expectedInvokeResponse = new InvokeResponse()
             {
@@ -1638,6 +1660,7 @@ namespace Microsoft.TeamsAI.Tests.Application
             await app.OnTurnAsync(turnContext1);
             await app.OnTurnAsync(turnContext2);
             await app.OnTurnAsync(turnContext3);
+            await app.OnTurnAsync(turnContext4);
 
             // Assert
             Assert.Single(names);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -3,6 +3,8 @@ using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.TeamsAI.Tests.TestUtils;
+using Moq;
+using Newtonsoft.Json.Linq;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.TeamsAI.Tests.Application
@@ -1133,6 +1135,131 @@ namespace Microsoft.TeamsAI.Tests.Application
             // Assert
             Assert.Single(names);
             Assert.Equal("1", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnConfigFetch()
+        {
+            // Arrange
+            Activity[]? activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+            var adapter = new SimpleAdapter(CaptureSend);
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/fetch"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/submit"
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Message
+            };
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var configResponseMock = new Mock<ConfigResponseBase>();
+            var expectedInvokeResponse = new InvokeResponse()
+            {
+                Status = 200,
+                Body = configResponseMock.Object
+            };
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConfigFetch((turnContext, _, _, _) =>
+            {
+                names.Add(turnContext.Activity.Name);
+                return Task.FromResult(configResponseMock.Object);
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(names);
+            Assert.Equal("config/fetch", names[0]);
+            Assert.NotNull(activitiesToSend);
+            Assert.Equal(1, activitiesToSend.Length);
+            Assert.Equal("invokeResponse", activitiesToSend[0].Type);
+            Assert.Equivalent(expectedInvokeResponse, activitiesToSend[0].Value);
+        }
+
+        [Fact]
+        public async Task Test_OnConfigSubmit()
+        {
+            // Arrange
+            Activity[]? activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+            var adapter = new SimpleAdapter(CaptureSend);
+            object data = new
+            {
+                testKey = "testValue"
+            };
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/submit",
+                Value = JObject.FromObject(data)
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/fetch"
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Message
+            };
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var configResponseMock = new Mock<ConfigResponseBase>();
+            var expectedInvokeResponse = new InvokeResponse()
+            {
+                Status = 200,
+                Body = configResponseMock.Object
+            };
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnConfigSubmit((turnContext, _, configData, _) =>
+            {
+                Assert.NotNull(configData);
+                Assert.Equal(configData, configData as JObject);
+                names.Add(turnContext.Activity.Name);
+                return Task.FromResult(configResponseMock.Object);
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(names);
+            Assert.Equal("config/submit", names[0]);
+            Assert.NotNull(activitiesToSend);
+            Assert.Equal(1, activitiesToSend.Length);
+            Assert.Equal("invokeResponse", activitiesToSend[0].Type);
+            Assert.Equivalent(expectedInvokeResponse, activitiesToSend[0].Value);
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -29,8 +29,8 @@ namespace Microsoft.TeamsAI
         where TState : ITurnState<StateBase, StateBase, TempState>
         where TTurnStateManager : ITurnStateManager<TState>, new()
     {
-        private static readonly string CONFIG_FETCH_NAME = "config/fetch";
-        private static readonly string CONFIG_SUBMIT_NAME = "config/submit";
+        private static readonly string CONFIG_FETCH_INVOKE_NAME = "config/fetch";
+        private static readonly string CONFIG_SUBMIT_INVOKE_NAME = "config/submit";
 
         private readonly AI<TState>? _ai;
         private readonly int _typingTimerDelay = 1000;
@@ -531,7 +531,7 @@ namespace Microsoft.TeamsAI
         }
 
         /// <summary>
-        /// Handles config fetch events.
+        /// Handles config fetch events for Microsoft Teams.
         /// </summary>
         /// <param name="handler">Function to call when the event is triggered.</param>
         /// <returns>The application instance for chaining purposes.</returns>
@@ -540,7 +540,8 @@ namespace Microsoft.TeamsAI
             Verify.ParamNotNull(handler);
             RouteSelector routeSelector = (turnContext, cancellationToken) => Task.FromResult(
                 string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(turnContext.Activity.Name, CONFIG_FETCH_NAME));
+                && string.Equals(turnContext.Activity.Name, CONFIG_FETCH_INVOKE_NAME)
+                && string.Equals(turnContext.Activity.ChannelId, Channels.Msteams));
             RouteHandler<TState> routeHandler = async (ITurnContext turnContext, TState turnState, CancellationToken cancellationToken) =>
             {
                 ConfigResponseBase result = await handler(turnContext, turnState, turnContext.Activity.Value, cancellationToken);
@@ -557,7 +558,7 @@ namespace Microsoft.TeamsAI
         }
 
         /// <summary>
-        /// Handles config submit events.
+        /// Handles config submit events for Microsoft Teams.
         /// </summary>
         /// <param name="handler">Function to call when the event is triggered.</param>
         /// <returns>The application instance for chaining purposes.</returns>
@@ -566,7 +567,8 @@ namespace Microsoft.TeamsAI
             Verify.ParamNotNull(handler);
             RouteSelector routeSelector = (turnContext, cancellationToken) => Task.FromResult(
                 string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(turnContext.Activity.Name, CONFIG_SUBMIT_NAME));
+                && string.Equals(turnContext.Activity.Name, CONFIG_SUBMIT_INVOKE_NAME)
+                && string.Equals(turnContext.Activity.ChannelId, Channels.Msteams));
             RouteHandler<TState> routeHandler = async (ITurnContext turnContext, TState turnState, CancellationToken cancellationToken) =>
             {
                 ConfigResponseBase result = await handler(turnContext, turnState, turnContext.Activity.Value, cancellationToken);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -4,6 +4,7 @@ using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.TeamsAI.AI;
+using Microsoft.TeamsAI.Application;
 using Microsoft.TeamsAI.State;
 using Microsoft.TeamsAI.Utilities;
 using System.Collections.Concurrent;
@@ -28,6 +29,9 @@ namespace Microsoft.TeamsAI
         where TState : ITurnState<StateBase, StateBase, TempState>
         where TTurnStateManager : ITurnStateManager<TState>, new()
     {
+        private static readonly string CONFIG_FETCH_NAME = "config/fetch";
+        private static readonly string CONFIG_SUBMIT_NAME = "config/submit";
+
         private readonly AI<TState>? _ai;
         private readonly int _typingTimerDelay = 1000;
         private TypingTimer? _typingTimer;
@@ -492,6 +496,58 @@ namespace Microsoft.TeamsAI
                 && context.Activity.ReactionsRemoved.Count > 0
             );
             AddRoute(routeSelector, handler, isInvokeRoute: false);
+            return this;
+        }
+
+        /// <summary>
+        /// Handles config fetch events.
+        /// </summary>
+        /// <param name="handler">Function to call when the event is triggered.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnConfigFetch(ConfigHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (turnContext, cancellationToken) => Task.FromResult(
+                string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(turnContext.Activity.Name, CONFIG_FETCH_NAME));
+            RouteHandler<TState> routeHandler = async (ITurnContext turnContext, TState turnState, CancellationToken cancellationToken) =>
+            {
+                ConfigResponseBase result = await handler(turnContext, turnState, turnContext.Activity.Value, cancellationToken);
+
+                // Check to see if an invoke response has already been added
+                if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
+                {
+                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(result);
+                    await turnContext.SendActivityAsync(activity, cancellationToken);
+                }
+            };
+            AddRoute(routeSelector, routeHandler, isInvokeRoute: true);
+            return this;
+        }
+
+        /// <summary>
+        /// Handles config submit events.
+        /// </summary>
+        /// <param name="handler">Function to call when the event is triggered.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnConfigSubmit(ConfigHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (turnContext, cancellationToken) => Task.FromResult(
+                string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(turnContext.Activity.Name, CONFIG_SUBMIT_NAME));
+            RouteHandler<TState> routeHandler = async (ITurnContext turnContext, TState turnState, CancellationToken cancellationToken) =>
+            {
+                ConfigResponseBase result = await handler(turnContext, turnState, turnContext.Activity.Value, cancellationToken);
+
+                // Check to see if an invoke response has already been added
+                if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
+                {
+                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(result);
+                    await turnContext.SendActivityAsync(activity, cancellationToken);
+                }
+            };
+            AddRoute(routeSelector, routeHandler, isInvokeRoute: true);
             return this;
         }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ConfigHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ConfigHandler.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema.Teams;
+using Microsoft.TeamsAI.State;
+
+namespace Microsoft.TeamsAI.Application
+{
+    /// <summary>
+    /// Function for handling config events.
+    /// </summary>
+    /// <typeparam name="TState">Type of the turn state. This allows for strongly typed access to the turn state.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="configData">The config data.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns>An instance of ConfigResponseBase.</returns>
+    public delegate Task<ConfigResponseBase> ConfigHandler<TState>(ITurnContext turnContext, TState turnState, object configData, CancellationToken cancellationToken) where TState : ITurnState<StateBase, StateBase, TempState>;
+}


### PR DESCRIPTION
## Linked issues

closes: #605 

## Details

Provide a list of your changes here. If you are fixing a bug, please provide steps to reproduce the bug.

#### Change details

- config/fetch
- config/submit

Reference: https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs#L95.

Do not separate the response types (auth and task module) into two handlers like OnConfigFetchAuth and OnConfigFetchTask because it seems that there are no useful information in Activity.Value to distinguish them. Thus, just simply pass Activity.Value to handler then return invoke response based on handler result.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
