### PR TITLE
[C#] feat: add meeting handlers

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MeetingsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MeetingsTests.cs
@@ -1,0 +1,158 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.TeamsAI.Tests.TestUtils;
+
+namespace Microsoft.TeamsAI.Tests.Application
+{
+    public class MeetingsTests
+    {
+        [Fact]
+        public async void Test_OnStart()
+        {
+            // Arrange
+            var adapter = new NotImplementedAdapter();
+            var turnContexts = CreateMeetingTurnContext("application/vnd.microsoft.meetingStart", adapter);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var ids = new List<string>();
+            app.Meetings.OnStart((context, _, _, _) =>
+            {
+                ids.Add(context.Activity.Id);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            foreach (var turnContext in turnContexts)
+            {
+                await app.OnTurnAsync(turnContext);
+            }
+
+            // Assert
+            Assert.Single(ids);
+            Assert.Equal("test.id", ids[0]);
+        }
+
+        [Fact]
+        public async void Test_OnEnd()
+        {
+            // Arrange
+            var adapter = new NotImplementedAdapter();
+            var turnContexts = CreateMeetingTurnContext("application/vnd.microsoft.meetingEnd", adapter);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var ids = new List<string>();
+            app.Meetings.OnEnd((context, _, _, _) =>
+            {
+                ids.Add(context.Activity.Id);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            foreach (var turnContext in turnContexts)
+            {
+                await app.OnTurnAsync(turnContext);
+            }
+
+            // Assert
+            Assert.Single(ids);
+            Assert.Equal("test.id", ids[0]);
+        }
+
+        [Fact]
+        public async void Test_OnParticipantsJoin()
+        {
+            // Arrange
+            var adapter = new NotImplementedAdapter();
+            var turnContexts = CreateMeetingTurnContext("application/vnd.microsoft.meetingParticipantJoin", adapter);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var ids = new List<string>();
+            app.Meetings.OnParticipantsJoin((context, _, _, _) =>
+            {
+                ids.Add(context.Activity.Id);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            foreach (var turnContext in turnContexts)
+            {
+                await app.OnTurnAsync(turnContext);
+            }
+
+            // Assert
+            Assert.Single(ids);
+            Assert.Equal("test.id", ids[0]);
+        }
+
+        [Fact]
+        public async void Test_OnParticipantsLeave()
+        {
+            // Arrange
+            var adapter = new NotImplementedAdapter();
+            var turnContexts = CreateMeetingTurnContext("application/vnd.microsoft.meetingParticipantLeave", adapter);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var ids = new List<string>();
+            app.Meetings.OnParticipantsLeave((context, _, _, _) =>
+            {
+                ids.Add(context.Activity.Id);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            foreach (var turnContext in turnContexts)
+            {
+                await app.OnTurnAsync(turnContext);
+            }
+
+            // Assert
+            Assert.Single(ids);
+            Assert.Equal("test.id", ids[0]);
+        }
+
+        private static TurnContext[] CreateMeetingTurnContext(string activityName, BotAdapter adapter)
+        {
+            return new TurnContext[]
+            {
+                new(adapter, new Activity
+                {
+                    Type = ActivityTypes.Event,
+                    ChannelId = Channels.Msteams,
+                    Name = activityName,
+                    Id = "test.id"
+                }),
+                new(adapter, new Activity
+                {
+                    Type = ActivityTypes.Event,
+                    ChannelId = Channels.Msteams,
+                    Name = "fake.name"
+                }),
+                new(adapter, new Activity
+                {
+                    Type = ActivityTypes.Invoke,
+                    ChannelId = Channels.Msteams,
+                    Name = activityName
+                }),
+                new(adapter, new Activity
+                {
+                    Type = ActivityTypes.Event,
+                    ChannelId = Channels.Webchat,
+                    Name = activityName
+                }),
+            };
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ActivityUtilities.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ActivityUtilities.cs
@@ -5,11 +5,11 @@ using System.Net;
 
 namespace Microsoft.TeamsAI
 {
-    internal static class InvokeActivityUtilities
+    internal static class ActivityUtilities
     {
-        public static T? GetInvokeValue<T>(IInvokeActivity activity)
+        public static T? GetTypedValue<T>(Activity activity)
         {
-            if (activity.Value == null)
+            if (activity?.Value == null)
             {
                 return default;
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCards.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCards.cs
@@ -78,7 +78,7 @@ namespace Microsoft.TeamsAI
                 AdaptiveCardInvokeValue? invokeValue;
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, ACTION_INVOKE_NAME)
-                    || (invokeValue = InvokeActivityUtilities.GetInvokeValue<AdaptiveCardInvokeValue>(turnContext.Activity)) == null
+                    || (invokeValue = ActivityUtilities.GetTypedValue<AdaptiveCardInvokeValue>(turnContext.Activity)) == null
                     || invokeValue.Action == null
                     || !string.Equals(invokeValue.Action.Type, ACTION_EXECUTE_TYPE))
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.TeamsAI
                 }
 
                 AdaptiveCardInvokeResponse adaptiveCardInvokeResponse = await handler(turnContext, turnState, invokeValue.Action.Data, cancellationToken);
-                Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(adaptiveCardInvokeResponse);
+                Activity activity = ActivityUtilities.CreateInvokeResponseActivity(adaptiveCardInvokeResponse);
                 await turnContext.SendActivityAsync(activity, cancellationToken);
             };
             _app.AddRoute(routeSelector, routeHandler, isInvokeRoute: true);
@@ -327,7 +327,7 @@ namespace Microsoft.TeamsAI
                 AdaptiveCardSearchInvokeValue? searchInvokeValue;
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, SEARCH_INVOKE_NAME)
-                    || (searchInvokeValue = InvokeActivityUtilities.GetInvokeValue<AdaptiveCardSearchInvokeValue>(turnContext.Activity)) == null)
+                    || (searchInvokeValue = ActivityUtilities.GetTypedValue<AdaptiveCardSearchInvokeValue>(turnContext.Activity)) == null)
                 {
                     throw new TeamsAIException($"Unexpected AdaptiveCards.OnSearch() triggered for activity type: {turnContext.Activity.Type}");
                 }
@@ -348,7 +348,7 @@ namespace Microsoft.TeamsAI
                             Results = results
                         }
                     };
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(searchInvokeResponse);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(searchInvokeResponse);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -398,7 +398,7 @@ namespace Microsoft.TeamsAI
                 return Task.FromResult(
                     string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(turnContext.Activity.Name, ACTION_INVOKE_NAME)
-                    && (invokeValue = InvokeActivityUtilities.GetInvokeValue<AdaptiveCardInvokeValue>(turnContext.Activity)) != null
+                    && (invokeValue = ActivityUtilities.GetTypedValue<AdaptiveCardInvokeValue>(turnContext.Activity)) != null
                     && invokeValue.Action != null
                     && string.Equals(invokeValue.Action.Type, ACTION_EXECUTE_TYPE)
                     && isMatch(invokeValue.Action.Verb));
@@ -431,7 +431,7 @@ namespace Microsoft.TeamsAI
                 return Task.FromResult(
                     string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(turnContext.Activity.Name, SEARCH_INVOKE_NAME)
-                    && (searchInvokeValue = InvokeActivityUtilities.GetInvokeValue<AdaptiveCardSearchInvokeValue>(turnContext.Activity)) != null
+                    && (searchInvokeValue = ActivityUtilities.GetTypedValue<AdaptiveCardSearchInvokeValue>(turnContext.Activity)) != null
                     && isMatch(searchInvokeValue.Dataset!));
             };
             return routeSelector;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -56,6 +56,7 @@ namespace Microsoft.TeamsAI
             }
 
             AdaptiveCards = new AdaptiveCards<TState, TTurnStateManager>(this);
+            Meetings = new Meetings<TState, TTurnStateManager>(this);
             MessageExtensions = new MessageExtensions<TState, TTurnStateManager>(this);
             TaskModules = new TaskModules<TState, TTurnStateManager>(this);
 
@@ -75,6 +76,11 @@ namespace Microsoft.TeamsAI
         /// Fluent interface for accessing Adaptive Card specific features.
         /// </summary>
         public AdaptiveCards<TState, TTurnStateManager> AdaptiveCards { get; }
+
+        /// <summary>
+        /// Fluent interface for accessing Meetings' specific features.
+        /// </summary>
+        public Meetings<TState, TTurnStateManager> Meetings { get; }
 
         /// <summary>
         /// Fluent interface for accessing Message Extensions' specific features.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/Meetings.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/Meetings.cs
@@ -7,7 +7,7 @@ using Microsoft.TeamsAI.Utilities;
 namespace Microsoft.TeamsAI
 {
     /// <summary>
-    /// AdaptiveCards class to enable fluent style registration of handlers related to Microsoft Teams Meetings.
+    /// Meetings class to enable fluent style registration of handlers related to Microsoft Teams Meetings.
     /// </summary>
     /// <typeparam name="TState">The type of the turn state object used by the application.</typeparam>
     /// <typeparam name="TTurnStateManager">The type of the turn state manager object used by the application.</typeparam>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/Meetings.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/Meetings.cs
@@ -1,0 +1,121 @@
+﻿using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Schema.Teams;
+using Microsoft.TeamsAI.State;
+using Microsoft.TeamsAI.Utilities;
+
+namespace Microsoft.TeamsAI
+{
+    /// <summary>
+    /// AdaptiveCards class to enable fluent style registration of handlers related to Microsoft Teams Meetings.
+    /// </summary>
+    /// <typeparam name="TState">The type of the turn state object used by the application.</typeparam>
+    /// <typeparam name="TTurnStateManager">The type of the turn state manager object used by the application.</typeparam>
+    public class Meetings<TState, TTurnStateManager>
+        where TState : ITurnState<StateBase, StateBase, TempState>
+        where TTurnStateManager : ITurnStateManager<TState>, new()
+    {
+        private readonly Application<TState, TTurnStateManager> _app;
+
+        /// <summary>
+        /// Creates a new instance of the Meetings class.
+        /// </summary>
+        /// <param name="app"></param> The top level application class to register handlers with.
+        public Meetings(Application<TState, TTurnStateManager> app)
+        {
+            this._app = app;
+        }
+
+        /// <summary>
+        /// Handles Microsoft Teams meeting start events.
+        /// </summary>
+        /// <param name="handler">Function to call when a Microsoft Teams meeting start event activity is received from the connector.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnStart(MeetingStartHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (context, _) => Task.FromResult
+            (
+                string.Equals(context.Activity?.Type, ActivityTypes.Event, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(context.Activity?.ChannelId, Channels.Msteams)
+                && string.Equals(context.Activity?.Name, "application/vnd.microsoft.meetingStart")
+            );
+            RouteHandler<TState> routeHandler = async (turnContext, turnState, cancellationToken) =>
+            {
+                MeetingStartEventDetails meeting = ActivityUtilities.GetTypedValue<MeetingStartEventDetails>(turnContext.Activity) ?? new();
+                await handler(turnContext, turnState, meeting, cancellationToken);
+            };
+            _app.AddRoute(routeSelector, routeHandler, isInvokeRoute: false);
+            return _app;
+        }
+
+        /// <summary>
+        /// Handles Microsoft Teams meeting end events.
+        /// </summary>
+        /// <param name="handler">Function to call when a Microsoft Teams meeting end event activity is received from the connector.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnEnd(MeetingEndHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (context, _) => Task.FromResult
+            (
+                string.Equals(context.Activity?.Type, ActivityTypes.Event, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(context.Activity?.ChannelId, Channels.Msteams)
+                && string.Equals(context.Activity?.Name, "application/vnd.microsoft.meetingEnd")
+            );
+            RouteHandler<TState> routeHandler = async (turnContext, turnState, cancellationToken) =>
+            {
+                MeetingEndEventDetails meeting = ActivityUtilities.GetTypedValue<MeetingEndEventDetails>(turnContext.Activity) ?? new();
+                await handler(turnContext, turnState, meeting, cancellationToken);
+            };
+            _app.AddRoute(routeSelector, routeHandler, isInvokeRoute: false);
+            return _app;
+        }
+
+        /// <summary>
+        /// Handles Microsoft Teams meeting participants join events.
+        /// </summary>
+        /// <param name="handler">Function to call when a Microsoft Teams meeting participants join event activity is received from the connector.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnParticipantsJoin(MeetingParticipantsEventHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (context, _) => Task.FromResult
+            (
+                string.Equals(context.Activity?.Type, ActivityTypes.Event, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(context.Activity?.ChannelId, Channels.Msteams)
+                && string.Equals(context.Activity?.Name, "application/vnd.microsoft.meetingParticipantJoin")
+            );
+            RouteHandler<TState> routeHandler = async (turnContext, turnState, cancellationToken) =>
+            {
+                MeetingParticipantsEventDetails meeting = ActivityUtilities.GetTypedValue<MeetingParticipantsEventDetails>(turnContext.Activity) ?? new();
+                await handler(turnContext, turnState, meeting, cancellationToken);
+            };
+            _app.AddRoute(routeSelector, routeHandler, isInvokeRoute: false);
+            return _app;
+        }
+
+        /// <summary>
+        /// Handles Microsoft Teams meeting participants leave events.
+        /// </summary>
+        /// <param name="handler">Function to call when a Microsoft Teams meeting participants leave event activity is received from the connector.</param>
+        /// <returns>The application instance for chaining purposes.</returns>
+        public Application<TState, TTurnStateManager> OnParticipantsLeave(MeetingParticipantsEventHandler<TState> handler)
+        {
+            Verify.ParamNotNull(handler);
+            RouteSelector routeSelector = (context, _) => Task.FromResult
+            (
+                string.Equals(context.Activity?.Type, ActivityTypes.Event, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(context.Activity?.ChannelId, Channels.Msteams)
+                && string.Equals(context.Activity?.Name, "application/vnd.microsoft.meetingParticipantLeave")
+            );
+            RouteHandler<TState> routeHandler = async (turnContext, turnState, cancellationToken) =>
+            {
+                MeetingParticipantsEventDetails meeting = ActivityUtilities.GetTypedValue<MeetingParticipantsEventDetails>(turnContext.Activity) ?? new();
+                await handler(turnContext, turnState, meeting, cancellationToken);
+            };
+            _app.AddRoute(routeSelector, routeHandler, isInvokeRoute: false);
+            return _app;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/MeetingsHandlers.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/MeetingsHandlers.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema.Teams;
+using Microsoft.TeamsAI.State;
+
+namespace Microsoft.TeamsAI
+{
+    /// <summary>
+    /// Function for handling Microsoft Teams meeting start events.
+    /// </summary>
+    /// <typeparam name="TState">Type of the turn state. This allows for strongly typed access to the turn state.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="meeting">The details of the meeting.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns>A task that represents the work queued to execute.</returns>
+    public delegate Task MeetingStartHandler<TState>(ITurnContext turnContext, TState turnState, MeetingStartEventDetails meeting, CancellationToken cancellationToken) where TState : ITurnState<StateBase, StateBase, TempState>;
+
+    /// <summary>
+    /// Function for handling Microsoft Teams meeting end events.
+    /// </summary>
+    /// <typeparam name="TState">Type of the turn state. This allows for strongly typed access to the turn state.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="meeting">The details of the meeting.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns>A task that represents the work queued to execute.</returns>
+    public delegate Task MeetingEndHandler<TState>(ITurnContext turnContext, TState turnState, MeetingEndEventDetails meeting, CancellationToken cancellationToken) where TState : ITurnState<StateBase, StateBase, TempState>;
+
+    /// <summary>
+    /// Function for handling Microsoft Teams meeting participants join or leave events.
+    /// </summary>
+    /// <typeparam name="TState">Type of the turn state. This allows for strongly typed access to the turn state.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="meeting">The details of the meeting.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns>A task that represents the work queued to execute.</returns>
+    public delegate Task MeetingParticipantsEventHandler<TState>(ITurnContext turnContext, TState turnState, MeetingParticipantsEventDetails meeting, CancellationToken cancellationToken) where TState : ITurnState<StateBase, StateBase, TempState>;
+
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/MessageExtensions/MessageExtensions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/MessageExtensions/MessageExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.TeamsAI
             {
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, SUBMIT_ACTION_INVOKE_NAME)
-                    || (messagingExtensionAction = InvokeActivityUtilities.GetInvokeValue<MessagingExtensionAction>(turnContext.Activity)) == null)
+                    || (messagingExtensionAction = ActivityUtilities.GetTypedValue<MessagingExtensionAction>(turnContext.Activity)) == null)
                 {
                     throw new TeamsAIException($"Unexpected MessageExtensions.OnSubmitAction() triggered for activity type: {turnContext.Activity.Type}");
                 }
@@ -90,7 +90,7 @@ namespace Microsoft.TeamsAI
                 // Check to see if an invoke response has already been added
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(result);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(result);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -176,7 +176,7 @@ namespace Microsoft.TeamsAI
                 MessagingExtensionAction? messagingExtensionAction;
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, SUBMIT_ACTION_INVOKE_NAME)
-                    || (messagingExtensionAction = InvokeActivityUtilities.GetInvokeValue<MessagingExtensionAction>(turnContext.Activity)) == null
+                    || (messagingExtensionAction = ActivityUtilities.GetTypedValue<MessagingExtensionAction>(turnContext.Activity)) == null
                     || !string.Equals(messagingExtensionAction.BotMessagePreviewAction, "edit"))
                 {
                     throw new TeamsAIException($"Unexpected MessageExtensions.OnBotMessagePreviewEdit() triggered for activity type: {turnContext.Activity.Type}");
@@ -187,7 +187,7 @@ namespace Microsoft.TeamsAI
                 // Check to see if an invoke response has already been added
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(result);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(result);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -276,7 +276,7 @@ namespace Microsoft.TeamsAI
                 MessagingExtensionAction? messagingExtensionAction;
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, SUBMIT_ACTION_INVOKE_NAME)
-                    || (messagingExtensionAction = InvokeActivityUtilities.GetInvokeValue<MessagingExtensionAction>(turnContext.Activity)) == null
+                    || (messagingExtensionAction = ActivityUtilities.GetTypedValue<MessagingExtensionAction>(turnContext.Activity)) == null
                     || !string.Equals(messagingExtensionAction.BotMessagePreviewAction, "send"))
                 {
                     throw new TeamsAIException($"Unexpected MessageExtensions.OnBotMessagePreviewSend() triggered for activity type: {turnContext.Activity.Type}");
@@ -289,7 +289,7 @@ namespace Microsoft.TeamsAI
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
                     MessagingExtensionActionResponse response = new();
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(response);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(response);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -383,7 +383,7 @@ namespace Microsoft.TeamsAI
                 // Check to see if an invoke response has already been added
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(result);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(result);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -468,7 +468,7 @@ namespace Microsoft.TeamsAI
                 MessagingExtensionQuery? messagingExtensionQuery;
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, QUERY_INVOKE_NAME)
-                    || (messagingExtensionQuery = InvokeActivityUtilities.GetInvokeValue<MessagingExtensionQuery>(turnContext.Activity)) == null)
+                    || (messagingExtensionQuery = ActivityUtilities.GetTypedValue<MessagingExtensionQuery>(turnContext.Activity)) == null)
                 {
                     throw new TeamsAIException($"Unexpected MessageExtensions.OnQuery() triggered for activity type: {turnContext.Activity.Type}");
                 }
@@ -488,7 +488,7 @@ namespace Microsoft.TeamsAI
                     {
                         ComposeExtension = result
                     };
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(response);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(response);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -561,7 +561,7 @@ namespace Microsoft.TeamsAI
                     {
                         ComposeExtension = result
                     };
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(response);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(response);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -584,7 +584,7 @@ namespace Microsoft.TeamsAI
             };
             RouteHandler<TState> routeHandler = async (ITurnContext turnContext, TState turnState, CancellationToken cancellationToken) =>
             {
-                AppBasedLinkQuery? appBasedLinkQuery = InvokeActivityUtilities.GetInvokeValue<AppBasedLinkQuery>(turnContext.Activity);
+                AppBasedLinkQuery? appBasedLinkQuery = ActivityUtilities.GetTypedValue<AppBasedLinkQuery>(turnContext.Activity);
                 MessagingExtensionResult result = await handler(turnContext, turnState, appBasedLinkQuery!.Url, cancellationToken);
 
                 // Check to see if an invoke response has already been added
@@ -594,7 +594,7 @@ namespace Microsoft.TeamsAI
                     {
                         ComposeExtension = result
                     };
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(response);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(response);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -622,7 +622,7 @@ namespace Microsoft.TeamsAI
             };
             RouteHandler<TState> routeHandler = async (ITurnContext turnContext, TState turnState, CancellationToken cancellationToken) =>
             {
-                AppBasedLinkQuery? appBasedLinkQuery = InvokeActivityUtilities.GetInvokeValue<AppBasedLinkQuery>(turnContext.Activity);
+                AppBasedLinkQuery? appBasedLinkQuery = ActivityUtilities.GetTypedValue<AppBasedLinkQuery>(turnContext.Activity);
                 MessagingExtensionResult result = await handler(turnContext, turnState, appBasedLinkQuery!.Url, cancellationToken);
 
                 // Check to see if an invoke response has already been added
@@ -632,7 +632,7 @@ namespace Microsoft.TeamsAI
                     {
                         ComposeExtension = result
                     };
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(response);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(response);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -667,7 +667,7 @@ namespace Microsoft.TeamsAI
                     {
                         ComposeExtension = result
                     };
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(response);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(response);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -698,7 +698,7 @@ namespace Microsoft.TeamsAI
                 // Check to see if an invoke response has already been added
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity();
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity();
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -731,7 +731,7 @@ namespace Microsoft.TeamsAI
                 // Check to see if an invoke response has already been added
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity();
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity();
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TaskModules/TaskModules.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TaskModules/TaskModules.cs
@@ -78,7 +78,7 @@ namespace Microsoft.TeamsAI
                 TaskModuleAction? taskModuleAction;
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, FETCH_INVOKE_NAME)
-                    || (taskModuleAction = InvokeActivityUtilities.GetInvokeValue<TaskModuleAction>(turnContext.Activity)) == null)
+                    || (taskModuleAction = ActivityUtilities.GetTypedValue<TaskModuleAction>(turnContext.Activity)) == null)
                 {
                     throw new TeamsAIException($"Unexpected TaskModules.OnFetch() triggered for activity type: {turnContext.Activity.Type}");
                 }
@@ -88,7 +88,7 @@ namespace Microsoft.TeamsAI
                 // Check to see if an invoke response has already been added
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(result);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(result);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };
@@ -179,7 +179,7 @@ namespace Microsoft.TeamsAI
                 TaskModuleAction? taskModuleAction;
                 if (!string.Equals(turnContext.Activity.Type, ActivityTypes.Invoke, StringComparison.OrdinalIgnoreCase)
                     || !string.Equals(turnContext.Activity.Name, SUBMIT_INVOKE_NAME)
-                    || (taskModuleAction = InvokeActivityUtilities.GetInvokeValue<TaskModuleAction>(turnContext.Activity)) == null)
+                    || (taskModuleAction = ActivityUtilities.GetTypedValue<TaskModuleAction>(turnContext.Activity)) == null)
                 {
                     throw new TeamsAIException($"Unexpected TaskModules.OnSubmit() triggered for activity type: {turnContext.Activity.Type}");
                 }
@@ -189,7 +189,7 @@ namespace Microsoft.TeamsAI
                 // Check to see if an invoke response has already been added
                 if (turnContext.TurnState.Get<object>(BotAdapter.InvokeResponseKey) == null)
                 {
-                    Activity activity = InvokeActivityUtilities.CreateInvokeResponseActivity(result);
+                    Activity activity = ActivityUtilities.CreateInvokeResponseActivity(result);
                     await turnContext.SendActivityAsync(activity, cancellationToken);
                 }
             };


### PR DESCRIPTION
## Linked issues

closes: #696

## Details

Add handlers for meeting events

#### Change details

Add handlers under `Application.Meetings` for following events:
- application/vnd.microsoft.meetingStart
- application/vnd.microsoft.meetingEnd
- application/vnd.microsoft.meetingParticipantJoin
- application/vnd.microsoft.meetingParticipantLeave

Refactor `InvokeActivityUtilities` to `ActivityUtilities` since the event activity has `Activity.Value` as well.

Unit tests.

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
