### PR TITLE
[C#] feat: call OpenAI's assistant and thread APIs

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIClientAssistantTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIClientAssistantTests.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Teams.AI.AI.OpenAI;
+using Microsoft.Teams.AI.AI.OpenAI.Models;
+using Microsoft.Teams.AI.Utilities;
+using System.Net;
+
+namespace Microsoft.Teams.AI.Tests.AITests
+{
+    public partial class OpenAIClientTests
+    {
+        [Fact]
+        public async Task Test_OpenAIClient_CreateAssistant()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""id"": ""asst_test"",
+  ""created_at"": 10000
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.CreateAssistant(new AssistantCreateParams
+            {
+                Instructions = "Your are a test bot",
+                Model = "gpt-3.5-turbo"
+            }, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("asst_test", result.Id);
+            Assert.Equal(10000, result.CreatedAt);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_RetrieveAssistant()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""id"": ""asst_test"",
+  ""created_at"": 10000
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.RetrieveAssistant("asst_test", CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("asst_test", result.Id);
+            Assert.Equal(10000, result.CreatedAt);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIClientTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIClientTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Teams.AI.Utilities;
 
 namespace Microsoft.Teams.AI.Tests.AITests
 {
-    public class OpenAIClientTests
+    public partial class OpenAIClientTests
     {
         [Fact]
         public async Task Test_OpenAIClient_Uses_DefaultHttpClient()

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIClientThreadTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIClientThreadTests.cs
@@ -1,0 +1,268 @@
+﻿using Microsoft.Teams.AI.AI.OpenAI;
+using Microsoft.Teams.AI.AI.OpenAI.Models;
+using Microsoft.Teams.AI.Utilities;
+using System.Net;
+
+namespace Microsoft.Teams.AI.Tests.AITests
+{
+    public partial class OpenAIClientTests
+    {
+        [Fact]
+        public async Task Test_OpenAIClient_CreateThread()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""id"": ""thread_test"",
+  ""created_at"": 10000
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.CreateThread(new ThreadCreateParams(), CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("thread_test", result.Id);
+            Assert.Equal(10000, result.CreatedAt);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_CreateMessage()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""id"": ""msg_test"",
+  ""created_at"": 10000,
+  ""role"": ""user"",
+  ""content"": [
+    {
+      ""type"": ""text"",
+      ""text"": {
+        ""value"": ""hello""
+      }
+    }
+  ]
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.CreateMessage("thread_test", new MessageCreateParams
+            {
+                Content = "hello"
+            }, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("msg_test", result.Id);
+            Assert.Equal(10000, result.CreatedAt);
+            Assert.Equal("user", result.Role);
+            Assert.Equal("hello", result.Content.FirstOrDefault()?.Text?.Value);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_ListNewMessages()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""data"": [
+    {
+      ""id"": ""msg_2""
+    },
+    {
+      ""id"": ""msg_1""
+    }
+  ],
+  ""first_id"": ""msg_2"",
+  ""last_id"": ""msg_1"",
+  ""has_more"": false
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.ListNewMessages("thread_1", "msg_0", CancellationToken.None).ToListAsync();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count);
+            Assert.Equal("msg_2", result[0].Id);
+            Assert.Equal("msg_1", result[1].Id);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_CreateRun()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""id"": ""run_test"",
+  ""assistant_id"": ""asst_test"",
+  ""created_at"": 10000
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.CreateRun("thread_test", new RunCreateParams
+            {
+                AssistantId = "asst_test"
+            }, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("run_test", result.Id);
+            Assert.Equal("asst_test", result.AssistantId);
+            Assert.Equal(10000, result.CreatedAt);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_RetrieveRun()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""id"": ""run_test"",
+  ""assistant_id"": ""asst_test"",
+  ""created_at"": 10000
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.RetrieveRun("thread_test", "run_test", CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("run_test", result.Id);
+            Assert.Equal("asst_test", result.AssistantId);
+            Assert.Equal(10000, result.CreatedAt);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_RetrieveLastRun()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""data"": [
+    {
+      ""id"": ""run_test""
+    }
+  ],
+  ""first_id"": ""run_test"",
+  ""last_id"": ""run_test"",
+  ""has_more"": false
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.RetrieveLastRun("thread_test", CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("run_test", result.Id);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_RetrieveLastRun_NullResult()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""data"": [],
+  ""has_more"": false
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.RetrieveLastRun("thread_test", CancellationToken.None);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Test_OpenAIClient_SubmitToolOutputs()
+        {
+            // Arrange
+            var response = new TestHttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(@"{
+  ""id"": ""run_test"",
+  ""assistant_id"": ""asst_test"",
+  ""created_at"": 10000
+}")
+            };
+            var httpClient = new HttpClient(new TestHttpMessageHandler
+            {
+                Response = response
+            });
+            DefaultHttpClient.Instance = httpClient;
+            var openAIClient = new OpenAIClient(new OpenAIClientOptions("test-key"));
+
+            // Action
+            var result = await openAIClient.SubmitToolOutputs("thread_test", "run_test", new SubmitToolOutputsParams
+            {
+                ToolOutputs = new List<ToolOutput>
+                {
+                    new()
+                }
+            }, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("run_test", result.Id);
+            Assert.Equal("asst_test", result.AssistantId);
+            Assert.Equal(10000, result.CreatedAt);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Microsoft.Teams.AI.Tests.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Microsoft.Teams.AI.Tests.csproj
@@ -10,9 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.21.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Assistant.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Assistant.cs
@@ -1,0 +1,71 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.AI.AI.OpenAI.Models
+{
+    internal class Assistant
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("created_at")]
+        public long CreatedAt { get; set; }
+
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("file_ids")]
+        public List<string> FileIds { get; set; } = new List<string>();
+
+        [JsonPropertyName("instructions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Instructions { get; set; }
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("object")]
+        public string Object { get; } = "assistant";
+
+        [JsonPropertyName("tools")]
+        public List<Tool> Tools { get; set; } = new List<Tool>();
+    }
+
+    internal class AssistantCreateParams
+    {
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+
+        [JsonPropertyName("file_ids")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? FileIds { get; set; }
+
+        [JsonPropertyName("instructions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Instructions { get; set; }
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+
+        [JsonPropertyName("name")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("tools")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<Tool>? Tools { get; set; }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/ListResponse.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/ListResponse.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.AI.AI.OpenAI.Models
+{
+    internal class ListResponse<T> where T : new()
+    {
+        [JsonPropertyName("data")]
+        public List<T> Data { get; set; } = new List<T>();
+
+        [JsonPropertyName("first_id")]
+        public string FirstId { get; set; } = string.Empty;
+
+        [JsonPropertyName("last_id")]
+        public string LastId { get; set; } = string.Empty;
+
+        [JsonPropertyName("has_more")]
+        public bool HasMore { get; set; }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Message.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Message.cs
@@ -1,0 +1,80 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.AI.AI.OpenAI.Models
+{
+    internal class Message
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("assistant_id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? AssistantId { get; set; }
+
+        [JsonPropertyName("content")]
+        public List<MessageContent> Content { get; set; } = new List<MessageContent>();
+
+        [JsonPropertyName("created_at")]
+        public long CreatedAt { get; set; }
+
+        [JsonPropertyName("file_ids")]
+        public List<string> FileIds { get; set; } = new List<string>();
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+
+        [JsonPropertyName("object")]
+        public string Object { get; } = "thread.message";
+
+        [JsonPropertyName("role")]
+        public string Role { get; set; } = string.Empty;
+
+        [JsonPropertyName("run_id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? RunId { get; set; }
+
+        [JsonPropertyName("thread_id")]
+        public string ThreadId { get; set; } = string.Empty;
+    }
+
+    internal class MessageContent
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("text")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public MessageContentText? Text { get; set; }
+
+        [JsonPropertyName("image_file")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public object? ImageFile { get; set; }
+    }
+
+    internal class MessageContentText
+    {
+        [JsonPropertyName("value")]
+        public string Value { get; set; } = string.Empty;
+
+        [JsonPropertyName("annotations")]
+        public object? Annotations { get; set; }
+    }
+
+    internal class MessageCreateParams
+    {
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+
+        [JsonPropertyName("role")]
+        public string Role { get; } = "user";
+
+        [JsonPropertyName("file_ids")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<string>? FileIds { get; set; }
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Run.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Run.cs
@@ -1,0 +1,152 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.AI.AI.OpenAI.Models
+{
+    internal class Run
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("assistant_id")]
+        public string AssistantId { get; set; } = string.Empty;
+
+        [JsonPropertyName("cancelled_at")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public long? CancelledAt { get; set; }
+
+        [JsonPropertyName("completed_at")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public long? CompletedAt { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public long CreatedAt { get; set; }
+
+        [JsonPropertyName("expires_at")]
+        public long ExpiredAt { get; set; }
+
+        [JsonPropertyName("failed_at")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public long? FailedAt { get; set; }
+
+        [JsonPropertyName("file_ids")]
+        public List<string> FileIds { get; set; } = new List<string>();
+
+        [JsonPropertyName("instructions")]
+        public string Instructions { get; set; } = string.Empty;
+
+        [JsonPropertyName("last_error")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public LastError? LastError { get; set; }
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+
+        [JsonPropertyName("model")]
+        public string Model { get; set; } = string.Empty;
+
+        [JsonPropertyName("object")]
+        public string Object { get; } = "thread.run";
+
+        [JsonPropertyName("required_action")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public RequiredAction? RequiredAction { get; set; }
+
+        [JsonPropertyName("started_at")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public long? StartedAt { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonPropertyName("thread_id")]
+        public string ThreadId { get; set; } = string.Empty;
+
+        [JsonPropertyName("tools")]
+        public List<Tool> Tools { get; set; } = new List<Tool>();
+    }
+
+    internal class LastError
+    {
+        [JsonPropertyName("code")]
+        public string Code { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+    }
+
+    internal class RequiredAction
+    {
+        [JsonPropertyName("submit_tool_outputs")]
+        public SubmitToolOutputs SubmitToolOutputs { get; set; } = new();
+
+        [JsonPropertyName("type")]
+        public string Type { get; } = "submit_tool_outputs";
+    }
+
+    internal class SubmitToolOutputs
+    {
+        [JsonPropertyName("tool_calls")]
+        public List<ToolCall> ToolCalls { get; set; } = new List<ToolCall>();
+    }
+
+    internal class ToolCall
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("function")]
+        public ToolCallFunction Function { get; set; } = new();
+
+        [JsonPropertyName("type")]
+        public string Type { get; } = "function";
+    }
+
+    internal class ToolCallFunction
+    {
+        [JsonPropertyName("arguments")]
+        public string Arguments { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+    }
+
+    internal class RunCreateParams
+    {
+        [JsonPropertyName("assistant_id")]
+        public string AssistantId { get; set; } = string.Empty;
+
+        [JsonPropertyName("instructions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Instructions { get; set; }
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+
+        [JsonPropertyName("model")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("tools")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<Tool>? Tools { get; set; }
+    }
+
+    internal class SubmitToolOutputsParams
+    {
+        [JsonPropertyName("tool_outputs")]
+        public List<ToolOutput> ToolOutputs { get; set; } = new List<ToolOutput>();
+    }
+
+    internal class ToolOutput
+    {
+        [JsonPropertyName("output")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Output { get; set; }
+
+        [JsonPropertyName("tool_call_id")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ToolCallId { get; set; }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Thread.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Thread.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.AI.AI.OpenAI.Models
+{
+    internal class Thread
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("created_at")]
+        public long CreatedAt { get; set; }
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+
+        [JsonPropertyName("object")]
+        public string Object { get; } = "thread";
+    }
+
+    internal class ThreadCreateParams
+    {
+        [JsonPropertyName("messages")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<MessageCreateParams>? Messages { get; set; }
+
+        [JsonPropertyName("metadata")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, object>? Metadata { get; set; }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Tool.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/Models/Tool.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Microsoft.Teams.AI.AI.OpenAI.Models
+{
+    internal class Tool
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("function")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Function? Function { get; set; }
+    }
+
+    internal class Function
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("parameters")]
+        public Dictionary<string, object> Parameters { get; set; } = new Dictionary<string, object>();
+
+        [JsonPropertyName("description")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Description { get; set; }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.Assistant.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.Assistant.cs
@@ -1,0 +1,85 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Teams.AI.AI.OpenAI.Models;
+using Microsoft.Teams.AI.Exceptions;
+
+// For Unit Tests - so the Moq framework can mock internal classes
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+namespace Microsoft.Teams.AI.AI.OpenAI
+{
+    /// <summary>
+    /// The client to make calls to OpenAI's API
+    /// </summary>
+    internal partial class OpenAIClient
+    {
+        private const string OpenAIAssistantEndpoint = "https://api.openai.com/v1/assistants";
+        private static readonly IEnumerable<KeyValuePair<string, string>> OpenAIBetaHeaders =
+            new List<KeyValuePair<string, string>> { new("OpenAI-Beta", "assistants=v1") }.AsReadOnly();
+
+        /// <summary>
+        /// Create an OpenAI Assistant.
+        /// </summary>
+        /// <param name="assistantCreateParams">The params to create the Assistant.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The created Assistant.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Assistant> CreateAssistant(AssistantCreateParams assistantCreateParams, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpContent content = new StringContent(
+                    JsonSerializer.Serialize(assistantCreateParams, _serializerOptions),
+                    Encoding.UTF8,
+                    "application/json"
+                );
+
+                using HttpResponseMessage httpResponse = await _ExecutePostRequest(OpenAIAssistantEndpoint, content, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                Assistant result = JsonSerializer.Deserialize<Assistant>(responseJson) ?? throw new SerializationException($"Failed to deserialize assistant result response json: {responseJson}");
+
+                return result;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// Retrieve an OpenAI Assistant.
+        /// </summary>
+        /// <param name="assistantId">The Assistant ID.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The Assistant.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Assistant> RetrieveAssistant(string assistantId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpResponseMessage httpResponse = await _ExecuteGetRequest($"{OpenAIAssistantEndpoint}/{assistantId}", null, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                Assistant result = JsonSerializer.Deserialize<Assistant>(responseJson) ?? throw new SerializationException($"Failed to deserialize assistant result response json: {responseJson}");
+
+                return result;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.Thread.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.Thread.cs
@@ -1,0 +1,290 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Teams.AI.AI.OpenAI.Models;
+using Microsoft.Teams.AI.Exceptions;
+
+// For Unit Tests - so the Moq framework can mock internal classes
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+namespace Microsoft.Teams.AI.AI.OpenAI
+{
+    /// <summary>
+    /// The client to make calls to OpenAI's API
+    /// </summary>
+    internal partial class OpenAIClient
+    {
+        private const string OpenAIThreadEndpoint = "https://api.openai.com/v1/threads";
+        private static readonly IEnumerable<KeyValuePair<string, string>> LimitOneQuery =
+            new List<KeyValuePair<string, string>> { new("limit", "1") }.AsReadOnly();
+
+        /// <summary>
+        /// Create a thread.
+        /// </summary>
+        /// <param name="threadCreateParams">The params to create the thread.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The created thread.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Models.Thread> CreateThread(ThreadCreateParams threadCreateParams, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpContent content = new StringContent(
+                    JsonSerializer.Serialize(threadCreateParams, _serializerOptions),
+                    Encoding.UTF8,
+                    "application/json"
+                );
+
+                using HttpResponseMessage httpResponse = await _ExecutePostRequest(OpenAIThreadEndpoint, content, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                Models.Thread result = JsonSerializer.Deserialize<Models.Thread>(responseJson) ?? throw new SerializationException($"Failed to deserialize thread result response json: {responseJson}");
+
+                return result;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// Create a message in a thread.
+        /// </summary>
+        /// <param name="threadId">The thread ID.</param>
+        /// <param name="messageCreateParams">The params to create the message.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The created message.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Message> CreateMessage(string threadId, MessageCreateParams messageCreateParams, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpContent content = new StringContent(
+                    JsonSerializer.Serialize(messageCreateParams, _serializerOptions),
+                    Encoding.UTF8,
+                    "application/json"
+                );
+
+                using HttpResponseMessage httpResponse = await _ExecutePostRequest($"{OpenAIThreadEndpoint}/{threadId}/messages", content, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                Message result = JsonSerializer.Deserialize<Message>(responseJson) ?? throw new SerializationException($"Failed to deserialize message result response json: {responseJson}");
+
+                return result;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// List new messages of a thread.
+        /// </summary>
+        /// <param name="threadId">The thread ID.</param>
+        /// <param name="lastMessageId">The last message ID (exclude from the list results).</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The new messages ordered by created_at timestamp desc.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async IAsyncEnumerable<Message> ListNewMessages(string threadId, string? lastMessageId, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            bool hasMore;
+            string? before = lastMessageId;
+            string? after = null;
+            do
+            {
+                ListResponse<Message> listResult;
+                try
+                {
+                    using HttpResponseMessage httpResponse = await _ExecuteGetRequest($"{OpenAIThreadEndpoint}/{threadId}/messages", BuildListQuery(before, after), OpenAIBetaHeaders, cancellationToken);
+                    string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                    listResult = JsonSerializer.Deserialize<ListResponse<Message>>(responseJson) ?? throw new SerializationException($"Failed to deserialize message list result response json: {responseJson}");
+                }
+                catch (HttpOperationException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+                }
+
+                foreach (Message message in listResult.Data)
+                {
+                    yield return message;
+                }
+
+                hasMore = listResult.HasMore;
+                if (hasMore)
+                {
+                    after = listResult.LastId;
+                }
+            } while (hasMore);
+        }
+
+        /// <summary>
+        /// Create a run of a thread.
+        /// </summary>
+        /// <param name="threadId">The thread ID.</param>
+        /// <param name="runCreateParams">The params to create the run.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The created run.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Run> CreateRun(string threadId, RunCreateParams runCreateParams, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpContent content = new StringContent(
+                    JsonSerializer.Serialize(runCreateParams, _serializerOptions),
+                    Encoding.UTF8,
+                    "application/json"
+                );
+
+                using HttpResponseMessage httpResponse = await _ExecutePostRequest($"{OpenAIThreadEndpoint}/{threadId}/runs", content, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                Run result = JsonSerializer.Deserialize<Run>(responseJson) ?? throw new SerializationException($"Failed to deserialize run result response json: {responseJson}");
+
+                return result;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// Retrieve a run of a thread.
+        /// </summary>
+        /// <param name="threadId">The thread ID.</param>
+        /// <param name="runId">The run ID.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The run.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Run> RetrieveRun(string threadId, string runId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpResponseMessage httpResponse = await _ExecuteGetRequest($"{OpenAIThreadEndpoint}/{threadId}/runs/{runId}", null, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                Run result = JsonSerializer.Deserialize<Run>(responseJson) ?? throw new SerializationException($"Failed to deserialize run result response json: {responseJson}");
+
+                return result;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the last run of a thread.
+        /// </summary>
+        /// <param name="threadId">The thread ID.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The last run if exist, otherwise null.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Run?> RetrieveLastRun(string threadId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpResponseMessage httpResponse = await _ExecuteGetRequest($"{OpenAIThreadEndpoint}/{threadId}/runs", LimitOneQuery, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                ListResponse<Run> result = JsonSerializer.Deserialize<ListResponse<Run>>(responseJson) ?? throw new SerializationException($"Failed to deserialize run list result response json: {responseJson}");
+
+                return result.Data?.Count > 0 ? result.Data[0] : null;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// Submit tool outputs of a run.
+        /// </summary>
+        /// <param name="threadId">The thread ID.</param>
+        /// <param name="runId">The run ID.</param>
+        /// <param name="submitToolOutputsParams">The params to submit.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>The run.</returns>
+        /// <exception cref="HttpOperationException" />
+        public virtual async Task<Run> SubmitToolOutputs(string threadId, string runId, SubmitToolOutputsParams submitToolOutputsParams, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using HttpContent content = new StringContent(
+                    JsonSerializer.Serialize(submitToolOutputsParams, _serializerOptions),
+                    Encoding.UTF8,
+                    "application/json"
+                );
+
+                using HttpResponseMessage httpResponse = await _ExecutePostRequest($"{OpenAIThreadEndpoint}/{threadId}/runs/{runId}/submit_tool_outputs", content, OpenAIBetaHeaders, cancellationToken);
+
+                string responseJson = await httpResponse.Content.ReadAsStringAsync();
+                Run result = JsonSerializer.Deserialize<Run>(responseJson) ?? throw new SerializationException($"Failed to deserialize run result response json: {responseJson}");
+
+                return result;
+            }
+            catch (HttpOperationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new TeamsAIException($"Something went wrong: {e.Message}", e);
+            }
+        }
+
+        private List<KeyValuePair<string, string>> BuildListQuery(string? before, string? after)
+        {
+            List<KeyValuePair<string, string>> result = new();
+            result.Add(new("order", "desc"));
+
+            if (string.IsNullOrEmpty(before) && string.IsNullOrEmpty(after))
+            {
+                return result;
+            }
+
+            if (!string.IsNullOrEmpty(before))
+            {
+                result.Add(new("before", before!));
+            }
+            if (!string.IsNullOrEmpty(after))
+            {
+                result.Add(new("after", after!));
+            }
+            return result;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/OpenAI/OpenAIClient.cs
@@ -1,9 +1,11 @@
-﻿using System.Net;
+﻿using System.Collections.Specialized;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.AI.AI.Moderator;
@@ -17,7 +19,7 @@ namespace Microsoft.Teams.AI.AI.OpenAI
     /// <summary>
     /// The client to make calls to OpenAI's API
     /// </summary>
-    internal class OpenAIClient
+    internal partial class OpenAIClient
     {
         private const string HttpUserAgent = "Microsoft Teams AI";
         private const string OpenAIModerationEndpoint = "https://api.openai.com/v1/moderations";
@@ -81,7 +83,67 @@ namespace Microsoft.Teams.AI.AI.OpenAI
             }
         }
 
-        private async Task<HttpResponseMessage> _ExecutePostRequest(string url, HttpContent? content, CancellationToken cancellationToken = default)
+        private async Task<HttpResponseMessage> _ExecuteGetRequest(
+            string url,
+            IEnumerable<KeyValuePair<string, string>>? queries = null,
+            IEnumerable<KeyValuePair<string, string>>? additionalHeaders = null,
+            CancellationToken cancellationToken = default)
+        {
+            HttpResponseMessage? response = null;
+
+            UriBuilder uriBuilder = new(url);
+            if (queries != null)
+            {
+                NameValueCollection queryCollection = HttpUtility.ParseQueryString(uriBuilder.Query);
+                foreach (KeyValuePair<string, string> query in queries)
+                {
+                    queryCollection.Add(query.Key, query.Value);
+                }
+                uriBuilder.Query = queryCollection.ToString();
+            }
+
+            using (HttpRequestMessage request = new(HttpMethod.Get, uriBuilder.ToString()))
+            {
+                request.Headers.Add("Accept", "application/json");
+                request.Headers.Add("User-Agent", HttpUserAgent);
+                request.Headers.Add("Authorization", $"Bearer {_options.ApiKey}");
+
+                if (_options.Organization != null)
+                {
+                    request.Headers.Add("OpenAI-Organization", _options.Organization);
+                }
+
+                if (additionalHeaders != null)
+                {
+                    foreach (KeyValuePair<string, string> header in additionalHeaders)
+                    {
+                        request.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
+                response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            _logger.LogTrace($"HTTP response: {(int)response.StatusCode} {response.StatusCode:G}");
+
+            // Throw an exception if not a success status code
+            if (response.IsSuccessStatusCode)
+            {
+                return response;
+            }
+
+            HttpStatusCode statusCode = response.StatusCode;
+            string failureReason = response.ReasonPhrase;
+            response?.Dispose();
+
+            throw new HttpOperationException($"HTTP response failure status code: {(int)statusCode} ({failureReason})", statusCode, failureReason);
+        }
+
+        private async Task<HttpResponseMessage> _ExecutePostRequest(
+            string url,
+            HttpContent? content,
+            IEnumerable<KeyValuePair<string, string>>? additionalHeaders = null,
+            CancellationToken cancellationToken = default)
         {
             HttpResponseMessage? response = null;
 
@@ -94,6 +156,14 @@ namespace Microsoft.Teams.AI.AI.OpenAI
                 if (_options.Organization != null)
                 {
                     request.Headers.Add("OpenAI-Organization", _options.Organization);
+                }
+
+                if (additionalHeaders != null)
+                {
+                    foreach (KeyValuePair<string, string> header in additionalHeaders)
+                    {
+                        request.Headers.Add(header.Key, header.Value);
+                    }
                 }
 
                 if (content != null)


### PR DESCRIPTION
## Linked issues

#minor (avoid closing issue)
closes: #798

## Details

Since OpenAI does not officially have .NET SDK, this PR adds OpenAI Assistant and Thread API calls to `OpenAIClient`

#### Change details

- Call OpenAI's Assistant and Thread APIs
- Seperate into partial `OpenAIClient` class
- Only add APIs that will be called in `AssistantPlanner`

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
