### PR TITLE
[C#] refactor: add OpenAIModel

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AddHeaderRequestPolicy.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AddHeaderRequestPolicy.cs
@@ -1,0 +1,25 @@
+﻿using Azure.Core.Pipeline;
+using Azure.Core;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Helper class to inject headers into Azure SDK HTTP pipeline.
+    /// </summary>
+    internal class AddHeaderRequestPolicy : HttpPipelineSynchronousPolicy
+    {
+        private readonly string _headerName;
+        private readonly string _headerValue;
+
+        public AddHeaderRequestPolicy(string headerName, string headerValue)
+        {
+            this._headerName = headerName;
+            this._headerValue = headerValue;
+        }
+
+        public override void OnSendingRequest(HttpMessage message)
+        {
+            message.Request.Headers.Add(this._headerName, this._headerValue);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AddQueryRequestPolicy.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AddQueryRequestPolicy.cs
@@ -1,0 +1,25 @@
+﻿using Azure.Core.Pipeline;
+using Azure.Core;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Helper class to inject query into Azure SDK HTTP pipeline.
+    /// </summary>
+    internal class AddQueryRequestPolicy : HttpPipelineSynchronousPolicy
+    {
+        private readonly string _queryName;
+        private readonly string _queryValue;
+
+        public AddQueryRequestPolicy(string queryName, string queryValue)
+        {
+            this._queryName = queryName;
+            this._queryValue = queryValue;
+        }
+
+        public override void OnSendingRequest(HttpMessage message)
+        {
+            message.Request.Uri.AppendQuery(_queryName, _queryValue);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AzureOpenAIModelOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AzureOpenAIModelOptions.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Teams.AI.Utilities;
+using static Microsoft.Teams.AI.AI.Prompts.PromptTemplate.PromptTemplateConfiguration.CompletionConfiguration;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Options for configuring an `OpenAIModel` to call an Azure OpenAI hosted model.
+    /// </summary>
+    public class AzureOpenAIModelOptions : BaseOpenAIModelOptions
+    {
+        /// <summary>
+        /// API key to use when making requests to Azure OpenAI.
+        /// </summary>
+        public string AzureApiKey { get; set; }
+
+        /// <summary>
+        /// Default name of the Azure OpenAI deployment (model) to use.
+        /// </summary>
+        public string AzureDefaultDeployment { get; set; }
+
+        /// <summary>
+        /// Deployment endpoint to use.
+        /// </summary>
+        public string AzureEndpoint { get; set; }
+
+        /// <summary>
+        /// Version of the API being called.
+        /// </summary>
+        public string AzureApiVersion { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureOpenAIModelOptions"/> class.
+        /// </summary>
+        /// <param name="azureApiKey">API key to use when making requests to Azure OpenAI.</param>
+        /// <param name="azureDefaultDeployment">Default name of the Azure OpenAI deployment (model) to use.</param>
+        /// <param name="azureEndpoint">Deployment endpoint to use.</param>
+        /// <param name="azureApiVersion">Version of the API being called.</param>
+        /// <param name="completionType">Type of completion to use for the default model.</param>
+        /// <param name="logRequests">Whether to log requests to the console.</param>
+        /// <param name="retryPolicy">Retry policy to use when calling the OpenAI API.</param>
+        /// <param name="useSystemMessages"></param>
+        /// <exception cref="ArgumentException"></exception>
+        public AzureOpenAIModelOptions(
+            string azureApiKey,
+            string azureDefaultDeployment,
+            string azureEndpoint,
+            string azureApiVersion = "2023-05-15",
+            CompletionType completionType = CompletionType.Chat,
+            bool logRequests = false,
+            List<int>? retryPolicy = null,
+            bool useSystemMessages = false) : base(completionType, logRequests, retryPolicy, useSystemMessages)
+        {
+            Verify.ParamNotNull(azureApiKey);
+            Verify.ParamNotNull(azureDefaultDeployment);
+            Verify.ParamNotNull(azureEndpoint);
+
+            azureEndpoint = azureEndpoint.Trim();
+            if (!azureEndpoint.StartsWith("https://"))
+            {
+                throw new ArgumentException($"Model created with an invalid endpoint of `{azureEndpoint}`. The endpoint must be a valid HTTPS url.");
+            }
+
+            this.AzureApiKey = azureApiKey;
+            this.AzureDefaultDeployment = azureDefaultDeployment;
+            this.AzureEndpoint = azureEndpoint;
+            this.AzureApiVersion = azureApiVersion;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AzureSdkChatMessageExtensions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/AzureSdkChatMessageExtensions.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="Azure.AI.OpenAI.ChatMessage"/> class.
+    /// </summary>
+    internal static class AzureSdkChatMessageExtensions
+    {
+        /// <summary>
+        /// Converts an <see cref="Azure.AI.OpenAI.ChatMessage"/> to a <see cref="ChatMessage"/>.
+        /// </summary>
+        /// <param name="chatMessage">The original <see cref="Azure.AI.OpenAI.ChatMessage" />.</param>
+        /// <returns>A <see cref="ChatMessage"/>.</returns>
+        public static ChatMessage ToChatMessage(this Azure.AI.OpenAI.ChatMessage chatMessage)
+        {
+            ChatMessage message = new(new ChatRole(chatMessage.Role.ToString()), chatMessage.Content)
+            {
+                Name = chatMessage.Name,
+                FunctionCall = new FunctionCall(chatMessage.FunctionCall.Name, chatMessage.FunctionCall.Arguments)
+            };
+            return message;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/BaseOpenAIModelOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/BaseOpenAIModelOptions.cs
@@ -1,0 +1,61 @@
+﻿using static Microsoft.Teams.AI.AI.Prompts.PromptTemplate.PromptTemplateConfiguration.CompletionConfiguration;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Base model options common to both OpenAI and Azure OpenAI services.
+    /// </summary>
+    public abstract class BaseOpenAIModelOptions
+    {
+        /// <summary>
+        /// Type of completion to use for the default model.
+        /// </summary>
+        public CompletionType CompletionType { get; set; }
+
+        /// <summary>
+        /// Whether to log requests to the console.
+        /// </summary>
+        /// <remarks>
+        /// This is useful for debugging prompts.
+        /// </remarks>
+        public bool LogRequests { get; set; }
+
+        /// <summary>
+        /// Retry policy to use when calling the OpenAI API.
+        /// </summary>
+        /// <remarks>
+        /// The default retry policy is `[2000, 5000]` which means that the first retry will be after
+        /// 2 seconds and the second retry will be after 5 seconds.
+        /// </remarks>
+        public List<int> RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Whether to use `system` messages when calling the OpenAI API.
+        /// </summary>
+        /// <remarks>
+        /// The current generation of models tend to follow instructions from `user` messages better
+        /// then `system` messages so the default is `false`, which causes any `system` message in the
+        /// prompt to be sent as `user` messages instead.
+        /// </remarks>
+        public bool UseSystemMessages { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseOpenAIModelOptions"/> class.
+        /// </summary>
+        /// <param name="completionType">Type of completion to use for the default model.</param>
+        /// <param name="logRequests">Whether to log requests to the console.</param>
+        /// <param name="retryPolicy">Retry policy to use when calling the OpenAI API.</param>
+        /// <param name="useSystemMessages"></param>
+        protected BaseOpenAIModelOptions(
+            CompletionType completionType = CompletionType.Chat,
+            bool logRequests = false,
+            List<int>? retryPolicy = null,
+            bool useSystemMessages = false)
+        {
+            this.CompletionType = completionType;
+            this.LogRequests = logRequests;
+            this.RetryPolicy = retryPolicy ?? new List<int> { 2000, 5000 };
+            this.UseSystemMessages = useSystemMessages;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/ChatMessageExtensions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/ChatMessageExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="ChatMessage"/> class.
+    /// </summary>
+    internal static class ChatMessageExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="ChatMessage"/> to an <see cref="Azure.AI.OpenAI.ChatMessage"/>.
+        /// </summary>
+        /// <param name="chatMessage">The original <see cref="ChatMessage" />.</param>
+        /// <returns>An <see cref="Azure.AI.OpenAI.ChatMessage"/>.</returns>
+        public static Azure.AI.OpenAI.ChatMessage ToAzureSdkChatMessage(this ChatMessage chatMessage)
+        {
+            Azure.AI.OpenAI.ChatMessage message = new(new Azure.AI.OpenAI.ChatRole(chatMessage.Role.ToString()), chatMessage.Content)
+            {
+                Name = chatMessage.Name,
+            };
+            if (chatMessage.FunctionCall != null)
+            {
+                message.FunctionCall = new Azure.AI.OpenAI.FunctionCall(chatMessage.FunctionCall.Name, chatMessage.FunctionCall.Arguments);
+            }
+            return message;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/ConfiguredDelayStrategy.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/ConfiguredDelayStrategy.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Teams.AI.AI.Models
         protected override TimeSpan GetNextDelayCore(Response? response, int retryNumber)
         {
             int sum = 0;
-            for (int i = 0; i < _delays.Count; i++)
+            for (int i = 0; i < retryNumber; i++)
             {
                 sum += _delays[i];
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/ConfiguredDelayStrategy.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/ConfiguredDelayStrategy.cs
@@ -1,0 +1,28 @@
+﻿using Azure;
+using Azure.Core;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// A configured delay strategy to support the `RetryPolicy` defined in <see cref="BaseOpenAIModelOptions"/>.
+    /// </summary>
+    internal class ConfiguredDelayStrategy : DelayStrategy
+    {
+        private List<int> _delays;
+
+        public ConfiguredDelayStrategy(List<int> delays)
+        {
+            this._delays = delays;
+        }
+
+        protected override TimeSpan GetNextDelayCore(Response? response, int retryNumber)
+        {
+            int sum = 0;
+            for (int i = 0; i < _delays.Count; i++)
+            {
+                sum += _delays[i];
+            }
+            return Max(TimeSpan.Zero, TimeSpan.FromMilliseconds(_delays[retryNumber] - sum));
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/IPromptCompletionModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/IPromptCompletionModel.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Teams.AI.Memory;
+using Microsoft.Teams.AI.AI.Prompts;
+using Microsoft.Teams.AI.AI.Tokenizers;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// An AI model that can be used to complete prompts.
+    /// </summary>
+    public interface IPromptCompletionModel
+    {
+        /// <summary>
+        /// Completes a prompt.
+        /// </summary>
+        /// <param name="turnContext">Current turn context.</param>
+        /// <param name="memory">An interface for accessing state values.</param>
+        /// <param name="promptFunctions">Functions to use when rendering the prompt.</param>
+        /// <param name="tokenizer">Tokenizer to use when rendering the prompt.</param>
+        /// <param name="promptTemplate">Prompt template to complete.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A `PromptResponse` with the status and message.</returns>
+        Task<PromptResponse> CompletePromptAsync(
+            ITurnContext turnContext,
+            IMemory memory,
+            IPromptFunctions<List<string>> promptFunctions,
+            ITokenizer tokenizer,
+            PromptTemplate promptTemplate,
+            CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
@@ -1,0 +1,254 @@
+﻿using Azure;
+using Azure.AI.OpenAI;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Teams.AI.AI.Prompts;
+using Microsoft.Teams.AI.AI.Prompts.Sections;
+using Microsoft.Teams.AI.AI.Tokenizers;
+using Microsoft.Teams.AI.Exceptions;
+using Microsoft.Teams.AI.Memory;
+using System.Net;
+using System.Text.Json;
+using static Microsoft.Teams.AI.AI.Prompts.PromptTemplate.PromptTemplateConfiguration.CompletionConfiguration;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// A `PromptCompletionModel` for calling OpenAI and Azure OpenAI hosted models.
+    /// </summary>
+    public class OpenAIModel : IPromptCompletionModel
+    {
+        private readonly BaseOpenAIModelOptions _options;
+        private readonly ILogger _logger;
+        private readonly HttpClient? _httpClient;
+
+        private bool _useAzure;
+        private readonly OpenAIClient _openAIClient;
+        private string _deploymentName;
+
+        private static readonly string _userAgent = "AlphaWave";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenAIModel"/> class.
+        /// </summary>
+        /// <param name="options">Options for configuring `OpenAIModel`.</param>
+        /// <param name="loggerFactory">The logger factory instance.</param>
+        /// <param name="httpClient">HTTP client.</param>
+        public OpenAIModel(BaseOpenAIModelOptions options, ILoggerFactory? loggerFactory = null, HttpClient? httpClient = null)
+        {
+            _options = options;
+            _logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger<OpenAIModel>();
+            _httpClient = httpClient;
+
+            _useAzure = options is AzureOpenAIModelOptions;
+            OpenAIClientOptions openAIClientOptions = new()
+            {
+                RetryPolicy = new RetryPolicy(_options.RetryPolicy.Count, new ConfiguredDelayStrategy(_options.RetryPolicy))
+            };
+            openAIClientOptions.AddPolicy(new AddHeaderRequestPolicy("User-Agent", _userAgent), HttpPipelinePosition.PerCall);
+            if (_httpClient != null)
+            {
+                openAIClientOptions.Transport = new HttpClientTransport(_httpClient);
+            }
+
+            if (_useAzure)
+            {
+                AzureOpenAIModelOptions azureOpenAIModelOptions = (AzureOpenAIModelOptions)options;
+                openAIClientOptions.AddPolicy(new AddQueryRequestPolicy("api-version", azureOpenAIModelOptions.AzureApiVersion), HttpPipelinePosition.PerCall);
+                _openAIClient = new OpenAIClient(new Uri(azureOpenAIModelOptions.AzureEndpoint), new AzureKeyCredential(azureOpenAIModelOptions.AzureApiKey), openAIClientOptions);
+                _deploymentName = azureOpenAIModelOptions.AzureDefaultDeployment;
+            }
+            else
+            {
+                OpenAIModelOptions openAIModelOptions = (OpenAIModelOptions)options;
+                if (!string.IsNullOrEmpty(openAIModelOptions.Organization))
+                {
+                    openAIClientOptions.AddPolicy(new AddHeaderRequestPolicy("OpenAI-Organization", openAIModelOptions.Organization!), HttpPipelinePosition.PerCall);
+                }
+                _openAIClient = new OpenAIClient(openAIModelOptions.ApiKey, openAIClientOptions);
+                _deploymentName = openAIModelOptions.DefaultModel;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<PromptResponse> CompletePromptAsync(ITurnContext turnContext, IMemory memory, IPromptFunctions<List<string>> promptFunctions, ITokenizer tokenizer, PromptTemplate promptTemplate, CancellationToken cancellationToken = default)
+        {
+            DateTime startTime = DateTime.UtcNow;
+            int maxInputTokens = promptTemplate.Configuration.Completion.MaxInputTokens;
+            if (_options.CompletionType == CompletionType.Text)
+            {
+                // Render prompt
+                RenderedPromptSection<string> prompt = await promptTemplate.Prompt.RenderAsTextAsync(turnContext, memory, promptFunctions, tokenizer, maxInputTokens);
+                if (prompt.TooLong)
+                {
+                    return new PromptResponse
+                    {
+                        Status = PromptResponseStatus.TooLong,
+                        Error = new Error
+                        {
+                            Message = $"The generated text completion prompt had a length of {prompt.Length} tokens which exceeded the MaxInputTokens of {maxInputTokens}."
+                        }
+                    };
+                }
+                if (_options.LogRequests)
+                {
+                    // TODO: Colorize
+                    _logger.LogTrace("PROMPT:");
+                    _logger.LogTrace(prompt.Output);
+                }
+
+                CompletionsOptions completionsOptions = new(_deploymentName, new List<string> { prompt.Output })
+                {
+                    MaxTokens = maxInputTokens,
+                    Temperature = (float)promptTemplate.Configuration.Completion.Temperature,
+                    NucleusSamplingFactor = (float)promptTemplate.Configuration.Completion.TopP,
+                    PresencePenalty = (float)promptTemplate.Configuration.Completion.PresencePenalty,
+                    FrequencyPenalty = (float)promptTemplate.Configuration.Completion.FrequencyPenalty,
+                };
+
+                Response? rawResponse;
+                Response<Completions>? completionsResponse = null;
+                PromptResponse promptResponse = new();
+                try
+                {
+                    completionsResponse = await _openAIClient.GetCompletionsAsync(completionsOptions, cancellationToken);
+                    rawResponse = completionsResponse.GetRawResponse();
+                    promptResponse.Status = PromptResponseStatus.Success;
+                    promptResponse.Message = new ChatMessage(ChatRole.Assistant, completionsResponse.Value.Choices[0].Text);
+                }
+                catch (RequestFailedException e)
+                {
+                    rawResponse = e.GetRawResponse();
+                    HttpOperationException httpOperationException = e.ToHttpOperationException();
+                    if (httpOperationException.StatusCode == (HttpStatusCode)429)
+                    {
+                        promptResponse.Status = PromptResponseStatus.RateLimited;
+                        promptResponse.Error = new Error
+                        {
+                            Message = "The text completion API returned a rate limit error."
+                        };
+                    }
+                    else
+                    {
+                        promptResponse.Status = PromptResponseStatus.Error;
+                        promptResponse.Error = new Error
+                        {
+                            Message = $"The text completion API returned an error status of {httpOperationException.StatusCode}: {httpOperationException.Message}"
+                        };
+                    }
+                }
+
+                if (_options.LogRequests)
+                {
+                    // TODO: Colorize
+                    _logger.LogTrace("RESPONSE:");
+                    _logger.LogTrace($"status {rawResponse!.Status}");
+                    _logger.LogTrace($"duration {(DateTime.UtcNow - startTime).TotalMilliseconds} ms");
+                    if (promptResponse.Status == PromptResponseStatus.Success)
+                    {
+                        _logger.LogTrace(JsonSerializer.Serialize(completionsResponse!.Value));
+                    }
+                    if (promptResponse.Status == PromptResponseStatus.RateLimited)
+                    {
+                        _logger.LogTrace("HEADERS:");
+                        _logger.LogTrace(JsonSerializer.Serialize(rawResponse.Headers));
+                    }
+                }
+
+                return promptResponse;
+            }
+            else
+            {
+                // Render prompt
+                RenderedPromptSection<List<ChatMessage>> prompt = await promptTemplate.Prompt.RenderAsMessagesAsync(turnContext, memory, promptFunctions, tokenizer, maxInputTokens);
+                if (prompt.TooLong)
+                {
+                    return new PromptResponse
+                    {
+                        Status = PromptResponseStatus.TooLong,
+                        Error = new Error
+                        {
+                            Message = $"The generated chat completion prompt had a length of {prompt.Length} tokens which exceeded the MaxInputTokens of {maxInputTokens}."
+                        }
+                    };
+                }
+                if (!_options.UseSystemMessages && prompt.Output.Count > 0 && prompt.Output[0].Role == ChatRole.System)
+                {
+                    prompt.Output[0].Role = ChatRole.User;
+                }
+                if (_options.LogRequests)
+                {
+                    // TODO: Colorize
+                    _logger.LogTrace("CHAT PROMPT:");
+                    _logger.LogTrace(JsonSerializer.Serialize(prompt.Output));
+                }
+
+                // Call chat completion API
+                IEnumerable<Azure.AI.OpenAI.ChatMessage> chatMessages = prompt.Output.Select(chatMessage => chatMessage.ToAzureSdkChatMessage());
+                ChatCompletionsOptions chatCompletionsOptions = new(_deploymentName, chatMessages)
+                {
+                    MaxTokens = maxInputTokens,
+                    Temperature = (float)promptTemplate.Configuration.Completion.Temperature,
+                    NucleusSamplingFactor = (float)promptTemplate.Configuration.Completion.TopP,
+                    PresencePenalty = (float)promptTemplate.Configuration.Completion.PresencePenalty,
+                    FrequencyPenalty = (float)promptTemplate.Configuration.Completion.FrequencyPenalty,
+                };
+
+                Response? rawResponse;
+                Response<ChatCompletions>? chatCompletionsResponse = null;
+                PromptResponse promptResponse = new();
+                try
+                {
+                    chatCompletionsResponse = await _openAIClient.GetChatCompletionsAsync(chatCompletionsOptions, cancellationToken);
+                    rawResponse = chatCompletionsResponse.GetRawResponse();
+                    promptResponse.Status = PromptResponseStatus.Success;
+                    promptResponse.Message = chatCompletionsResponse.Value.Choices[0].Message.ToChatMessage();
+                }
+                catch (RequestFailedException e)
+                {
+                    rawResponse = e.GetRawResponse();
+                    HttpOperationException httpOperationException = e.ToHttpOperationException();
+                    if (httpOperationException.StatusCode == (HttpStatusCode)429)
+                    {
+                        promptResponse.Status = PromptResponseStatus.RateLimited;
+                        promptResponse.Error = new Error
+                        {
+                            Message = "The chat completion API returned a rate limit error."
+                        };
+                    }
+                    else
+                    {
+                        promptResponse.Status = PromptResponseStatus.Error;
+                        promptResponse.Error = new Error
+                        {
+                            Message = $"The chat completion API returned an error status of {httpOperationException.StatusCode}: {httpOperationException.Message}"
+                        };
+                    }
+                }
+
+                if (_options.LogRequests)
+                {
+                    // TODO: Colorize
+                    _logger.LogTrace("RESPONSE:");
+                    _logger.LogTrace($"status {rawResponse!.Status}");
+                    _logger.LogTrace($"duration {(DateTime.UtcNow - startTime).TotalMilliseconds} ms");
+                    if (promptResponse.Status == PromptResponseStatus.Success)
+                    {
+                        _logger.LogTrace(JsonSerializer.Serialize(chatCompletionsResponse!.Value));
+                    }
+                    if (promptResponse.Status == PromptResponseStatus.RateLimited)
+                    {
+                        _logger.LogTrace("HEADERS:");
+                        _logger.LogTrace(JsonSerializer.Serialize(rawResponse.Headers));
+                    }
+                }
+
+                return promptResponse;
+            }
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModelOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModelOptions.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.Teams.AI.Utilities;
+using static Microsoft.Teams.AI.AI.Prompts.PromptTemplate.PromptTemplateConfiguration.CompletionConfiguration;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Options for configuring an `OpenAIModel` to call an OpenAI hosted model.
+    /// </summary>
+    public class OpenAIModelOptions : BaseOpenAIModelOptions
+    {
+        /// <summary>
+        /// API key to use when calling the OpenAI API.
+        /// </summary>
+        /// <remarks>
+        /// A new API key can be created at https://platform.openai.com/account/api-keys.
+        /// </remarks>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Default model to use for completion.
+        /// </summary>
+        /// <remarks>
+        /// For Azure OpenAI this is the name of the deployment to use.
+        /// </remarks>
+        public string DefaultModel { get; set; }
+
+        /// <summary>
+        /// Optional. Organization to use when calling the OpenAI API.
+        /// </summary>
+        public string? Organization { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenAIModelOptions"/> class.
+        /// </summary>
+        /// <param name="apiKey">API key to use when calling the OpenAI API.</param>
+        /// <param name="defaultModel">Default model to use for completion.</param>
+        /// <param name="organization">Organization to use when calling the OpenAI API.</param>
+        /// <param name="completionType">Type of completion to use for the default model.</param>
+        /// <param name="logRequests">Whether to log requests to the console.</param>
+        /// <param name="retryPolicy">Retry policy to use when calling the OpenAI API.</param>
+        /// <param name="useSystemMessages"></param>
+        public OpenAIModelOptions(
+            string apiKey,
+            string defaultModel,
+            string? organization = null,
+            CompletionType completionType = CompletionType.Chat,
+            bool logRequests = false,
+            List<int>? retryPolicy = null,
+            bool useSystemMessages = false) : base(completionType, logRequests, retryPolicy, useSystemMessages)
+        {
+            Verify.ParamNotNull(apiKey);
+            Verify.ParamNotNull(defaultModel);
+
+            this.ApiKey = apiKey;
+            this.DefaultModel = defaultModel;
+            this.Organization = organization;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/RequestFailedExceptionExtensions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/RequestFailedExceptionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Azure;
+using Microsoft.Teams.AI.Exceptions;
+using System.Net;
+
+namespace Microsoft.Teams.AI.AI.Models
+{
+    /// <summary>
+    /// Provides extension methods for the <see cref="RequestFailedException"/> class.
+    /// </summary>
+    internal static class RequestFailedExceptionExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="RequestFailedException"/> to an <see cref="HttpOperationException"/>.
+        /// </summary>
+        /// <param name="exception">The original <see cref="RequestFailedException"/>.</param>
+        /// <returns>An <see cref="HttpOperationException"/> instance.</returns>
+        public static HttpOperationException ToHttpOperationException(this RequestFailedException exception)
+        {
+            string? responseContent = null;
+
+            try
+            {
+                responseContent = exception.GetRawResponse()?.Content?.ToString();
+            }
+            catch { }
+
+            return new HttpOperationException(exception.Message, (HttpStatusCode)exception.Status, responseContent);
+        }
+    }
+}


### PR DESCRIPTION
## Linked issues

closes: #723 

## Details

#### Change details

- BaseOpenAIModelOptions
- OpenAIModelOptions
- AzureOpenAIModelOptions
- IPromptCompletionModel
- OpenAIModel

Followings are different from JS part:
- use Azure.AI.OpenAI instead of http requests
- remove requestConfig from BaseOpenAIModelOptions, but instead pass HttpClient in OpenAIModel constructor
- remove endpoint from OpenAIModelOptions because it is not supported by Azure.AI.OpenAI

TODOs in PRs afterwards:
- support logging colorized contents
- unit test

## Attestation Checklist

- [ ] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
