### PR TITLE
[JS] chore: Change assistants planner scope to "preview"

### DIFF
--- a/js/packages/teams-ai/src/planners/index.ts
+++ b/js/packages/teams-ai/src/planners/index.ts
@@ -7,7 +7,7 @@
  */
 
 export * from "./ActionPlanner";
-export * from "./AssistantsPlanner";
+export * as preview from "./AssistantsPlanner";
 export * from "./LLMClient";
 export * from "./Planner";
 export * from "./TestPlanner";

--- a/js/samples/06.assistants.a.mathBot/src/bot.ts
+++ b/js/samples/06.assistants.a.mathBot/src/bot.ts
@@ -1,13 +1,11 @@
-import {
-    Application,
-    AssistantsPlanner,
-    AI
-} from '@microsoft/teams-ai';
+import { Application, preview, AI } from '@microsoft/teams-ai';
 import { MemoryStorage, TurnContext } from 'botbuilder';
 
 if (!process.env.OPENAI_KEY) {
     throw new Error('Missing environment variables - please check that OPENAI_KEY.');
 }
+
+const { AssistantsPlanner } = preview;
 
 // Create Assistant if no ID is provided
 if (!process.env.ASSISTANT_ID) {

--- a/js/samples/06.assistants.b.orderBot/src/bot.ts
+++ b/js/samples/06.assistants.b.orderBot/src/bot.ts
@@ -1,6 +1,6 @@
 import {
     Application,
-    AssistantsPlanner,
+    preview,
     AI
 } from '@microsoft/teams-ai';
 import { CardFactory, MemoryStorage, MessageFactory, TurnContext } from 'botbuilder';
@@ -10,6 +10,8 @@ import { generateCardForOrder } from './foodOrderCard';
 if (!process.env.OPENAI_KEY) {
     throw new Error('Missing environment variables - please check that OPENAI_KEY.');
 }
+
+const { AssistantsPlanner } = preview;
 
 // Create Assistant if no ID is provided
 if (!process.env.ASSISTANT_ID) {


### PR DESCRIPTION
## Linked issues

closes: #906 

## Details

Exports the _AssistantsPlanner.ts_ file like this: 

```js
export * as preview from "./AssistantsPlanner.ts"
```

Samples consume it like this:

```js
import { preview } from "@microsoft/teams-ai"

const { AssistantsPlanner } = preview
```

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
