### PR TITLE
[JS] fix: assistant tool_outputs

### DIFF
--- a/js/packages/teams-ai/src/planners/AssistantsPlanner.ts
+++ b/js/packages/teams-ai/src/planners/AssistantsPlanner.ts
@@ -289,7 +289,10 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
         for (const action in actionOutputs) {
             const output = actionOutputs[action];
             const tool_call_id = tool_map[action];
-            tool_outputs.push({ tool_call_id, output });
+            if (tool_call_id !== undefined) {
+                // Add required output only
+                tool_outputs.push({ tool_call_id, output });
+            }
         }
 
         // Submit the tool outputs


### PR DESCRIPTION
## Linked issues

closes: #925

## Details

Fix the missing `tool_call_id` issue when a turn contains multiple assistant runs

#### Change details

- One turn may execute several actions, but may some of them are required for assistant. Only return required tool calls to assistant.

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
