### PR TITLE
[JS] feat: add jsdoc for authentication code

### DIFF
--- a/js/packages/teams-ai/src/authentication/AdaptiveCardAuthenticationBase.ts
+++ b/js/packages/teams-ai/src/authentication/AdaptiveCardAuthenticationBase.ts
@@ -26,8 +26,16 @@ export interface AdaptiveCardLoginRequest {
 
 /**
  * @internal
+ * 
+ * Base class to handle adaptive card authentication.
  */
 export abstract class AdaptiveCardAuthenticationBase {
+
+    /**
+     * Authenticates the user.
+     * @param {TurnContext} context - The turn context.
+     * @returns {Promise<string | undefined>} - The authentication token, or undefined if authentication failed. Teams will ask user to sign-in if authentication failed.
+     */
     public async authenticate(context: TurnContext): Promise<string | undefined> {
         const value = context.activity.value;
         
@@ -90,15 +98,36 @@ export abstract class AdaptiveCardAuthenticationBase {
         return;
     }
 
+    /**
+     * Checks if the activity is a valid Adaptive Card activity that supports authentication.
+     * @param context - The turn context.
+     * @returns A boolean indicating if the activity is valid.
+     */
     public isValidActivity(context: TurnContext): boolean {
         return context.activity.type == ActivityTypes.Invoke && context.activity.name == ACTION_INVOKE_NAME;
     }
 
+    /**
+     * Handles the SSO token exchange.
+     * @param context - The turn context.
+     * @returns A promise that resolves to the token response or undefined if token exchange failed.
+     */
     public abstract handleSsoTokenExchange(
         context: TurnContext
     ): Promise<TokenResponse | undefined>
 
+    /**
+     * Handles the user sign-in.
+     * @param context - The turn context.
+     * @param magicCode - The magic code from user sign-in.
+     * @returns A promise that resolves to the token response or undefined if failed to verify the magic code.
+     */
     public abstract handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined>
 
+    /**
+     * Gets the login request for Adaptive Card authentication.
+     * @param context - The turn context.
+     * @returns A promise that resolves to the login request.
+     */
     public abstract getLoginRequest(context: TurnContext): Promise<AdaptiveCardLoginRequest>
 }

--- a/js/packages/teams-ai/src/authentication/Authentication.ts
+++ b/js/packages/teams-ai/src/authentication/Authentication.ts
@@ -16,7 +16,7 @@ import { MessageExtensionAuthenticationBase } from './MessageExtensionAuthentica
 import { BotAuthenticationBase, deleteTokenFromState, setTokenInState } from './BotAuthenticationBase';
 import * as UserTokenAccess from './UserTokenAccess';
 import { AdaptiveCardAuthenticationBase } from './AdaptiveCardAuthenticationBase';
-import { TeamsSsoSettings } from './TeamsBotSsoPrompt';
+import { TeamsSsoSettings } from './TeamsSsoSettings';
 import { OAuthPromptMessageExtensionAuthentication } from './OAuthMessageExtensionAuthentication';
 import { OAuthBotAuthentication } from './OAuthBotAuthentication';
 import { TeamsSsoBotAuthentication } from './TeamsSsoBotAuthentication';

--- a/js/packages/teams-ai/src/authentication/MessageExtensionAuthenticationBase.ts
+++ b/js/packages/teams-ai/src/authentication/MessageExtensionAuthenticationBase.ts
@@ -3,8 +3,15 @@ import { MessageExtensionsInvokeNames } from '../MessageExtensions';
 
 /**
  * @internal
+ * Base class to handle authentication for Teams Message Extension.
  */
 export abstract class MessageExtensionAuthenticationBase {
+
+    /**
+     * Authenticates the user.
+     * @param {TurnContext} context - The turn context.
+     * @returns {Promise<string | undefined>} - The authentication token, or undefined if authentication failed. Teams will ask user to sign-in if authentication failed.
+     */
     public async authenticate(context: TurnContext): Promise<string | undefined> {
         const value = context.activity.value;
         const tokenExchangeRequest = value.authentication;
@@ -75,6 +82,11 @@ export abstract class MessageExtensionAuthenticationBase {
         return;
     }
 
+    /**
+     * Checks if the activity is a valid Message Extension activity that supports authentication.
+     * @param {TurnContext} context - The turn context.
+     * @returns {boolean} - A boolean indicating if the activity is valid.
+     */
     public isValidActivity(context: TurnContext): boolean {
         return (
             context.activity.type == ActivityTypes.Invoke &&
@@ -85,11 +97,27 @@ export abstract class MessageExtensionAuthenticationBase {
         );
     }
 
+    /**
+     * Handles the SSO token exchange.
+     * @param {TurnContext} context - The turn context.
+     * @returns {Promise<TokenResponse | undefined>} - A promise that resolves to the token response or undefined if token exchange failed.
+     */
     public abstract handleSsoTokenExchange(
         context: TurnContext
     ): Promise<TokenResponse | undefined>
 
+    /**
+     * Handles the user sign-in.
+     * @param {TurnContext} context - The turn context.
+     * @param {string} magicCode - The magic code from user sign-in.
+     * @returns {Promise<TokenResponse | undefined>} - A promise that resolves to the token response or undefined if failed to verify the magic code.
+     */
     public abstract handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined>
 
+    /**
+     * Gets the sign-in link for the user.
+     * @param {TurnContext} context - The turn context.
+     * @returns {Promise<string | undefined>} - A promise that resolves to the sign-in link or undefined if no sign-in link available.
+     */
     public abstract getSignInLink(context: TurnContext): Promise<string | undefined>
 }

--- a/js/packages/teams-ai/src/authentication/OAuthAdaptiveCardAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthAdaptiveCardAuthentication.ts
@@ -6,11 +6,26 @@ import { AdaptiveCardAuthenticationBase, AdaptiveCardLoginRequest } from './Adap
 import { AuthError, OAuthSettings } from './Authentication';
 import * as UserTokenAccess from './UserTokenAccess';
 
+/**
+ * @internal
+ * 
+ * Handles authentication for Adaptive Cards in Teams.
+ */
 export class OAuthAdaptiveCardAuthentication extends AdaptiveCardAuthenticationBase {
+
+    /**
+     * Creates a new instance of OAuthAdaptiveCardAuthentication.
+     * @param settings The OAuthSettings.
+     */
     public constructor(private readonly settings: OAuthSettings) {
         super();
     }
 
+    /**
+     * Handles the SSO token exchange.
+     * @param context The turn context.
+     * @returns A promise that resolves to the token response or undefined if token exchange failed.
+     */
     public async handleSsoTokenExchange(context: TurnContext): Promise<TokenResponse | undefined> {
         const tokenExchangeRequest = context.activity.value.authentication;
 
@@ -21,10 +36,21 @@ export class OAuthAdaptiveCardAuthentication extends AdaptiveCardAuthenticationB
         return await UserTokenAccess.exchangeToken(context, this.settings, tokenExchangeRequest);
     }
 
+    /**
+     * Handles the signin/verifyState activity.
+     * @param context The turn context.
+     * @param magicCode The magic code from sign-in.
+     * @returns A promise that resolves to undefined. The parent class will trigger silentAuth again.
+     */
     public async handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined> {
         return await UserTokenAccess.getUserToken(context, this.settings, magicCode);
     }
 
+    /**
+     * Gets the sign-in link for the user.
+     * @param context The turn context.
+     * @returns A promise that resolves to the sign-in link or undefined if no sign-in link available.
+     */
     public async getLoginRequest(context: TurnContext): Promise<AdaptiveCardLoginRequest> {
         const signInResource = await UserTokenAccess.getSignInResource(context, this.settings);
         const signInLink = signInResource.signInLink;

--- a/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.ts
@@ -16,9 +16,22 @@ import { Application } from '../Application';
 import { TurnState } from '../TurnState';
 import { TurnStateProperty } from '../TurnStateProperty';
 
+/**
+ * @internal
+ * 
+ * Handles authentication for Teams bots.
+ * @template TState - The type of the turn state object.
+ */
 export class OAuthBotAuthentication<TState extends TurnState> extends BotAuthenticationBase<TState> {
     private _oauthPrompt: OAuthPrompt;
 
+    /**
+     * Initializes a new instance of the OAuthBotAuthentication class.
+     * @param app - The application object.
+     * @param oauthPromptSettings - The settings for OAuthPrompt.
+     * @param settingName - The name of the setting.
+     * @param storage - The storage object for storing state.
+     */
     public constructor(
         app: Application<TState>,
         oauthPromptSettings: OAuthPromptSettings, // Child classes will have different types for this
@@ -34,6 +47,13 @@ export class OAuthBotAuthentication<TState extends TurnState> extends BotAuthent
         app.adapter.use(new FilteredTeamsSSOTokenExchangeMiddleware(this._storage, oauthPromptSettings.connectionName));
     }
 
+    /**
+     * Run or continue the OAuthPrompt dialog and returns the result.
+     * @param context - The turn context object.
+     * @param state - The turn state object.
+     * @param dialogStateProperty - The name of the dialog state property.
+     * @returns A promise that resolves to the dialog turn result containing the token response.
+     */
     public async runDialog(
         context: TurnContext,
         state: TState,
@@ -47,6 +67,14 @@ export class OAuthBotAuthentication<TState extends TurnState> extends BotAuthent
         return results;
     }
 
+    
+    /**
+     * Continue the OAuthPrompt dialog and returns the result.
+     * @param context - The turn context object.
+     * @param state - The turn state object.
+     * @param dialogStateProperty - The name of the dialog state property.
+     * @returns A promise that resolves to the dialog turn result containing the token response.
+     */
     public async continueDialog(
         context: TurnContext,
         state: TState,
@@ -56,6 +84,13 @@ export class OAuthBotAuthentication<TState extends TurnState> extends BotAuthent
         return await dialogContext.continueDialog();
     }
 
+    /**
+     * Creates a new DialogContext for OAuthPrompt.
+     * @param context - The turn context object.
+     * @param state - The turn state object.
+     * @param dialogStateProperty - The name of the dialog state property.
+     * @returns A promise that resolves to the dialog context.
+     */
     private async createDialogContext(
         context: TurnContext,
         state: TState,

--- a/js/packages/teams-ai/src/authentication/OAuthMessageExtensionAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthMessageExtensionAuthentication.ts
@@ -6,11 +6,26 @@ import { OAuthPromptSettings } from 'botbuilder-dialogs';
 import { MessageExtensionAuthenticationBase } from './MessageExtensionAuthenticationBase';
 import * as UserTokenAccess from './UserTokenAccess';
 
+/**
+ * @internal
+ * 
+ * Handles authentication for Teams Message Extension.
+ */
 export class OAuthPromptMessageExtensionAuthentication extends MessageExtensionAuthenticationBase {
+
+    /**
+     * Creates a new instance of OAuthPromptMessageExtensionAuthentication.
+     * @param settings The OAuthPromptSettings.
+     */
     public constructor(private readonly settings: OAuthPromptSettings) {
         super();
     }
 
+    /**
+     * Handles the SSO token exchange.
+     * @param context The turn context.
+     * @returns A promise that resolves to the token response or undefined if token exchange failed.
+     */
     public async handleSsoTokenExchange(context: TurnContext): Promise<TokenResponse | undefined> {
         const tokenExchangeRequest = context.activity.value.authentication;
 
@@ -21,10 +36,21 @@ export class OAuthPromptMessageExtensionAuthentication extends MessageExtensionA
         return await UserTokenAccess.exchangeToken(context, this.settings, tokenExchangeRequest);
     }
 
+    /**
+     * Handles the signin/verifyState activity.
+     * @param context The turn context.
+     * @param magicCode The magic code from sign-in.
+     * @returns A promise that resolves to undefined. The parent class will trigger silentAuth again.
+     */
     public async handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined> {
         return await UserTokenAccess.getUserToken(context, this.settings, magicCode);
     }
 
+    /**
+     * Gets the sign-in link for the user.
+     * @param context The turn context.
+     * @returns A promise that resolves to the sign-in link or undefined if no sign-in link available.
+     */
     public async getSignInLink(context: TurnContext): Promise<string | undefined> {
         const signInResource = await UserTokenAccess.getSignInResource(context, this.settings);
         return signInResource.signInLink;

--- a/js/packages/teams-ai/src/authentication/TeamsSsoAdaptiveCardAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoAdaptiveCardAuthentication.ts
@@ -5,23 +5,48 @@ import { TurnContext } from "botbuilder-core";
 import { TokenResponse } from "botframework-schema";
 import { AdaptiveCardAuthenticationBase, AdaptiveCardLoginRequest } from "./AdaptiveCardAuthenticationBase";
 
+/**
+ * @internal
+ * 
+ * Handles authentication using Teams SSO for Adaptive Cards in Teams.
+ */
 export class TeamsSsoAdaptiveCardAuthentication extends AdaptiveCardAuthenticationBase {
+    /**
+     * Initializes a new instance of the TeamsSsoAdaptiveCardAuthentication class.
+     */
     public constructor() {
         super();
     }
 
+    /**
+     * Handles the SSO token exchange.
+     */
     public async handleSsoTokenExchange(): Promise<never> {
         throw new Error('Not implemented');
     }
     
+    /**
+     * Handles the user sign-in.
+     * @param context - The turn context.
+     * @param magicCode - The magic code from user sign-in.
+     */
     public async handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined> {
         throw new Error('Not implemented');
     }
 
+    /**
+     * Gets the login request for Adaptive Card authentication.
+     * @param context - The turn context.
+     */
     public async getLoginRequest(context: TurnContext): Promise<AdaptiveCardLoginRequest> {
         throw new Error('Not implemented');
     }
 
+    /**
+     * Checks if the activity is valid for Adaptive Card authentication.
+     * @param context - The turn context.
+     * @returns A boolean indicating if the activity is valid.
+     */
     public override isValidActivity(context: TurnContext): boolean {
         if (super.isValidActivity(context)) {
             console.warn("TeamsSsoSetting does not support Adaptive Card authentication yet. Please use OAuthSetting instead.")

--- a/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.spec.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.spec.ts
@@ -5,7 +5,8 @@ import { Activity, MemoryStorage, TestAdapter, TurnContext } from "botbuilder"
 import * as sinon from 'sinon';
 import assert from 'assert';
 import { Application, RouteSelector } from "../Application";
-import { TeamsSsoPrompt, TeamsSsoSettings } from "./TeamsBotSsoPrompt";
+import { TeamsSsoPrompt } from "./TeamsBotSsoPrompt";
+import { TeamsSsoSettings } from "./TeamsSsoSettings";
 import { TurnState } from "../TurnState";
 import { TeamsSsoBotAuthentication } from "./TeamsSsoBotAuthentication";
 import { ConfidentialClientApplication } from "@azure/msal-node";

--- a/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.ts
@@ -6,27 +6,43 @@ import { Dialog, DialogContext, DialogTurnStatus } from "botbuilder-dialogs";
 import { Application } from "../Application";
 import { TurnState } from "../TurnState";
 import { BotAuthenticationBase } from "./BotAuthenticationBase";
-import { TeamsSsoPrompt, TeamsSsoSettings } from "./TeamsBotSsoPrompt";
+import { TeamsSsoPrompt } from "./TeamsBotSsoPrompt";
 import { DialogSet, DialogState, DialogTurnResult, WaterfallDialog } from "botbuilder-dialogs";
 import { TurnStateProperty } from "../TurnStateProperty";
 import { ConfidentialClientApplication } from "@azure/msal-node";
+import { TeamsSsoSettings } from "./TeamsSsoSettings";
 
 const SSO_DIALOG_ID = "_TeamsSsoDialog";
 
+
+/**
+ * @internal
+ * 
+ * Handles authentication for Teams bots using Single Sign-On (SSO).
+ * @template TState - The type of the turn state object.
+ */
 export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuthenticationBase<TState> {
     private _prompt: TeamsSsoPrompt;
     private _tokenExchangeIdRegex: RegExp;
 
+    /**
+     * Initializes a new instance of the TeamsSsoBotAuthentication class.
+     * @param app - The application object.
+     * @param settings - The settings for Teams SSO.
+     * @param settingName - The name of the setting.
+     * @param msal - The MSAL (Microsoft Authentication Library) object.
+     * @param storage - The storage object for storing state.
+     */
     public constructor(
         app: Application<TState>,
-        promptSettings: TeamsSsoSettings, // Child classes will have different types for this
+        settings: TeamsSsoSettings,
         settingName: string,
         msal: ConfidentialClientApplication,
         storage?: Storage
     ) {
         super(app, settingName, storage);
 
-        this._prompt = new TeamsSsoPrompt('TeamsSsoPrompt', settingName, promptSettings, msal);
+        this._prompt = new TeamsSsoPrompt('TeamsSsoPrompt', settingName, settings, msal);
         this._tokenExchangeIdRegex = new RegExp(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-${this._settingName}`);
 
         // Do not save state for duplicate token exchange events to avoid eTag conflicts
@@ -35,6 +51,13 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
         });
     }
 
+    /**
+     * Run or continue the SSO dialog and returns the result.
+     * @param context - The turn context object.
+     * @param state - The turn state object.
+     * @param dialogStateProperty - The name of the dialog state property.
+     * @returns A promise that resolves to the dialog turn result containing the token response.
+     */
     public async runDialog(context: TurnContext, state: TState, dialogStateProperty: string): Promise<DialogTurnResult<TokenResponse>> {
         const dialogContext = await this.createSsoDialogContext(context, state, dialogStateProperty);
         let results = await dialogContext.continueDialog();
@@ -44,15 +67,34 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
         return results;
     }
 
+    /**
+     * Continues the SSO dialog and returns the result.
+     * @param context - The turn context object.
+     * @param state - The turn state object.
+     * @param dialogStateProperty - The name of the dialog state property.
+     * @returns A promise that resolves to the dialog turn result containing the token response.
+     */
     public async continueDialog(context: TurnContext, state: TState, dialogStateProperty: string): Promise<DialogTurnResult<TokenResponse>> {
         const dialogContext = await this.createSsoDialogContext(context, state, dialogStateProperty);
         return await dialogContext.continueDialog();
     }
 
+    /**
+     * Determines whether the token exchange activity should be processed by current authentication setting.
+     * @param context - The turn context object.
+     * @returns A promise that resolves to a boolean indicating whether the token exchange route should be processed by current class instance.
+     */
     protected async tokenExchangeRouteSelector(context: TurnContext): Promise<boolean> {
         return await super.tokenExchangeRouteSelector(context) && this._tokenExchangeIdRegex.test(context.activity.value.id);
     }
 
+    /**
+     * Creates the SSO dialog context.
+     * @param context - The turn context object.
+     * @param state - The turn state object.
+     * @param dialogStateProperty - The name of the dialog state property.
+     * @returns A promise that resolves to the dialog context object.
+     */
     private async createSsoDialogContext(context: TurnContext, state: TState, dialogStateProperty: string): Promise<DialogContext> {
         const accessor = new TurnStateProperty<DialogState>(state, 'conversation', dialogStateProperty);
         const dialogSet = new DialogSet(accessor);
@@ -74,6 +116,11 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
         return await dialogSet.createContext(context);
     }
 
+    /**
+     * Checks if deduplication should be performed for token exchange.
+     * @param context - The turn context object.
+     * @returns A promise that resolves to a boolean indicating whether deduplication should be performed.
+     */
     private async shouldDedup(context: TurnContext): Promise<boolean> {
         const storeItem = {
             eTag: context.activity.value.id,
@@ -93,6 +140,12 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
         return false;
     }
 
+    /**
+     * Gets the storage key for storing the token exchange state.
+     * @param context - The turn context object.
+     * @returns The storage key.
+     * @throws Error if the context is invalid or the activity is not a token exchange invoke.
+     */
     private getStorageKey(context: TurnContext): string {
         if (!context || !context.activity || !context.activity.conversation) {
             throw new Error("Invalid context, can not get storage key!");

--- a/js/packages/teams-ai/src/authentication/TeamsSsoMessageExtensionAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoMessageExtensionAuthentication.ts
@@ -4,21 +4,41 @@
 import { TurnContext } from "botbuilder-core";
 import { TokenResponse } from "botframework-schema";
 import { MessageExtensionAuthenticationBase } from "./MessageExtensionAuthenticationBase";
-import { TeamsSsoSettings } from "./TeamsBotSsoPrompt";
+import { TeamsSsoSettings } from "./TeamsSsoSettings";
 import { ConfidentialClientApplication } from "@azure/msal-node";
 import { MessageExtensionsInvokeNames } from '../MessageExtensions';
 
+/**
+ * @internal
+ * 
+ * Handles authentication for Teams Message Extension using Single Sign-On (SSO).
+ */
 export class TeamsSsoMessageExtensionAuthentication extends MessageExtensionAuthenticationBase {
 
+    /**
+     * Creates a new instance of TeamsSsoMessageExtensionAuthentication.
+     * @param settings The Teams SSO settings.
+     * @param msal The MSAL (Microsoft Authentication Library) instance.
+     */
     public constructor(private readonly settings: TeamsSsoSettings, private readonly msal: ConfidentialClientApplication) {
         super();
     }
 
+    /**
+     * Checks if the activity is a valid Message Extension activity that supports SSO
+     * @param context The turn context.
+     * @returns A boolean indicating if the activity is valid.
+     */
     public override isValidActivity(context: TurnContext): boolean {
         // Currently only search based message extensions has SSO
         return super.isValidActivity(context) && context.activity.name == MessageExtensionsInvokeNames.QUERY_INVOKE;
     }
 
+    /**
+     * Handles the SSO token exchange.
+     * @param context The turn context.
+     * @returns A promise that resolves to the token response or undefined if token exchange failed.
+     */
     public async handleSsoTokenExchange(context: TurnContext): Promise<TokenResponse | undefined> {
         const tokenExchangeRequest = context.activity.value.authentication;
 
@@ -40,11 +60,22 @@ export class TeamsSsoMessageExtensionAuthentication extends MessageExtensionAuth
         return undefined;
     }
 
+    /**
+     * Handles the signin/verifyState activity.
+     * @param context The turn context.
+     * @param magicCode The magic code from sign-in.
+     * @returns A promise that resolves to undefined. The parent class will trigger silentAuth again.
+     */
     public async handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined> {
         return undefined; // Let parent class trigger silentAuth again
     }
 
-    public async getSignInLink(context: TurnContext): Promise<string | undefined> {
+    /**
+     * Gets the sign-in link for the user.
+     * @param context The turn context.
+     * @returns A promise that resolves to the sign-in link.
+     */
+    public async getSignInLink(context: TurnContext): Promise<string> {
         const clientId = this.settings.msalConfig.auth.clientId;
         const scope = encodeURI(this.settings.scopes.join(" "));
         const authority = this.settings.msalConfig.auth.authority ?? "https://login.microsoftonline.com/common/";

--- a/js/packages/teams-ai/src/authentication/TeamsSsoSettings.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoSettings.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Configuration } from "@azure/msal-node";
+
+/**
+ * Represents the settings for Teams Single Sign-On (SSO) authentication.
+ */
+export interface TeamsSsoSettings {
+    /**
+     * The scopes required for authentication.
+     */
+    scopes: string[];
+    /**
+     * The MSAL (Microsoft Authentication Library) configuration.
+     */
+    msalConfig: Configuration;
+    /**
+     * The sign-in link for authentication.
+     * The library will pass `scope`, `clientId`, and `tenantId` to the link as query parameters.
+     * Your sign-in page can leverage these parameters to compose the AAD sign-in URL.
+     */
+    signInLink: string;
+    /**
+     * (Optional) number of milliseconds to wait for the user to authenticate.
+     * Defaults to a value `900,000` (15 minutes.)
+     * Only works in conversional bot scenario.
+     */
+    timeout?: number;
+    /**
+     * (Optional) value indicating whether the OAuthPrompt should end upon
+     * receiving an invalid message. 
+     * Defaults to `true`.
+     */
+    endOnInvalidMessage?: boolean;
+}


### PR DESCRIPTION
## Linked issues

closes: #849

## Details

1. Add JSDoc for authentication code
2. Move `TeamsSsoSettings` out of `TeamsBotSsoPromt`, as it's not only for this prompt

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

