### PR TITLE
[C#] feat: add teams sso implementation

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Schema;
-using Microsoft.Teams.AI.Application.Authentication.Bot;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
             return Task.FromResult("mocked link");
         }
 
-        public override Task<TokenResponse> HandlerUserSignIn(ITurnContext context, string magicCode)
+        public override Task<TokenResponse> HandleUserSignIn(ITurnContext context, string magicCode)
         {
             if (_signInResponse == null)
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication
 {
     public class MockedAuthentication<TState> : IAuthentication<TState>
-        where TState : TurnState
+        where TState : TurnState, new()
     {
         private string _mockedToken;
         private SignInStatus _mockedStatus;
@@ -17,9 +18,24 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             _validActivity = validActivity;
         }
 
+        public void Initialize(Application<TState> app, string name, IStorage? storage = null)
+        {
+            return;
+        }
+
         public Task<bool> IsValidActivity(ITurnContext context)
         {
             return Task.FromResult(_validActivity);
+        }
+
+        public IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler)
+        {
+            return this;
+        }
+
+        public IAuthentication<TState> OnUserSignInSuccess(Func<ITurnContext, TState, Task> handler)
+        {
+            return this;
         }
 
         public Task<SignInResponse> SignInUser(ITurnContext context, TState state)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ApplicationOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ApplicationOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Teams.AI
     /// </summary>
     /// <typeparam name="TState">Type of the turn state.</typeparam>
     public class ApplicationOptions<TState>
-        where TState : TurnState
+        where TState : TurnState, new()
     {
         /// <summary>
         /// Optional. Bot adapter being used.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.Teams.AI.Application.Authentication.AdaptiveCards
+namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Base class for adaptive card authentication that handles common logic

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/OAuthAdaptiveCardsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/OAuthAdaptiveCardsAuthentication.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Teams.AI.Application.Authentication.AdaptiveCards
+﻿namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Handles authentication for Adaptive Cards in Teams using OAuth Connection.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/TeamsSsoAdaptiveCardsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/TeamsSsoAdaptiveCardsAuthentication.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Teams.AI.Application.Authentication.AdaptiveCards
+﻿namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Handles authentication for Adaptive Cards in Teams based on Teams SSO.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthUtilities.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthUtilities.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Teams.AI
     /// <summary>
     /// Authentication utilities
     /// </summary>
-    public class AuthUtilities
+    internal class AuthUtilities
     {
         /// <summary>
         /// Set token in state

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -90,7 +90,13 @@ namespace Microsoft.Teams.AI
             return await auth.IsValidActivity(context);
         }
 
-        private IAuthentication<TState> Get(string name)
+        /// <summary>
+        /// Get an authentication class via name
+        /// </summary>
+        /// <param name="name">The name of authentication class</param>
+        /// <returns>The authentication class</returns>
+        /// <exception cref="TeamsAIException">When cannot find the class with given name</exception>
+        public IAuthentication<TState> Get(string name)
         {
             if (_authentications.ContainsKey(name))
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Teams.AI
     /// Options for authentication.
     /// </summary>
     public class AuthenticationOptions<TState>
-        where TState : TurnState
+        where TState : TurnState, new()
     {
         /// <summary>
         /// The authentication classes to sign-in and sign-out users.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
@@ -4,7 +4,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 
-namespace Microsoft.Teams.AI.Application.Authentication.Bot
+namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Base class for bot authentication that handles common logic
@@ -182,22 +182,18 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
         /// The handler function is called when the user has successfully signed in
         /// </summary>
         /// <param name="handler">The handler function to call when the user has successfully signed in</param>
-        /// <returns>The class itself for chaining purpose</returns>
-        public BotAuthenticationBase<TState> OnUserSignInSuccess(Func<ITurnContext, TState, Task> handler)
+        public void OnUserSignInSuccess(Func<ITurnContext, TState, Task> handler)
         {
             _userSignInSuccessHandler = handler;
-            return this;
         }
 
         /// <summary>
         /// The handler function is called when the user sign in flow fails
         /// </summary>
         /// <param name="handler">The handler function to call when the user failed to signed in</param>
-        /// <returns>The class itself for chaining purpose</returns>
-        public BotAuthenticationBase<TState> OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler)
+        public void OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler)
         {
             _userSignInFailureHandler = handler;
-            return this;
         }
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>True if valid. Otherwise, false.</returns>
-        public bool IsValidActivity(ITurnContext context)
+        public virtual bool IsValidActivity(ITurnContext context)
         {
             return context.Activity.Type == ActivityTypes.Message
                 && !string.IsNullOrEmpty(context.Activity.Text);
@@ -206,7 +206,7 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
         /// <param name="context">The turn context</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>True if the activity should be handled by current authentication hanlder. Otherwise, false.</returns>
-        protected Task<bool> VerifyStateRouteSelector(ITurnContext context, CancellationToken cancellationToken)
+        protected virtual Task<bool> VerifyStateRouteSelector(ITurnContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(context.Activity.Type == ActivityTypes.Invoke
                 && context.Activity.Name == SignInConstants.VerifyStateOperationName);
@@ -218,7 +218,7 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
         /// <param name="context">The turn context</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>True if the activity should be handled by current authentication hanlder. Otherwise, false.</returns>
-        protected Task<bool> TokenExchangeRouteSelector(ITurnContext context, CancellationToken cancellationToken)
+        protected virtual Task<bool> TokenExchangeRouteSelector(ITurnContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(context.Activity.Type == ActivityTypes.Invoke
                 && context.Activity.Name == SignInConstants.TokenExchangeOperationName);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/OAuthBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/OAuthBotAuthentication.cs
@@ -2,12 +2,12 @@
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Teams.AI.State;
 
-namespace Microsoft.Teams.AI.Application.Authentication.Bot
+namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Handles authentication for bot in Teams using OAuth Connection.
     /// </summary>
-    public class OAuthBotAuthentication<TState> : BotAuthenticationBase<TState>
+    internal class OAuthBotAuthentication<TState> : BotAuthenticationBase<TState>
         where TState : TurnState, new()
     {
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
@@ -6,12 +6,12 @@ using Microsoft.Teams.AI.Exceptions;
 using Newtonsoft.Json.Linq;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Teams.AI.Application.Authentication.Bot
+namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Handles authentication for bot in Teams using Teams SSO.
     /// </summary>
-    public class TeamsSsoBotAuthentication<TState> : BotAuthenticationBase<TState>
+    internal class TeamsSsoBotAuthentication<TState> : BotAuthenticationBase<TState>
         where TState : TurnState, new()
     {
         private const string SSO_DIALOG_ID = "_TeamsSsoDialog";
@@ -23,6 +23,7 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
         /// </summary>
         /// <param name="app">The application instance</param>
         /// <param name="name">The name of current authentication handler</param>
+        /// <param name="settings">The authentication settings</param>
         /// <param name="storage">The storage to save turn state</param>
         public TeamsSsoBotAuthentication(Application<TState> app, string name, TeamsSsoSettings settings, IStorage? storage = null) : base(app, name, storage)
         {
@@ -67,6 +68,12 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
             return result;
         }
 
+        /// <summary>
+        /// The route selector for signin/tokenExchange activity
+        /// </summary>
+        /// <param name="context">The turn context</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>True if the activity should be handled by current authentication hanlder. Otherwise, false.</returns>
         protected override async Task<bool> TokenExchangeRouteSelector(ITurnContext context, CancellationToken cancellationToken)
         {
             JObject value = JObject.FromObject(context.Activity.Value);
@@ -78,7 +85,7 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
 
         private async Task<DialogContext> CreateSsoDialogContext(ITurnContext context, TState state, string dialogStateProperty)
         {
-            TurnStateProperty<DialogState> accessor = new TurnStateProperty<DialogState>(state, "conversation", dialogStateProperty);
+            TurnStateProperty<DialogState> accessor = new(state, "conversation", dialogStateProperty);
             DialogSet dialogSet = new(accessor);
             WaterfallDialog ssoDialog = new(SSO_DIALOG_ID);
             dialogSet.Add(this._prompt);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
@@ -1,6 +1,10 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
 using Microsoft.Teams.AI.State;
+using Microsoft.Teams.AI.Exceptions;
+using Newtonsoft.Json.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Teams.AI.Application.Authentication.Bot
 {
@@ -10,14 +14,26 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
     public class TeamsSsoBotAuthentication<TState> : BotAuthenticationBase<TState>
         where TState : TurnState, new()
     {
+        private const string SSO_DIALOG_ID = "_TeamsSsoDialog";
+        private Regex _tokenExchangeIdRegex;
+        private TeamsSsoPrompt _prompt;
+
         /// <summary>
         /// Initializes the class
         /// </summary>
         /// <param name="app">The application instance</param>
         /// <param name="name">The name of current authentication handler</param>
         /// <param name="storage">The storage to save turn state</param>
-        public TeamsSsoBotAuthentication(Application<TState> app, string name, IStorage? storage = null) : base(app, name, storage)
+        public TeamsSsoBotAuthentication(Application<TState> app, string name, TeamsSsoSettings settings, IStorage? storage = null) : base(app, name, storage)
         {
+            _tokenExchangeIdRegex = new Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-" + name);
+            _prompt = new TeamsSsoPrompt("TeamsSsoPrompt", name, settings);
+
+            // Do not save state for duplicate token exchange events to avoid eTag conflicts
+            app.OnAfterTurn((context, state, cancellationToken) =>
+            {
+                return Task.FromResult(state.Temp.DuplicateTokenExchange != true);
+            });
         }
 
         /// <summary>
@@ -27,9 +43,10 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
         /// <param name="state">The turn state</param>
         /// <param name="dialogStateProperty">The property name for storing dialog state.</param>
         /// <returns>Dialog turn result that contains token if sign in success</returns>
-        public override Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override async Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty)
         {
-            throw new NotImplementedException();
+            DialogContext dialogContext = await CreateSsoDialogContext(context, state, dialogStateProperty);
+            return await dialogContext.ContinueDialogAsync();
         }
 
         /// <summary>
@@ -39,9 +56,109 @@ namespace Microsoft.Teams.AI.Application.Authentication.Bot
         /// <param name="state">The turn state</param>
         /// <param name="dialogStateProperty">The property name for storing dialog state.</param>
         /// <returns>Dialog turn result that contains token if sign in success</returns>
-        public override Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override async Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty)
         {
-            throw new NotImplementedException();
+            DialogContext dialogContext = await CreateSsoDialogContext(context, state, dialogStateProperty);
+            DialogTurnResult result = await dialogContext.ContinueDialogAsync();
+            if (result.Status == DialogTurnStatus.Empty)
+            {
+                result = await dialogContext.BeginDialogAsync(SSO_DIALOG_ID);
+            }
+            return result;
+        }
+
+        protected override async Task<bool> TokenExchangeRouteSelector(ITurnContext context, CancellationToken cancellationToken)
+        {
+            JObject value = JObject.FromObject(context.Activity.Value);
+            JToken? id = value["id"];
+            string idStr = id?.ToString() ?? "";
+            return await base.TokenExchangeRouteSelector(context, cancellationToken)
+                && this._tokenExchangeIdRegex.IsMatch(idStr);
+        }
+
+        private async Task<DialogContext> CreateSsoDialogContext(ITurnContext context, TState state, string dialogStateProperty)
+        {
+            TurnStateProperty<DialogState> accessor = new TurnStateProperty<DialogState>(state, "conversation", dialogStateProperty);
+            DialogSet dialogSet = new(accessor);
+            WaterfallDialog ssoDialog = new(SSO_DIALOG_ID);
+            dialogSet.Add(this._prompt);
+            dialogSet.Add(new WaterfallDialog(SSO_DIALOG_ID, new WaterfallStep[]
+            {
+                async (step, cancellationToken) =>
+                {
+                    return await step.BeginDialogAsync(this._prompt.Id);
+                },
+                async (step, cancellationToken) =>
+                {
+                     TokenResponse? tokenResponse = step.Result as TokenResponse;
+                    if (tokenResponse != null && await ShouldDedup(context))
+                    {
+                        state.Temp.DuplicateTokenExchange = true;
+                        return Dialog.EndOfTurn;
+                    }
+                    return await step.EndDialogAsync(step.Result);
+                }
+            }));
+            return await dialogSet.CreateContextAsync(context);
+        }
+
+        private async Task<bool> ShouldDedup(ITurnContext context)
+        {
+            string key = GetStorageKey(context);
+            string id = (context.Activity.Value as JObject)?.Value<string>("id")!; // The id exists if GetStorageKey success
+            IStoreItem storeItem = new TokenStoreItem(id);
+            Dictionary<string, object> storesItems = new()
+            {
+                {key, storeItem}
+            };
+
+            try
+            {
+                await this._storage.WriteAsync(storesItems);
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message.StartsWith("Etag conflict", StringComparison.OrdinalIgnoreCase) || ex.Message.Contains("pre-condition is not met"))
+                {
+                    return true;
+                }
+                throw;
+            }
+            return false;
+        }
+
+        private string GetStorageKey(ITurnContext context)
+        {
+            if (context == null || context.Activity == null
+                || context.Activity.Conversation == null)
+            {
+                throw new TeamsAIAuthException("Invalid context, can not get storage key!");
+            }
+
+            Activity activity = context.Activity;
+            string channelId = activity.ChannelId;
+            string conversationId = activity.Conversation.Id;
+            if (activity.Type != ActivityTypes.Invoke || activity.Name != SignInConstants.TokenExchangeOperationName)
+            {
+                throw new TeamsAIAuthException("TokenExchangeState can only be used with Invokes of signin/tokenExchange.");
+            }
+            JObject value = JObject.FromObject(activity.Value);
+            JToken? id = value["id"];
+            if (id == null)
+            {
+                throw new TeamsAIAuthException("Invalid signin/tokenExchange. Missing activity.value.id.");
+            }
+            return $"{channelId}/{conversationId}/{id}";
+        }
+    }
+
+    internal class TokenStoreItem : IStoreItem
+    {
+        public string ETag { get; set; }
+
+        public TokenStoreItem(string etag)
+        {
+            ETag = etag;
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.Exceptions;
 
-namespace Microsoft.Teams.AI.Application.Authentication.Bot
+namespace Microsoft.Teams.AI
 {
     internal class TeamsSsoPrompt : Dialog
     {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
@@ -1,0 +1,232 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using System.Net;
+using Newtonsoft.Json.Linq;
+using Microsoft.Identity.Client;
+using Microsoft.Teams.AI.Exceptions;
+
+namespace Microsoft.Teams.AI.Application.Authentication.Bot
+{
+    internal class TeamsSsoPrompt : Dialog
+    {
+        private const string _expiresKey = "expires";
+        private string _name;
+        private TeamsSsoSettings _settings;
+
+        public TeamsSsoPrompt(string dialogId, string name, TeamsSsoSettings settings)
+            : base(dialogId)
+        {
+            this._name = name;
+            this._settings = settings;
+        }
+
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken)
+        {
+            int timeout = _settings.Timeout;
+
+            IDictionary<string, object> state = dc.ActiveDialog.State;
+            state[_expiresKey] = DateTime.Now.AddMilliseconds(timeout);
+
+            AuthenticationResult? token = await this.TryGetUserToken(dc.Context);
+            if (token != null)
+            {
+                TokenResponse tokenResponse = new()
+                {
+                    ConnectionName = "", // No connection name is available in this implementation
+                    Token = token.AccessToken,
+                    Expiration = token.ExpiresOn.ToString("o")
+                };
+                return await dc.EndDialogAsync(tokenResponse);
+            }
+
+            // Cannot get token from cache, send OAuth card to get SSO token
+            await this.SendOAuthCardToObtainTokenAsync(dc.Context, cancellationToken);
+            return EndOfTurn;
+        }
+
+        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
+        {
+            // Check for timeout
+            IDictionary<string, object> state = dc.ActiveDialog.State;
+            bool isMessage = (dc.Context.Activity.Type == ActivityTypes.Message);
+            bool isTimeoutActivityType =
+              isMessage ||
+              IsTeamsVerificationInvoke(dc.Context) ||
+              IsTokenExchangeRequestInvoke(dc.Context);
+
+            // If the incoming Activity is a message, or an Activity Type normally handled by TeamsBotSsoPrompt,
+            // check to see if this TeamsBotSsoPrompt Expiration has elapsed, and end the dialog if so.
+            bool hasTimedOut = isTimeoutActivityType && DateTime.Compare(DateTime.UtcNow, (DateTime)state[_expiresKey]) > 0;
+            if (hasTimedOut)
+            {
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                if (IsTeamsVerificationInvoke(dc.Context) || IsTokenExchangeRequestInvoke(dc.Context))
+                {
+                    // Recognize token
+                    PromptRecognizerResult<TokenResponse> recognized = await RecognizeTokenAsync(dc, cancellationToken).ConfigureAwait(false);
+
+                    if (recognized.Succeeded)
+                    {
+                        return await dc.EndDialogAsync(recognized.Value, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                else if (isMessage && _settings.EndOnInvalidMessage)
+                {
+                    return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+
+                return EndOfTurn;
+            }
+        }
+
+        private async Task<PromptRecognizerResult<TokenResponse>> RecognizeTokenAsync(DialogContext dc, CancellationToken cancellationToken)
+        {
+
+            ITurnContext context = dc.Context;
+            PromptRecognizerResult<TokenResponse> result = new();
+            TokenResponse? tokenResponse = null;
+
+            if (IsTokenExchangeRequestInvoke(context))
+            {
+                JObject? tokenResponseObject = context.Activity.Value as JObject;
+                string? ssoToken = tokenResponseObject?.ToObject<TokenExchangeInvokeRequest>()?.Token;
+                // Received activity is not a token exchange request
+                if (string.IsNullOrEmpty(ssoToken))
+                {
+                    string warningMsg =
+                      "The bot received an InvokeActivity that is missing a TokenExchangeInvokeRequest value. This is required to be sent with the InvokeActivity.";
+                    await SendInvokeResponseAsync(context, HttpStatusCode.BadRequest, warningMsg, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    try
+                    {
+                        AuthenticationResult exchangedToken = await _settings.MSAL.AcquireTokenOnBehalfOf(_settings.Scopes, new UserAssertion(ssoToken)).ExecuteAsync();
+
+                        tokenResponse = new TokenResponse
+                        {
+                            Token = exchangedToken.AccessToken,
+                            Expiration = exchangedToken.ExpiresOn.ToString("o")
+                        };
+
+                        await SendInvokeResponseAsync(context, HttpStatusCode.OK, null, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (MsalUiRequiredException) // Need user interaction
+                    {
+                        string warningMsg = "The bot is unable to exchange token. Ask for user consent first.";
+                        await SendInvokeResponseAsync(context, HttpStatusCode.PreconditionFailed, new TokenExchangeInvokeResponse
+                        {
+                            Id = context.Activity.Id,
+                            FailureDetail = warningMsg,
+                        }, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        string message = $"Failed to get access token with error: {ex.Message}";
+                        throw new TeamsAIAuthException(message);
+                    }
+                }
+            }
+            else if (IsTeamsVerificationInvoke(context))
+            {
+                await SendOAuthCardToObtainTokenAsync(context, cancellationToken).ConfigureAwait(false);
+                await SendInvokeResponseAsync(context, HttpStatusCode.OK, null, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (tokenResponse != null)
+            {
+                result.Succeeded = true;
+                result.Value = tokenResponse;
+            }
+            else
+            {
+                result.Succeeded = false;
+            }
+            return result;
+        }
+
+        private async Task SendOAuthCardToObtainTokenAsync(ITurnContext context, CancellationToken cancellationToken)
+        {
+            SignInResource signInResource = GetSignInResource();
+
+            // Ensure prompt initialized
+            IMessageActivity prompt = Activity.CreateMessageActivity();
+            prompt.Attachments = new List<Attachment>();
+            prompt.Attachments.Add(new Attachment
+            {
+                ContentType = OAuthCard.ContentType,
+                Content = new OAuthCard
+                {
+                    Text = "Sign In",
+                    Buttons = new[]
+                    {
+                            new CardAction
+                            {
+                                    Title = "Teams SSO Sign In",
+                                    Value = signInResource.SignInLink,
+                                    Type = ActionTypes.Signin,
+                            },
+                        },
+                    TokenExchangeResource = signInResource.TokenExchangeResource,
+                },
+            });
+            // Send prompt
+            await context.SendActivityAsync(prompt, cancellationToken).ConfigureAwait(false);
+        }
+
+        private SignInResource GetSignInResource()
+        {
+            string signInLink = $"{_settings.SignInLink}?scope={Uri.EscapeDataString(string.Join(" ", _settings.Scopes))}&clientId={_settings.MSAL.AppConfig.ClientId}&tenantId={_settings.MSAL.AppConfig.TenantId}";
+
+            SignInResource signInResource = new()
+            {
+                SignInLink = signInLink,
+                TokenExchangeResource = new TokenExchangeResource
+                {
+                    Id = $"{Guid.NewGuid()}-{_name}"
+                }
+            };
+
+            return signInResource;
+        }
+
+        private async Task<AuthenticationResult?> TryGetUserToken(ITurnContext context)
+        {
+            string homeAccountId = $"{context.Activity.From.AadObjectId}.{context.Activity.Conversation.TenantId}";
+            IAccount account = await this._settings.MSAL.GetAccountAsync(homeAccountId);
+            if (account != null)
+            {
+                AuthenticationResult result = await this._settings.MSAL.AcquireTokenSilent(this._settings.Scopes, account).ExecuteAsync();
+                return result;
+            }
+            return null; // Return empty indication no token found in cache
+        }
+
+        private bool IsTeamsVerificationInvoke(ITurnContext context)
+        {
+            return (context.Activity.Type == ActivityTypes.Invoke) && (context.Activity.Name == SignInConstants.VerifyStateOperationName);
+        }
+        private bool IsTokenExchangeRequestInvoke(ITurnContext context)
+        {
+            return (context.Activity.Type == ActivityTypes.Invoke) && (context.Activity.Name == SignInConstants.TokenExchangeOperationName);
+        }
+
+        private static async Task SendInvokeResponseAsync(ITurnContext turnContext, HttpStatusCode statusCode, object body, CancellationToken cancellationToken)
+        {
+            await turnContext.SendActivityAsync(
+                new Activity
+                {
+                    Type = ActivityTypesEx.InvokeResponse,
+                    Value = new InvokeResponse
+                    {
+                        Status = (int)statusCode,
+                        Body = body,
+                    },
+                }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI
@@ -47,7 +48,7 @@ namespace Microsoft.Teams.AI
     /// Handles user sign-in and sign-out.
     /// </summary>
     public interface IAuthentication<TState>
-        where TState : TurnState
+        where TState : TurnState, new()
     {
         /// <summary>
         /// Signs in a user.
@@ -71,5 +72,28 @@ namespace Microsoft.Teams.AI
         /// <param name="context">Current turn context.</param>
         /// <returns>True if current activity supports authentication. Otherwise, false.</returns>
         Task<bool> IsValidActivity(ITurnContext context);
+
+        /// <summary>
+        /// Initialize the authentication class
+        /// </summary>
+        /// <param name="app">The application object</param>
+        /// <param name="name">The name of the authentication handler</param>
+        /// <param name="storage">The storage to save turn state</param>
+        /// 
+        void Initialize(Application<TState> app, string name, IStorage? storage = null);
+
+        /// <summary>
+        /// The handler function is called when the user has successfully signed in
+        /// </summary>
+        /// <param name="handler">The handler function to call when the user has successfully signed in</param>
+        /// <returns>The class itself for chaining purpose</returns>
+        IAuthentication<TState> OnUserSignInSuccess(Func<ITurnContext, TState, Task> handler);
+
+        /// <summary>
+        /// The handler function is called when the user sign in flow fails
+        /// </summary>
+        /// <param name="handler">The handler function to call when the user failed to signed in</param>
+        /// <returns>The class itself for chaining purpose</returns>
+        IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler);
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
@@ -96,8 +96,7 @@ namespace Microsoft.Teams.AI
                     {
                         Actions = new List<CardAction>
                                 {
-                                    new CardAction
-                                    {
+                                    new() {
                                         Type = ActionTypes.OpenUrl,
                                         Value = signInLink,
                                         Title = "Bot Service OAuth",
@@ -121,9 +120,9 @@ namespace Microsoft.Teams.AI
         {
             return context.Activity.Type == ActivityTypes.Invoke
                 && (context.Activity.Name == MessageExtensionsInvokeNames.QUERY_INVOKE_NAME
-                    && context.Activity.Name == MessageExtensionsInvokeNames.FETCH_TASK_INVOKE_NAME
-                    && context.Activity.Name == MessageExtensionsInvokeNames.QUERY_LINK_INVOKE_NAME
-                    && context.Activity.Name == MessageExtensionsInvokeNames.ANONYMOUS_QUERY_LINK_INVOKE_NAME);
+                    || context.Activity.Name == MessageExtensionsInvokeNames.FETCH_TASK_INVOKE_NAME
+                    || context.Activity.Name == MessageExtensionsInvokeNames.QUERY_LINK_INVOKE_NAME
+                    || context.Activity.Name == MessageExtensionsInvokeNames.ANONYMOUS_QUERY_LINK_INVOKE_NAME);
         }
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Teams.AI
             {
                 try
                 {
-                    TokenResponse response = await HandlerUserSignIn(context, state.ToString());
+                    TokenResponse response = await HandleUserSignIn(context, state.ToString());
                     if (!string.IsNullOrEmpty(response.Token))
                     {
                         return new SignInResponse(SignInStatus.Complete)
@@ -117,7 +117,7 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>True if valid. Otherwise, false.</returns>
-        public bool IsValidActivity(ITurnContext context)
+        public virtual bool IsValidActivity(ITurnContext context)
         {
             return context.Activity.Type == ActivityTypes.Invoke
                 && (context.Activity.Name == MessageExtensionsInvokeNames.QUERY_INVOKE_NAME
@@ -139,7 +139,7 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="magicCode">The magic code from user sign-in.</param>
         /// <returns>The token response if successfully verified the magic code</returns>
-        public abstract Task<TokenResponse> HandlerUserSignIn(ITurnContext context, string magicCode);
+        public abstract Task<TokenResponse> HandleUserSignIn(ITurnContext context, string magicCode);
 
         /// <summary>
         /// Gets the sign in link for the user.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.Teams.AI.Application.Authentication.MessageExtensions
+namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Handles authentication for Message Extensions in Teams using OAuth Connection.
     /// </summary>
-    public class OAuthMessageExtensionsAuthentication : MessageExtensionsAuthenticationBase
+    internal class OAuthMessageExtensionsAuthentication : MessageExtensionsAuthenticationBase
     {
         /// <summary>
         /// Gets the sign in link for the user.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Teams.AI.Application.Authentication.MessageExtensions
         /// <param name="context">The turn context</param>
         /// <param name="magicCode">The magic code from user sign-in.</param>
         /// <returns>The token response if successfully verified the magic code</returns>
-        public override Task<TokenResponse> HandlerUserSignIn(ITurnContext context, string magicCode)
+        public override Task<TokenResponse> HandleUserSignIn(ITurnContext context, string magicCode)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
@@ -4,7 +4,7 @@ using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.Exceptions;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Teams.AI.Application.Authentication.MessageExtensions
+namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Handles authentication for Message Extensions in Teams using Teams SSO.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
@@ -1,13 +1,24 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Microsoft.Identity.Client;
+using Microsoft.Teams.AI.Exceptions;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.AI.Application.Authentication.MessageExtensions
 {
     /// <summary>
     /// Handles authentication for Message Extensions in Teams using Teams SSO.
     /// </summary>
-    public class TeamsSsoMessageExtensionsAuthentication : MessageExtensionsAuthenticationBase
+    internal class TeamsSsoMessageExtensionsAuthentication : MessageExtensionsAuthenticationBase
     {
+        private TeamsSsoSettings _settings;
+
+        public TeamsSsoMessageExtensionsAuthentication(TeamsSsoSettings settings)
+        {
+            _settings = settings;
+        }
+
+
         /// <summary>
         /// Gets the sign in link for the user.
         /// </summary>
@@ -15,7 +26,9 @@ namespace Microsoft.Teams.AI.Application.Authentication.MessageExtensions
         /// <returns>The sign in link</returns>
         public override Task<string> GetSignInLink(ITurnContext context)
         {
-            throw new NotImplementedException();
+            string signInLink = $"{_settings.SignInLink}?scope={Uri.EscapeDataString(string.Join(" ", _settings.Scopes))}&clientId={_settings.MSAL.AppConfig.ClientId}&tenantId={_settings.MSAL.AppConfig.TenantId}";
+
+            return Task.FromResult(signInLink);
         }
 
         /// <summary>
@@ -24,9 +37,10 @@ namespace Microsoft.Teams.AI.Application.Authentication.MessageExtensions
         /// <param name="context">The turn context</param>
         /// <param name="magicCode">The magic code from user sign-in.</param>
         /// <returns>The token response if successfully verified the magic code</returns>
-        public override Task<TokenResponse> HandlerUserSignIn(ITurnContext context, string magicCode)
+        public override Task<TokenResponse> HandleUserSignIn(ITurnContext context, string magicCode)
         {
-            throw new NotImplementedException();
+            // Return empty token response to tirgger silentAuth again
+            return Task.FromResult(new TokenResponse());
         }
 
         /// <summary>
@@ -34,9 +48,43 @@ namespace Microsoft.Teams.AI.Application.Authentication.MessageExtensions
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>The token response if token exchange success</returns>
-        public override Task<TokenResponse> HandleSsoTokenExchange(ITurnContext context)
+        public override async Task<TokenResponse> HandleSsoTokenExchange(ITurnContext context)
         {
-            throw new NotImplementedException();
+            JObject value = JObject.FromObject(context.Activity.Value);
+            JToken? tokenExchangeRequest = value["authentication"];
+            JToken? token = tokenExchangeRequest?["token"];
+            if (token != null)
+            {
+                try
+                {
+                    AuthenticationResult result = await _settings.MSAL.AcquireTokenOnBehalfOf(
+                        _settings.Scopes,
+                        new UserAssertion(token.ToString())
+                    ).ExecuteAsync();
+                    return new TokenResponse()
+                    {
+                        Token = result.AccessToken,
+                        Expiration = result.ExpiresOn.ToString("O")
+                    };
+                }
+                catch (MsalUiRequiredException)
+                {
+                    // Requires user consent, ignore this exception
+                }
+                catch (Exception ex)
+                {
+                    string message = $"Failed to exchange access token with error: {ex.Message}";
+                    throw new TeamsAIAuthException(message);
+                }
+            }
+
+            return new TokenResponse();
+        }
+
+        public override bool IsValidActivity(ITurnContext context)
+        {
+            return base.IsValidActivity(context)
+                && context.Activity.Name == MessageExtensionsInvokeNames.QUERY_INVOKE_NAME;
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 
-namespace Microsoft.Teams.AI.Application.Authentication
+namespace Microsoft.Teams.AI
 {
     /// <summary>
     /// Handles authentication using OAuth Connection.
@@ -10,11 +11,42 @@ namespace Microsoft.Teams.AI.Application.Authentication
         where TState : TurnState, new()
     {
         /// <summary>
+        /// Initialize the authentication class
+        /// </summary>
+        /// <param name="app">The application object</param>
+        /// <param name="name">The name of the authentication handler</param>
+        /// <param name="storage">The storage to save turn state</param>
+        public void Initialize(Application<TState> app, string name, IStorage? storage = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Whether the current activity is a valid activity that supports authentication
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>True if valid. Otherwise, false.</returns>
         public Task<bool> IsValidActivity(ITurnContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// The handler function is called when the user sign in flow fails
+        /// </summary>
+        /// <param name="handler">The handler function to call when the user failed to signed in</param>
+        /// <returns>The class itself for chaining purpose</returns>
+        public IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// The handler function is called when the user has successfully signed in
+        /// </summary>
+        /// <param name="handler">The handler function to call when the user has successfully signed in</param>
+        /// <returns>The class itself for chaining purpose</returns>
+        public IAuthentication<TState> OnUserSignInSuccess(Func<ITurnContext, TState, Task> handler)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoSettings.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoSettings.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Identity.Client;
+
+namespace Microsoft.Teams.AI.Application.Authentication
+{
+    public class TeamsSsoSettings
+    {
+        public string[] Scopes { get; set; }
+
+        public IConfidentialClientApplication MSAL { get; set; }
+
+        public string SignInLink { get; set; }
+
+        public int Timeout { get; set; }
+
+        public bool EndOnInvalidMessage { get; set; }
+
+        public TeamsSsoSettings(string[] scopes, string signInLink, IConfidentialClientApplication msal, int timeout = 900000, bool endOnInvalidMessage = true)
+        {
+            this.Scopes = scopes;
+            this.MSAL = msal;
+            this.SignInLink = signInLink;
+            this.Timeout = timeout;
+            this.EndOnInvalidMessage = endOnInvalidMessage;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoSettings.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoSettings.cs
@@ -1,19 +1,51 @@
 ﻿using Microsoft.Identity.Client;
 
-namespace Microsoft.Teams.AI.Application.Authentication
+namespace Microsoft.Teams.AI
 {
+    /// <summary>
+    /// Settings to initialize TeamsSsoAuthentication class
+    /// </summary>
     public class TeamsSsoSettings
     {
+        /// <summary>
+        /// The AAD scopes for authentication. Only one resource is allowed in the scopes.
+        /// </summary>
         public string[] Scopes { get; set; }
 
+        /// <summary>
+        /// The instance of ConfidentialClientApplication from Microsoft Authentication Library
+        /// </summary>
         public IConfidentialClientApplication MSAL { get; set; }
 
+        /// <summary>
+        /// The sign in link for authentication.
+        /// The library will pass `scope`, `clientId`, and `tenantId` to the link as query parameters.
+        /// Your sign in page can leverage these parameters to compose the AAD sign-in URL.
+        /// </summary>
         public string SignInLink { get; set; }
 
+        /// <summary>
+        /// Number of milliseconds to wait for the user to authenticate.
+        /// Defaults to a value `900,000` (15 minutes).
+        /// Only works in conversional bot scenario.
+        /// </summary>
         public int Timeout { get; set; }
 
+        /// <summary>
+        /// Value indicating whether the authentication should end upon receiving an invalid message.
+        /// Defaults to `true`.
+        /// Only works in conversional bot scenario.
+        /// </summary>
         public bool EndOnInvalidMessage { get; set; }
 
+        /// <summary>
+        /// Initializes the class
+        /// </summary>
+        /// <param name="scopes">The AAD scopes for authentication.</param>
+        /// <param name="signInLink">The sign in link for authentication.</param>
+        /// <param name="msal">The instance of ConfidentialClientApplication from Microsoft Authentication Library</param>
+        /// <param name="timeout">Number of milliseconds to wait for the user to authenticate.</param>
+        /// <param name="endOnInvalidMessage">Value indicating whether the authentication should end upon receiving an invalid message.</param>
         public TeamsSsoSettings(string[] scopes, string signInLink, IConfidentialClientApplication msal, int timeout = 900000, bool endOnInvalidMessage = true)
         {
             this.Scopes = scopes;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Teams.AI.State;
+using Microsoft.Teams.AI.Exceptions;
+
+namespace Microsoft.Teams.AI.Application.Authentication
+{
+    internal class TurnStateProperty<TState> : IStatePropertyAccessor<TState>
+        where TState : new()
+    {
+        private string _propertyName;
+        private TurnStateEntry _state;
+
+        public TurnStateProperty(TurnState state, string scopeName, string propertyName)
+        {
+            _propertyName = propertyName;
+
+            var scope = state.GetScope(scopeName);
+            if (scope == null)
+            {
+                throw new TeamsAIException($"TurnStateProperty: TurnState missing state scope named {scope}");
+            }
+
+            _state = scope;
+        }
+
+        public string Name => throw new NotImplementedException();
+
+        public Task DeleteAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            _state.Value?.Remove(_propertyName);
+            return Task.CompletedTask;
+        }
+
+        public Task<TState> GetAsync(ITurnContext turnContext, Func<TState> defaultValueFactory = null, CancellationToken cancellationToken = default)
+        {
+            if (_state.Value != null)
+            {
+                if (!_state.Value.ContainsKey(_propertyName))
+                {
+                    _state.Value[_propertyName] = defaultValueFactory();
+                }
+
+                if (_state.Value.TryGetValue(_propertyName, out TState result))
+                {
+                    return Task.FromResult(result);
+                }
+                else
+                {
+                    TState defaultValue = defaultValueFactory();
+                    _state.Value[_propertyName] = defaultValue;
+                    return Task.FromResult(defaultValue);
+                }
+            }
+
+            throw new TeamsAIException("No state value available");
+        }
+
+        public Task SetAsync(ITurnContext turnContext, TState value, CancellationToken cancellationToken = default)
+        {
+            this._state.Value?.Set(_propertyName, value);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
@@ -2,7 +2,7 @@
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Exceptions;
 
-namespace Microsoft.Teams.AI.Application.Authentication
+namespace Microsoft.Teams.AI
 {
     internal class TurnStateProperty<TState> : IStatePropertyAccessor<TState>
         where TState : new()
@@ -14,7 +14,7 @@ namespace Microsoft.Teams.AI.Application.Authentication
         {
             _propertyName = propertyName;
 
-            var scope = state.GetScope(scopeName);
+            TurnStateEntry? scope = state.GetScope(scopeName);
             if (scope == null)
             {
                 throw new TeamsAIException($"TurnStateProperty: TurnState missing state scope named {scope}");

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TempState.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TempState.cs
@@ -34,6 +34,12 @@ namespace Microsoft.Teams.AI.State
         /// </summary>
         public const string AuthTokenKey = "authTokens";
 
+
+        /// <summary>
+        /// Name of the duplicate token exchange property
+        /// </summary>
+        public const string DuplicateTokenExchangeKey = "duplicateTokenExchange";
+
         /// <summary>
         /// Creates a new instance of the <see cref="TempState"/> class.
         /// </summary>
@@ -43,6 +49,8 @@ namespace Microsoft.Teams.AI.State
             this[OutputKey] = string.Empty;
             this[HistoryKey] = string.Empty;
             this[ActionOutputsKey] = new Dictionary<string, string>();
+            this[AuthTokenKey] = new Dictionary<string, string>();
+            this[DuplicateTokenExchangeKey] = false;
         }
 
         /// <summary>
@@ -90,6 +98,15 @@ namespace Microsoft.Teams.AI.State
         {
             get => Get<Dictionary<string, string>>(AuthTokenKey)!;
             set => Set(AuthTokenKey, value);
+        }
+
+        /// <summary>
+        /// Whether current token exchange is a duplicate one
+        /// </summary>
+        public bool DuplicateTokenExchange
+        {
+            get => Get<bool>(DuplicateTokenExchangeKey)!;
+            set => Set(DuplicateTokenExchangeKey, value);
         }
     }
 }


### PR DESCRIPTION
## Linked issues

closes: #861

## Details

1. Implement token exchange and sign in logic for Teams SSO auth implementation
2. Updated the `IAuthentication` interface to initialize after `Application` instance is created - the authentication classes has dependency to `Application` when initialize
3. Change visibility of some classes to `internal`
4. Update the namespace of authentication classes to `Microsoft.Teams.AI` to align with other classes under the `Application` folder


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

Because some classes from botbuilder cannot be mocked, the UT for the new code is some kind of blocked. I have finished manual testing against the code. Will follow up with the UT problem.
