### PR TITLE
[JS] fix: #247 #635 Add fallthrough for empty result Task Module Fetch and tests

### DIFF
--- a/js/packages/teams-ai/src/Application.spec.ts
+++ b/js/packages/teams-ai/src/Application.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { TestAdapter, MemoryStorage, ActivityTypes } from 'botbuilder';
+import { ActivityTypes, Channels, MemoryStorage, TestAdapter } from 'botbuilder';
 import { Application, ApplicationBuilder, ConversationUpdateEvents } from './Application';
 import { TestPlanner } from './TestPlanner';
 import { TestPromptManager } from './TestPromptManager';
@@ -208,7 +208,7 @@ describe('Application', () => {
             });
 
             const activity = createTestConversationUpdate();
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
             activity.membersAdded = [
                 { id: '123', name: 'Member One' },
                 { id: '42', name: "Don't Panic" }
@@ -276,7 +276,7 @@ describe('Application', () => {
                 });
 
                 const activity = createTestConversationUpdate(channelData);
-                activity.channelId = 'msteams';
+                activity.channelId = Channels.Msteams;
                 await adapter.processActivity(activity, async (context) => {
                     await mockApp.run(context);
                     assert.equal(handlerCalled, true);
@@ -289,7 +289,7 @@ describe('Application', () => {
             const team = { id: 'mockTeamId' };
             const channel = { id: 'mockChannelId' };
             const activity = createTestConversationUpdate({ channel, eventType: 'channelCreated', team });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.conversationUpdate('channelCreated', async (context, _state) => {
                 handlerCalled = true;

--- a/js/packages/teams-ai/src/Application.ts
+++ b/js/packages/teams-ai/src/Application.ts
@@ -7,20 +7,21 @@
  */
 
 import {
-    TurnContext,
-    Storage,
+    Activity,
     ActivityTypes,
     BotAdapter,
+    Channels,
     ConversationReference,
-    Activity,
-    ResourceResponse
+    ResourceResponse,
+    Storage,
+    TurnContext
 } from 'botbuilder';
-import { TurnState, TurnStateManager } from './TurnState';
-import { DefaultTurnState, DefaultTurnStateManager } from './DefaultTurnStateManager';
 import { AdaptiveCards, AdaptiveCardsOptions } from './AdaptiveCards';
-import { MessageExtensions } from './MessageExtensions';
 import { AI, AIOptions } from './AI';
+import { DefaultTurnState, DefaultTurnStateManager } from './DefaultTurnStateManager';
+import { MessageExtensions } from './MessageExtensions';
 import { TaskModules, TaskModulesOptions } from './TaskModules';
+import { TurnState, TurnStateManager } from './TurnState';
 
 /**
  * @private
@@ -914,7 +915,7 @@ function createConversationUpdateSelector(event: ConversationUpdateEvents): Rout
              */
             return (context: TurnContext) => {
                 return Promise.resolve(
-                    context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.channelId === Channels.Msteams &&
                         context?.activity?.type == ActivityTypes.ConversationUpdate &&
                         context?.activity?.channelData?.eventType == event &&
                         context?.activity?.channelData?.channel &&
@@ -957,7 +958,7 @@ function createConversationUpdateSelector(event: ConversationUpdateEvents): Rout
              */
             return (context: TurnContext) => {
                 return Promise.resolve(
-                    context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.channelId === Channels.Msteams &&
                         context?.activity?.type == ActivityTypes.ConversationUpdate &&
                         context?.activity?.channelData?.eventType == event &&
                         context?.activity?.channelData?.team
@@ -977,6 +978,8 @@ function createConversationUpdateSelector(event: ConversationUpdateEvents): Rout
     }
 }
 
+// function createMessageUpdateActivitySelector()
+//
 /**
  * Creates a route selector function that matches a message based on a keyword.
  * @param {string | RegExp | RouteSelector} keyword The keyword to match against the message text. Can be a string, regular expression, or a custom selector function.
@@ -1043,7 +1046,6 @@ function createMessageReactionSelector(event: MessageReactionEvents): RouteSelec
             };
     }
 }
-// channelData: eventype of editMessage
 
 /**
  * @private

--- a/js/packages/teams-ai/src/MessageExtensions.spec.ts
+++ b/js/packages/teams-ai/src/MessageExtensions.spec.ts
@@ -3,6 +3,7 @@ import { Application, Query } from './Application';
 import { createTestInvoke } from './TestUtilities';
 import { MessageExtensions } from './MessageExtensions';
 import {
+    Channels,
     INVOKE_RESPONSE_KEY,
     MessagingExtensionResult,
     TaskModuleTaskInfo,
@@ -71,7 +72,7 @@ describe('MessageExtensions', () => {
             const activity = createTestInvoke(ANONYMOUS_QUERY_LINK_INVOKE_NAME, {
                 url: 'https://www.youtube.com/watch?v=971YIvosuUk&ab_channel=MicrosoftDeveloper'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
             // Set up the anonymousQueryLink handler
             mockApp.messageExtensions.anonymousQueryLink(async () => {
                 return {
@@ -129,7 +130,7 @@ describe('MessageExtensions', () => {
     describe(`${CONFIGURE_SETTINGS}`, () => {
         it('should return InvokeResponse with status code 200 with the configure setting invoke name', async () => {
             const activity = createTestInvoke(CONFIGURE_SETTINGS, { theme: 'dark' });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.configureSettings(async (context: TurnContext, _state, value) => {
                 assert.equal(value.theme, 'dark');
@@ -147,7 +148,7 @@ describe('MessageExtensions', () => {
     describe(`${FETCH_TASK_INVOKE_NAME}`, () => {
         it('should return InvokeResponse with status code 200 with the task invoke card', async () => {
             const activity = createTestInvoke(FETCH_TASK_INVOKE_NAME, { commandId: 'showTaskModule' });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.fetchTask('showTaskModule', async (context: TurnContext, _state) => {
                 return {
@@ -200,7 +201,7 @@ describe('MessageExtensions', () => {
 
         it('should return InvokeResponse with status code 200 with a string message', async () => {
             const activity = createTestInvoke(FETCH_TASK_INVOKE_NAME, { commandId: 'showMessage' });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.fetchTask('showMessage', async (context: TurnContext, _state) => {
                 return 'Fetch task string';
@@ -226,22 +227,22 @@ describe('MessageExtensions', () => {
             const activity = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'showTaskModule'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
             const regexp = new RegExp(/show$/, 'i');
             const activity2 = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'Show'
             });
-            activity2.channelId = 'msteams';
+            activity2.channelId = Channels.Msteams;
 
             const activity3 = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'show task module'
             });
-            activity3.channelId = 'msteams';
+            activity3.channelId = Channels.Msteams;
 
             const activity4 = createTestInvoke(FETCH_TASK_INVOKE_NAME, {
                 commandId: 'show task'
             });
-            activity4.channelId = 'msteams';
+            activity4.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.fetchTask(
                 [
@@ -323,7 +324,7 @@ describe('MessageExtensions', () => {
                     formField3: 'formField3_value'
                 }
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.submitAction('giveKudos', async (context: TurnContext, _state, value) => {
                 return {
@@ -387,7 +388,7 @@ describe('MessageExtensions', () => {
                 botActivityPreview: [1],
                 botMessagePreviewAction: 'send'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.botMessagePreviewSend(
                 'Create Preview',
@@ -410,7 +411,7 @@ describe('MessageExtensions', () => {
                 botActivityPreview: [1],
                 botMessagePreviewAction: 'edit'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.botMessagePreviewEdit(
                 'Create Preview',
@@ -435,14 +436,14 @@ describe('MessageExtensions', () => {
                 botActivityPreview: ['create preview'],
                 botMessagePreviewAction: 'send'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             const activity2 = createTestInvoke(SUBMIT_ACTION_INVOKE_NAME, {
                 commandId: 'preview',
                 botActivityPreview: ['preview'],
                 botMessagePreviewAction: 'send'
             });
-            activity2.channelId = 'msteams';
+            activity2.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.botMessagePreviewSend(
                 ['create preview', 'preview'],
@@ -471,7 +472,7 @@ describe('MessageExtensions', () => {
                 botActivityPreview: [1],
                 botMessagePreviewAction: 'edit'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.botMessagePreviewSend(
                 async (context) => {
@@ -495,7 +496,7 @@ describe('MessageExtensions', () => {
     describe(`${QUERY_INVOKE_NAME}`, () => {
         it('should return InvokeResponse with status code 200 with the query invoke name', async () => {
             const activity = createTestInvoke(QUERY_INVOKE_NAME, { commandId: 'showQuery' });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             interface MyParams {}
 
@@ -532,7 +533,7 @@ describe('MessageExtensions', () => {
                 displayText: 'Yes',
                 value: 'Yes'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.handleOnButtonClicked(async (context: TurnContext, _state, data) => {
                 assert.equal(data.title, 'Query button');
@@ -554,7 +555,7 @@ describe('MessageExtensions', () => {
             const activity = createTestInvoke(QUERY_LINK_INVOKE_NAME, {
                 url: 'https://www.youtube.com/watch?v=971YIvosuUk&ab_channel=MicrosoftDeveloper'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             // Set up the queryLink handler
             mockApp.messageExtensions.queryLink(async () => {
@@ -613,7 +614,7 @@ describe('MessageExtensions', () => {
     describe(`${QUERY_SETTING_URL}`, async () => {
         it('should return InvokeResponse with status code 200 when querySettingUrl is invoked', async () => {
             const activity = createTestInvoke(QUERY_SETTING_URL, {});
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             mockApp.messageExtensions.queryUrlSetting(async (context: TurnContext, _state) => {
                 return {
@@ -656,7 +657,7 @@ describe('MessageExtensions', () => {
                 ],
                 type: 'result'
             });
-            activity.channelId = 'msteams';
+            activity.channelId = Channels.Msteams;
 
             // Set up the selectItem handler
             mockApp.messageExtensions.selectItem(async (_context, _state, item) => {

--- a/js/packages/teams-ai/src/MessageExtensions.ts
+++ b/js/packages/teams-ai/src/MessageExtensions.ts
@@ -7,17 +7,18 @@
  */
 
 import {
-    TurnContext,
-    TaskModuleTaskInfo,
+    Activity,
     ActivityTypes,
-    InvokeResponse,
+    Channels,
     INVOKE_RESPONSE_KEY,
-    TaskModuleResponse,
-    MessagingExtensionResult,
+    InvokeResponse,
     MessagingExtensionActionResponse,
     MessagingExtensionParameter,
     MessagingExtensionQuery,
-    Activity
+    MessagingExtensionResult,
+    TaskModuleResponse,
+    TaskModuleTaskInfo,
+    TurnContext
 } from 'botbuilder';
 import { Application, RouteSelector, Query } from './Application';
 import { TurnState } from './TurnState';
@@ -99,7 +100,7 @@ export class MessageExtensions<TState extends TurnState> {
     ): Application<TState> {
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.channelId === 'msteams' &&
+                context?.activity?.channelId === Channels.Msteams &&
                     context?.activity?.type == ActivityTypes.Invoke &&
                     context?.activity.name === ANONYMOUS_QUERY_LINK_INVOKE_NAME
             );
@@ -153,7 +154,7 @@ export class MessageExtensions<TState extends TurnState> {
             this._app.addRoute(
                 selector,
                 async (context, state) => {
-                    if (context?.activity?.channelId === 'msteams') {
+                    if (context?.activity?.channelId === Channels.Msteams) {
                         // Insure that we're in an invoke as expected
                         if (
                             context?.activity?.type !== ActivityTypes.Invoke ||
@@ -205,7 +206,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
-                        context?.activity?.channelId !== 'msteams' ||
+                        context?.activity?.channelId !== Channels.Msteams ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== SUBMIT_ACTION_INVOKE_NAME ||
                         context?.activity?.value?.botMessagePreviewAction !== 'send'
@@ -254,7 +255,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
-                        context?.activity?.channelId !== 'msteams' ||
+                        context?.activity?.channelId !== Channels.Msteams ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== FETCH_TASK_INVOKE_NAME
                     ) {
@@ -323,7 +324,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
-                        context?.activity?.channelId !== 'msteams' ||
+                        context?.activity?.channelId !== Channels.Msteams ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== QUERY_INVOKE_NAME
                     ) {
@@ -381,7 +382,7 @@ export class MessageExtensions<TState extends TurnState> {
     ): Application<TState> {
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.channelId === 'msteams' &&
+                context?.activity?.channelId === Channels.Msteams &&
                     context?.activity?.type == ActivityTypes.Invoke &&
                     context?.activity.name === QUERY_LINK_INVOKE_NAME
             );
@@ -431,7 +432,7 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context.activity.channelId === 'msteams' &&
+                context.activity.channelId === Channels.Msteams &&
                     context?.activity?.type == ActivityTypes.Invoke &&
                     context?.activity.name === SELECT_ITEM_INVOKE_NAME
             );
@@ -486,7 +487,7 @@ export class MessageExtensions<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an invoke as expected
                     if (
-                        context?.activity?.channelId !== 'msteams' ||
+                        context?.activity?.channelId !== Channels.Msteams ||
                         context?.activity?.type !== ActivityTypes.Invoke ||
                         context?.activity?.name !== SUBMIT_ACTION_INVOKE_NAME
                     ) {
@@ -515,7 +516,7 @@ export class MessageExtensions<TState extends TurnState> {
         context: TurnContext,
         result: MessagingExtensionResult | TaskModuleTaskInfo | string | null | undefined
     ): Promise<void> {
-        if (context?.activity?.channelId === 'msteams' && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
+        if (context?.activity?.channelId === Channels.Msteams && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
             // Format invoke response
             let response: MessagingExtensionActionResponse;
             if (typeof result == 'string') {
@@ -571,7 +572,7 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.channelId === 'msteams' &&
+                context?.activity?.channelId === Channels.Msteams &&
                     context?.activity?.type == ActivityTypes.Invoke &&
                     context?.activity.name === QUERY_SETTING_URL
             );
@@ -615,7 +616,7 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.channelId === 'msteams' &&
+                context?.activity?.channelId === Channels.Msteams &&
                     context?.activity?.type == ActivityTypes.Invoke &&
                     context?.activity.name === CONFIGURE_SETTINGS
             );
@@ -659,7 +660,7 @@ export class MessageExtensions<TState extends TurnState> {
         // Define static route selector
         const selector = (context: TurnContext) =>
             Promise.resolve(
-                context?.activity?.channelId === 'msteams' &&
+                context?.activity?.channelId === Channels.Msteams &&
                     context?.activity?.type == ActivityTypes.Invoke &&
                     context?.activity.name === QUERY_CARD_BUTTON_CLICKED
             );
@@ -706,7 +707,7 @@ function createTaskSelector(
             const isInvoke = context?.activity?.type == ActivityTypes.Invoke && context?.activity?.name == invokeName;
             if (
                 isInvoke &&
-                context?.activity?.channelId === 'msteams' &&
+                context?.activity?.channelId === Channels.Msteams &&
                 typeof context?.activity?.value?.commandId == 'string' &&
                 matchesPreviewAction(context.activity, botMessagePreviewAction)
             ) {
@@ -721,7 +722,7 @@ function createTaskSelector(
             const isInvoke = context?.activity?.type == ActivityTypes.Invoke && context?.activity?.name == invokeName;
             return Promise.resolve(
                 isInvoke &&
-                    context?.activity?.channelId === 'msteams' &&
+                    context?.activity?.channelId === Channels.Msteams &&
                     context?.activity?.value?.commandId === commandId &&
                     matchesPreviewAction(context.activity, botMessagePreviewAction)
             );

--- a/js/packages/teams-ai/src/TaskModules.spec.ts
+++ b/js/packages/teams-ai/src/TaskModules.spec.ts
@@ -1,0 +1,194 @@
+import { strict as assert } from 'assert';
+import { Application } from './Application';
+import { createTestInvoke } from './TestUtilities';
+import {
+    ActivityTypes,
+    Channels,
+    INVOKE_RESPONSE_KEY,
+    TaskModuleContinueResponse,
+    TaskModuleMessageResponse,
+    // MessagingExtensionResult,
+    // TaskModuleTaskInfo,
+    TestAdapter,
+    TurnContext
+} from 'botbuilder';
+import { TaskModules } from './TaskModules';
+
+describe('TaskModules', () => {
+    const adapter = new TestAdapter();
+    const FETCH_INVOKE_NAME = `task/fetch`;
+    const SUBMIT_INVOKE_NAME = `task/submit`;
+
+    let mockApp: Application;
+    beforeEach(() => {
+        mockApp = new Application({ adapter });
+    });
+
+    const createExpected200Response = (taskModuleResponse: TaskModuleContinueResponse | TaskModuleMessageResponse) => {
+        if (taskModuleResponse.type != 'continue' && taskModuleResponse.type != 'message') {
+            throw new Error(
+                `Test setup failed. TaskModuleResponse.type must be either 'continue' or 'message', not ${taskModuleResponse.type}`
+            );
+        }
+
+        if (typeof taskModuleResponse.value != 'string' && typeof taskModuleResponse.value != 'object') {
+            throw new Error(
+                `Test setup faiiled. TaskModuleResponse.value type must be either a string or an object, not ${typeof taskModuleResponse.value}`
+            );
+        }
+        return {
+            status: 200,
+            body: { task: taskModuleResponse }
+        };
+    };
+
+    it('should exist when Application is instantiated', () => {
+        assert.notEqual(mockApp.taskModules, undefined);
+        assert.equal(mockApp.taskModules instanceof TaskModules, true);
+    });
+
+    describe(FETCH_INVOKE_NAME, () => {
+        const TEST_VERB = 'testVerb';
+        const happyPathTestData = [
+            {
+                testCase: 'should return a 200 and TaskModuleMessageResponse for a returned string',
+                testVerb: TEST_VERB,
+                testActivity: createTestInvoke(FETCH_INVOKE_NAME, {
+                    data: { verb: TEST_VERB }
+                }),
+                handlerReturnValue: 'message',
+                expectedResult: createExpected200Response({ type: 'message', value: 'message' })
+            }
+        ];
+
+        for (const { testCase, testVerb, testActivity, expectedResult, handlerReturnValue } of happyPathTestData) {
+            testActivity.channelId = Channels.Msteams;
+            it(testCase, async () => {
+                mockApp.taskModules.fetch(testVerb, async (_context, _state, _data) => {
+                    return handlerReturnValue;
+                });
+
+                await adapter.processActivity(testActivity, async (context) => {
+                    await mockApp.run(context);
+                    const response = context.turnState.get(INVOKE_RESPONSE_KEY);
+                    assert.deepEqual(response.value, expectedResult);
+                });
+            });
+        }
+
+        it('fetch() with custom RouteSelector happy path', async () => {
+            const expectedVerbValue = 'verbValue';
+            const testActivity = createTestInvoke(FETCH_INVOKE_NAME, {
+                data: { verb: expectedVerbValue }
+            });
+            testActivity.channelId = Channels.Msteams;
+            const messageResult = 'messageResult';
+            mockApp.taskModules.fetch(expectedVerbValue, async (_context, _state, _data) => {
+                return messageResult;
+            });
+
+            await adapter.processActivity(testActivity, async (context) => {
+                await mockApp.run(context);
+                const response = context.turnState.get(INVOKE_RESPONSE_KEY);
+                assert.deepEqual(response.value, {
+                    status: 200,
+                    body: { task: { type: 'message', value: messageResult } }
+                });
+            });
+        });
+
+        it('fetch() with custom RouteSelector handler result is falsy', async () => {
+            const expectedVerbValue = 'verbValue';
+            const testActivity = createTestInvoke(FETCH_INVOKE_NAME, {
+                data: { verb: expectedVerbValue }
+            });
+            testActivity.channelId = Channels.Msteams;
+            mockApp.taskModules.fetch(expectedVerbValue, async (_context, _state, _data) => {
+                return {};
+            });
+
+            await adapter.processActivity(testActivity, async (context) => {
+                await mockApp.run(context);
+                const response = context.turnState.get(INVOKE_RESPONSE_KEY);
+                assert.deepEqual(response.value, {
+                    status: 200,
+                    body: { task: { type: 'continue', value: {} } }
+                });
+            });
+        });
+
+        it('fetch() should throw an error when activity.name is incorrect', async () => {
+            const testActivity = { channelId: Channels.Msteams, type: ActivityTypes.Invoke, name: 'incorrectName' };
+            const badRouteSelector = (context: TurnContext) => {
+                return Promise.resolve(true);
+            };
+
+            mockApp.taskModules.fetch(badRouteSelector, async (_context, _state, _data) => {
+                return 'testFailed'; // the test should not reach this point
+            });
+            await assert.rejects(async () => {
+                await adapter.processActivity(testActivity, async (context) => {
+                    await mockApp.run(context);
+                });
+            });
+        });
+        it('fetch() with custom RouteSelector unhappy path', async () => {
+            const testActivity = { channelId: Channels.Msteams, type: ActivityTypes.Invoke, name: 'incorrectName' };
+            const badRouteSelector = (context: TurnContext) => {
+                return Promise.resolve(true);
+            };
+
+            mockApp.taskModules.fetch(badRouteSelector, async (context, _state, _data) => {
+                return Promise.resolve('');
+            });
+            await assert.rejects(async () => {
+                await adapter.processActivity(testActivity, async (context) => {
+                    await mockApp.run(context);
+                });
+            });
+        });
+
+        // it('fetch() with array of verbs', async () => {});
+    });
+
+    describe(SUBMIT_INVOKE_NAME, () => {
+        it('submit() with custom RouteSelector happy path', async () => {
+            const expectedVerbValue = 'verbValue';
+            const testActivity = createTestInvoke(SUBMIT_INVOKE_NAME, {
+                data: { verb: expectedVerbValue }
+            });
+            testActivity.channelId = Channels.Msteams;
+            const messageResult = 'messageResult';
+            mockApp.taskModules.submit(expectedVerbValue, async (_context, _state, _data) => {
+                return messageResult;
+            });
+
+            await adapter.processActivity(testActivity, async (context) => {
+                await mockApp.run(context);
+                const response = context.turnState.get(INVOKE_RESPONSE_KEY);
+                assert.deepEqual(response.value, {
+                    status: 200,
+                    body: { task: { type: 'message', value: messageResult } }
+                });
+            });
+        });
+
+        it('submit() with custom RouteSelector unhappy path', async () => {
+            const testActivity = { channelId: Channels.Msteams, type: ActivityTypes.Invoke, name: 'incorrectName' };
+            const badRouteSelector = (context: TurnContext) => {
+                return Promise.resolve(true);
+            };
+
+            mockApp.taskModules.submit(badRouteSelector, async (_context, _state, _data) => {
+                return Promise.resolve(undefined);
+            });
+            await assert.rejects(async () => {
+                await adapter.processActivity(testActivity, async (context) => {
+                    await mockApp.run(context);
+                });
+            });
+        });
+
+        // it('submit() with array of verbs', async () => {});
+    });
+});

--- a/js/packages/teams-ai/src/TaskModules.spec.ts
+++ b/js/packages/teams-ai/src/TaskModules.spec.ts
@@ -7,8 +7,6 @@ import {
     INVOKE_RESPONSE_KEY,
     TaskModuleContinueResponse,
     TaskModuleMessageResponse,
-    // MessagingExtensionResult,
-    // TaskModuleTaskInfo,
     TestAdapter,
     TurnContext
 } from 'botbuilder';
@@ -147,8 +145,6 @@ describe('TaskModules', () => {
                 });
             });
         });
-
-        // it('fetch() with array of verbs', async () => {});
     });
 
     describe(SUBMIT_INVOKE_NAME, () => {
@@ -188,7 +184,5 @@ describe('TaskModules', () => {
                 });
             });
         });
-
-        // it('submit() with array of verbs', async () => {});
     });
 });


### PR DESCRIPTION
## Linked issues

closes: #635
closes: #247 

## Details

- A behavior that was missing from Task Modules was handling submit "continue" scenario when the handler does not return a `TaskModuleResponse` or string. This ensures that the expected response (empty 200) is sent even if there is nothing new to render/send. 
- Modify so that Teams events check for channelId using `Channels` enum, not 'msteams' string
   - This included minor refactor for Message Extension and Application as well
- Add Task Module tests to get the file to 80% coverage

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

Thank you @th1nkful for the original [PR](https://github.com/microsoft/teams-ai/pull/636), which I modified to match Bot Framework protocol :)