### PR TITLE
[C#] feat: add file and o365 card handlers

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -1670,5 +1670,199 @@ namespace Microsoft.TeamsAI.Tests.Application
             Assert.Equal("invokeResponse", activitiesToSend[0].Type);
             Assert.Equivalent(expectedInvokeResponse, activitiesToSend[0].Value);
         }
+
+        [Fact]
+        public async Task Test_OnFileConsentAccept()
+        {
+            // Arrange
+            Activity[]? activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+            var adapter = new SimpleAdapter(CaptureSend);
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "fileConsent/invoke",
+                Value = JObject.FromObject(new
+                {
+                    action = "accept"
+                }),
+                Id = "test"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "fileConsent/invoke",
+                Value = JObject.FromObject(new
+                {
+                    action = "decline"
+                }),
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "composeExtension/queryLink"
+            };
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var expectedInvokeResponse = new InvokeResponse
+            {
+                Status = 200
+            };
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var ids = new List<string>();
+            app.OnFileConsentAccept((turnContext, _, _, _) =>
+            {
+                ids.Add(turnContext.Activity.Id);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(ids);
+            Assert.Equal("test", ids[0]);
+            Assert.NotNull(activitiesToSend);
+            Assert.Equal(1, activitiesToSend.Length);
+            Assert.Equal("invokeResponse", activitiesToSend[0].Type);
+            Assert.Equivalent(expectedInvokeResponse, activitiesToSend[0].Value);
+        }
+
+        [Fact]
+        public async Task Test_OnFileConsentDecline()
+        {
+            // Arrange
+            Activity[]? activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+            var adapter = new SimpleAdapter(CaptureSend);
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "fileConsent/invoke",
+                Value = JObject.FromObject(new
+                {
+                    action = "decline"
+                }),
+                Id = "test"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "fileConsent/invoke",
+                Value = JObject.FromObject(new
+                {
+                    action = "accept"
+                }),
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "composeExtension/queryLink"
+            };
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var expectedInvokeResponse = new InvokeResponse
+            {
+                Status = 200
+            };
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var ids = new List<string>();
+            app.OnFileConsentDecline((turnContext, _, _, _) =>
+            {
+                ids.Add(turnContext.Activity.Id);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(ids);
+            Assert.Equal("test", ids[0]);
+            Assert.NotNull(activitiesToSend);
+            Assert.Equal(1, activitiesToSend.Length);
+            Assert.Equal("invokeResponse", activitiesToSend[0].Type);
+            Assert.Equivalent(expectedInvokeResponse, activitiesToSend[0].Value);
+        }
+
+        [Fact]
+        public async Task Test_OnO365ConnectorCardAction()
+        {
+            // Arrange
+            Activity[]? activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+            var adapter = new SimpleAdapter(CaptureSend);
+            var activity1 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "actionableMessage/executeAction",
+                Value = new { },
+                Id = "test"
+            };
+            var activity2 = new Activity
+            {
+                Type = ActivityTypes.Event,
+                Name = "actionableMessage/executeAction"
+            };
+            var activity3 = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "composeExtension/queryLink"
+            };
+            var turnContext1 = new TurnContext(adapter, activity1);
+            var turnContext2 = new TurnContext(adapter, activity2);
+            var turnContext3 = new TurnContext(adapter, activity3);
+            var expectedInvokeResponse = new InvokeResponse
+            {
+                Status = 200
+            };
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var ids = new List<string>();
+            app.OnO365ConnectorCardAction((turnContext, _, _, _) =>
+            {
+                ids.Add(turnContext.Activity.Id);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext1);
+            await app.OnTurnAsync(turnContext2);
+            await app.OnTurnAsync(turnContext3);
+
+            // Assert
+            Assert.Single(ids);
+            Assert.Equal("test", ids[0]);
+            Assert.NotNull(activitiesToSend);
+            Assert.Equal(1, activitiesToSend.Length);
+            Assert.Equal("invokeResponse", activitiesToSend[0].Type);
+            Assert.Equivalent(expectedInvokeResponse, activitiesToSend[0].Value);
+        }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/FileConsentCardHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/FileConsentCardHandler.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema.Teams;
+using Microsoft.TeamsAI.State;
+
+namespace Microsoft.TeamsAI.Application
+{
+    /// <summary>
+    /// Function for handling file consent card activities.
+    /// </summary>
+    /// <typeparam name="TState">Type of the turn state. This allows for strongly typed access to the turn state.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="fileConsentCardResponse">The response representing the value of the invoke activity sent when the user acts on a file consent card.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns>A task that represents the work queued to execute.</returns>
+    public delegate Task FileConsentHandler<TState>(ITurnContext turnContext, TState turnState, FileConsentCardResponse fileConsentCardResponse, CancellationToken cancellationToken) where TState : ITurnState<StateBase, StateBase, TempState>;
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/O365ConnectorCardActionHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/O365ConnectorCardActionHandler.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema.Teams;
+using Microsoft.TeamsAI.State;
+
+namespace Microsoft.TeamsAI.Application
+{
+    /// <summary>
+    /// Function for handling O365 Connector Card Action activities.
+    /// </summary>
+    /// <typeparam name="TState">Type of the turn state. This allows for strongly typed access to the turn state.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="query">The O365 connector card HttpPOST invoke query.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns>A task that represents the work queued to execute.</returns>
+    public delegate Task O365ConnectorCardActionHandler<TState>(ITurnContext turnContext, TState turnState, O365ConnectorCardActionQuery query, CancellationToken cancellationToken) where TState : ITurnState<StateBase, StateBase, TempState>;
+}


### PR DESCRIPTION
## Linked issues

closes: #606

## Details

Add handlers for:
- `fileConsent/invoke`
- `actionableMessage/executeAction`

#### Change details

Added 3 methods to `Application`:
- `OnFileConsentAccept`
- `OnFileConsentDecline`
- `OnO365ConnectorCardAction`

Added unit tests

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
