### PR TITLE
[C#] fix: use TeamsAIException for PromptResponse.Error

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Teams.AI.AI.Clients
                 return new()
                 {
                     Status = PromptResponseStatus.Error,
-                    Error = new() { Message = ex.Message ?? string.Empty }
+                    Error = new(ex.Message ?? string.Empty)
                 };
             }
         }
@@ -366,10 +366,7 @@ namespace Microsoft.Teams.AI.AI.Clients
                 return new()
                 {
                     Status = PromptResponseStatus.InvalidResponse,
-                    Error = new()
-                    {
-                        Message = feedback ?? "The response was invalid. Try another strategy."
-                    }
+                    Error = new(feedback ?? "The response was invalid. Try another strategy.")
                 };
             }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
@@ -3,7 +3,6 @@ using Azure.AI.OpenAI;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.AI.AI.Prompts;
@@ -135,10 +134,7 @@ namespace Microsoft.Teams.AI.AI.Models
                     return new PromptResponse
                     {
                         Status = PromptResponseStatus.TooLong,
-                        Error = new Error
-                        {
-                            Message = $"The generated text completion prompt had a length of {prompt.Length} tokens which exceeded the MaxInputTokens of {maxInputTokens}."
-                        }
+                        Error = new($"The generated text completion prompt had a length of {prompt.Length} tokens which exceeded the MaxInputTokens of {maxInputTokens}.")
                     };
                 }
                 if (_options.LogRequests!.Value)
@@ -177,18 +173,12 @@ namespace Microsoft.Teams.AI.AI.Models
                     if (httpOperationException.StatusCode == (HttpStatusCode)429)
                     {
                         promptResponse.Status = PromptResponseStatus.RateLimited;
-                        promptResponse.Error = new Error
-                        {
-                            Message = "The text completion API returned a rate limit error."
-                        };
+                        promptResponse.Error = new("The text completion API returned a rate limit error.");
                     }
                     else
                     {
                         promptResponse.Status = PromptResponseStatus.Error;
-                        promptResponse.Error = new Error
-                        {
-                            Message = $"The text completion API returned an error status of {httpOperationException.StatusCode}: {httpOperationException.Message}"
-                        };
+                        promptResponse.Error = new($"The text completion API returned an error status of {httpOperationException.StatusCode}: {httpOperationException.Message}");
                     }
                 }
 
@@ -220,10 +210,7 @@ namespace Microsoft.Teams.AI.AI.Models
                     return new PromptResponse
                     {
                         Status = PromptResponseStatus.TooLong,
-                        Error = new Error
-                        {
-                            Message = $"The generated chat completion prompt had a length of {prompt.Length} tokens which exceeded the MaxInputTokens of {maxInputTokens}."
-                        }
+                        Error = new($"The generated chat completion prompt had a length of {prompt.Length} tokens which exceeded the MaxInputTokens of {maxInputTokens}.")
                     };
                 }
                 if (!_options.UseSystemMessages!.Value && prompt.Output.Count > 0 && prompt.Output[0].Role == ChatRole.System)
@@ -265,18 +252,12 @@ namespace Microsoft.Teams.AI.AI.Models
                     if (httpOperationException.StatusCode == (HttpStatusCode)429)
                     {
                         promptResponse.Status = PromptResponseStatus.RateLimited;
-                        promptResponse.Error = new Error
-                        {
-                            Message = "The chat completion API returned a rate limit error."
-                        };
+                        promptResponse.Error = new("The chat completion API returned a rate limit error.");
                     }
                     else
                     {
                         promptResponse.Status = PromptResponseStatus.Error;
-                        promptResponse.Error = new Error
-                        {
-                            Message = $"The chat completion API returned an error status of {httpOperationException.StatusCode}: {httpOperationException.Message}"
-                        };
+                        promptResponse.Error = new($"The chat completion API returned an error status of {httpOperationException.StatusCode}: {httpOperationException.Message}");
                     }
                 }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/PromptResponse.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/PromptResponse.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Schema;
-using Microsoft.Teams.AI.AI.Models;
+﻿using Microsoft.Teams.AI.AI.Models;
+using Microsoft.Teams.AI.Exceptions;
 
 namespace Microsoft.Teams.AI.AI.Prompts
 {
@@ -21,7 +21,7 @@ namespace Microsoft.Teams.AI.AI.Prompts
         /// <summary>
         /// Error returned.
         /// </summary>
-        public Error? Error { get; set; }
+        public TeamsAIException? Error { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
## Linked issues

closes: #915 
## Details

Provide a list of your changes here. If you are fixing a bug, please provide steps to reproduce the bug.

#### Change details

- use TeamsAIException instead of bot schema error for PromptResponse.Error

**code snippets**:

**screenshots**:

## Attestation Checklist

- [ ] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
