### PR TITLE
[JS] fix: remove duplicate OpenAI key conditional check

### DIFF
--- a/js/samples/04.ai.b.messageExtensions.AI-ME/src/index.ts
+++ b/js/samples/04.ai.b.messageExtensions.AI-ME/src/index.ts
@@ -91,10 +91,6 @@ import { createInitialView, createEditView, createPostCard } from './cards';
 // Set PREVIEW_MODE to true to enable this feature and update your manifest accordingly.
 const PREVIEW_MODE = false;
 
-if (!process.env.OPENAI_API_KEY) {
-    throw new Error('Missing environment OPENAI_API_KEY');
-}
-
 interface ConversationState extends DefaultConversationState {
 }
 


### PR DESCRIPTION
## Linked issues

closes: #930 

## Details

There's a duplicate conditional check for an OpenAI key (line 94 and 107). This restricts developers from using AzureOpenAI.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes