### PR TITLE
[C#] fix: ignore redundant action when submitting tool outputs

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/AssistantsPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/AssistantsPlanner.cs
@@ -230,12 +230,12 @@ namespace Microsoft.Teams.AI.AI.Planners.Experimental
             // Map the action outputs to tool outputs
             List<ToolOutput> toolOutputs = new();
             Dictionary<string, string> toolMap = state.SubmitToolMap;
-            foreach (KeyValuePair<string, string> action in state.Temp!.ActionOutputs)
+            foreach (KeyValuePair<string, string> requiredAction in toolMap)
             {
                 toolOutputs.Add(new()
                 {
-                    ToolCallId = toolMap[action.Key],
-                    Output = action.Value
+                    ToolCallId = requiredAction.Value,
+                    Output = state.Temp!.ActionOutputs.ContainsKey(requiredAction.Key) ? state.Temp!.ActionOutputs[requiredAction.Key] : string.Empty
                 });
             }
 


### PR DESCRIPTION
## Linked issues

closes: #925

## Details

Fix `KeyNotFound` exception when executed actions are more than assistant required actions.

#### Change details

- Only submit required actions and ignore others
- UT added

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
