### PR TITLE
[C#] fix: assistant message order

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestAssistantsOpenAIClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestAssistantsOpenAIClient.cs
@@ -88,11 +88,15 @@ namespace Microsoft.Teams.AI.Tests.TestUtils
 
         public override async IAsyncEnumerable<Message> ListNewMessagesAsync(string threadId, string? lastMessageId, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            string nextMessage = RemainingMessages.Dequeue();
-            await CreateMessageAsync(threadId, new()
+            while (RemainingMessages.Count > 0)
             {
-                Content = nextMessage
-            }, cancellationToken);
+                string nextMessage = RemainingMessages.Dequeue();
+                await CreateMessageAsync(threadId, new()
+                {
+                    Content = nextMessage
+                }, cancellationToken);
+            }
+
             List<Message> messages = Messages[threadId];
             bool start = lastMessageId == null;
             await foreach (var message in messages.ToAsyncEnumerable())

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/AssistantsPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/AssistantsPlanner.cs
@@ -186,6 +186,9 @@ namespace Microsoft.Teams.AI.AI.Planners
                 }
             }
 
+            // ListMessages return messages in desc, reverse to be in asc order
+            newMessages.Reverse();
+
             // Convert the messages to SAY commands
             Plan plan = new();
             foreach (Message message in newMessages)


### PR DESCRIPTION
## Linked issues

closes: #892

## Details

Fix the message order of Assistant's response.

#### Change details

Reverse the messages returned from OpenAI's `listMessages` API

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
