### PR TITLE
[C#] feat: Add Handler for Read Receipt Event

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -1670,5 +1670,76 @@ namespace Microsoft.TeamsAI.Tests.Application
             Assert.Equal("invokeResponse", activitiesToSend[0].Type);
             Assert.Equivalent(expectedInvokeResponse, activitiesToSend[0].Value);
         }
+
+        [Fact]
+        public async Task Test_OnTeamsReadReceipt()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Event,
+                ChannelId = Channels.Msteams,
+                Name = "application/vnd.microsoft.readReceipt",
+                Value = JObject.FromObject(new
+                {
+                    lastReadMessageId = "10101010",
+                }),
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnTeamsReadReceipt((context, _, _, _) =>
+            {
+                names.Add(context.Activity.Name);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Single(names);
+            Assert.Equal("application/vnd.microsoft.readReceipt", names[0]);
+        }
+
+        [Fact]
+        public async Task Test_OnTeamsReadReceipt_IncorrectName()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Event,
+                ChannelId = Channels.Msteams,
+                Name = "application/vnd.microsoft.meetingStart",
+                Value = JObject.FromObject(new
+                {
+                    lastReadMessageId = "10101010",
+                }),
+            };
+            var adapter = new NotImplementedAdapter();
+            var turnContext = new TurnContext(adapter, activity);
+            var app = new Application<TestTurnState, TestTurnStateManager>(new()
+            {
+                RemoveRecipientMention = false,
+                StartTypingTimer = false
+            });
+            var names = new List<string>();
+            app.OnTeamsReadReceipt((context, _, _, _) =>
+            {
+                names.Add(context.Activity.Name);
+                return Task.CompletedTask;
+            });
+
+            // Act
+            await app.OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Empty(names);
+        }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ReadReceiptHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ReadReceiptHandler.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema.Teams;
+using Microsoft.TeamsAI.State;
+
+namespace Microsoft.TeamsAI
+{
+    /// <summary>
+    /// Function for handling read receipt events.
+    /// </summary>
+    /// <typeparam name="TState">Type of the turn state. This allows for strongly typed access to the turn state.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="data">The read receipt data.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    public delegate Task ReadReceiptHandler<TState>(ITurnContext turnContext, TState turnState, ReadReceiptInfo data, CancellationToken cancellationToken) where TState : ITurnState<StateBase, StateBase, TempState>;
+}


### PR DESCRIPTION
## Linked issues

closes: #697 

## Details

- Added handling of read receipt events in personal scope, and associated tests. 

**Delegate:**
Task ReadReceiptHandler(ITurnContext turnContext, TState turnState, ReadReceiptInfo data, CancellationToken cancellationToken)

**API:**
OnTeamsReadReceipt(ReadReceiptHandler<TState> handler)

**Reference:**
[BotBuilder Code](https://github.com/microsoft/botbuilder-dotnet/blob/e4afa430ea73dd725be39a30d16fe361e77d07c8/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs#L807)
[BotBuilder PR](https://github.com/microsoft/botbuilder-dotnet/pull/6356)


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
