### PR TITLE
[C#] refactor: fix warnings in code

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
 
             // act
-            var response = await authManager.SignUserIn(turnContext, turnState);
+            var response = await authManager.SignUserInAsync(turnContext, turnState);
 
             // assert
             Assert.Equal(SignInStatus.Complete, response.Status);
@@ -48,7 +48,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
 
             // act
-            var response = await authManager.SignUserIn(turnContext, turnState, "sharepoint");
+            var response = await authManager.SignUserInAsync(turnContext, turnState, "sharepoint");
 
             // assert
             Assert.Equal(SignInStatus.Complete, response.Status);
@@ -72,7 +72,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
 
             // act
-            var response = await authManager.SignUserIn(turnContext, turnState);
+            var response = await authManager.SignUserInAsync(turnContext, turnState);
 
             // assert
             Assert.Equal(SignInStatus.Pending, response.Status);
@@ -99,7 +99,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             };
 
             // act
-            await authManager.SignOutUser(turnContext, turnState);
+            await authManager.SignOutUserAsync(turnContext, turnState);
 
             // assert
             Assert.False(turnState.Temp.AuthTokens.ContainsKey("graph"));
@@ -126,7 +126,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             };
 
             // act
-            await authManager.SignOutUser(turnContext, turnState, "sharepoint");
+            await authManager.SignOutUserAsync(turnContext, turnState, "sharepoint");
 
             // assert
             Assert.False(turnState.Temp.AuthTokens.ContainsKey("sharepoint"));
@@ -147,7 +147,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             var turnContext = MockTurnContext();
 
             // act
-            var validActivity = await authManager.IsValidActivity(turnContext);
+            var validActivity = await authManager.IsValidActivityAsync(turnContext);
 
             // assert
             Assert.True(validActivity);
@@ -167,7 +167,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             var turnContext = MockTurnContext();
 
             // act
-            var validActivity = await authManager.IsValidActivity(turnContext, "sharepoint");
+            var validActivity = await authManager.IsValidActivityAsync(turnContext, "sharepoint");
 
             // assert
             Assert.True(validActivity);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
@@ -21,16 +21,16 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             _throwExceptionWhenContinue = throwExceptionWhenContinue;
         }
 
-        public override Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty, CancellationToken cancellationToken = default)
         {
             if (_throwExceptionWhenContinue)
             {
-                throw new Exception("mocked error");
+                throw new TeamsAIAuthException("mocked error");
             }
             return Task.FromResult(_continueDialogResult);
         }
 
-        public override Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty, CancellationToken cancellationToken = default)
         {
             var result = _runDialogResult.FirstOrDefault();
             if (result == null)
@@ -113,7 +113,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
         {
             // arrange
             var app = new Application<TurnState>(new ApplicationOptions<TurnState>());
-            var botAuth = new MockedBotAuthentication<TurnState>(app, "test", runDialogResult: new List<DialogTurnResult>() { new DialogTurnResult(DialogTurnStatus.Complete, new TokenResponse(token: "test token")) });
+            var botAuth = new MockedBotAuthentication<TurnState>(app, "test", runDialogResult: new List<DialogTurnResult>() { new(DialogTurnStatus.Complete, new TokenResponse(token: "test token")) });
             var context = MockTurnContext();
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
 
@@ -130,7 +130,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
         {
             // arrange
             var app = new Application<TurnState>(new ApplicationOptions<TurnState>());
-            var botAuth = new MockedBotAuthentication<TurnState>(app, "test", runDialogResult: new List<DialogTurnResult>() { new DialogTurnResult(DialogTurnStatus.Complete) });
+            var botAuth = new MockedBotAuthentication<TurnState>(app, "test", runDialogResult: new List<DialogTurnResult>() { new(DialogTurnStatus.Complete) });
             var context = MockTurnContext();
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
 
@@ -161,7 +161,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
                 messageText = context.Activity.Text;
                 return Task.CompletedTask;
             });
-            botAuth.OnUserSignInFailure((context, state, exception) => { throw new Exception("sign in failure handler should not be called"); });
+            botAuth.OnUserSignInFailure((context, state, exception) => { throw new TeamsAIAuthException("sign in failure handler should not be called"); });
 
             // act
             await botAuth.HandleSignInActivity(context, state, new CancellationToken());
@@ -180,7 +180,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             var context = MockTurnContext();
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
             TeamsAIAuthException? authException = null;
-            botAuth.OnUserSignInSuccess((context, state) => { throw new Exception("sign in success handler should not be called"); });
+            botAuth.OnUserSignInSuccess((context, state) => { throw new TeamsAIAuthException("sign in success handler should not be called"); });
             botAuth.OnUserSignInFailure((context, state, exception) => { authException = exception; return Task.CompletedTask; });
 
             // act
@@ -200,7 +200,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             var context = MockTurnContext();
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
             TeamsAIAuthException? authException = null;
-            botAuth.OnUserSignInSuccess((context, state) => { throw new Exception("sign in success handler should not be called"); });
+            botAuth.OnUserSignInSuccess((context, state) => { throw new TeamsAIAuthException("sign in success handler should not be called"); });
             botAuth.OnUserSignInFailure((context, state, exception) => { authException = exception; return Task.CompletedTask; });
 
             // act

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
 using Microsoft.Teams.AI.Tests.TestUtils;
+using Microsoft.Teams.AI.Exceptions;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
 {
@@ -26,7 +27,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         {
             if (_signInResponse == null)
             {
-                throw new Exception("HandlerUserSignIn failed");
+                throw new TeamsAIAuthException("HandlerUserSignIn failed");
             }
             return Task.FromResult(_signInResponse);
         }
@@ -35,7 +36,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         {
             if (_tokenExchangeResponse == null)
             {
-                throw new Exception("HandleSsoTokenExchange failed");
+                throw new TeamsAIAuthException("HandleSsoTokenExchange failed");
             }
             return Task.FromResult(_tokenExchangeResponse);
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             return;
         }
 
-        public Task<bool> IsValidActivity(ITurnContext context)
+        public Task<bool> IsValidActivityAsync(ITurnContext context)
         {
             return Task.FromResult(_validActivity);
         }
@@ -38,7 +38,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             return this;
         }
 
-        public Task<SignInResponse> SignInUser(ITurnContext context, TState state)
+        public Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             var result = new SignInResponse(_mockedStatus);
             if (_mockedStatus == SignInStatus.Complete)
@@ -48,7 +48,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             return Task.FromResult(result);
         }
 
-        public Task SignOutUser(ITurnContext context, TState state)
+        public Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -846,9 +846,9 @@ namespace Microsoft.Teams.AI
                 if (Authentication != null && _startSignIn != null && await _startSignIn(turnContext, cancellationToken))
                 {
                     // Should skip activity that does not support sign-in
-                    if (await Authentication.IsValidActivity(turnContext))
+                    if (await Authentication.IsValidActivityAsync(turnContext))
                     {
-                        SignInResponse response = await Authentication.SignUserIn(turnContext, turnState);
+                        SignInResponse response = await Authentication.SignUserInAsync(turnContext, turnState);
                         if (response.Status == SignInStatus.Pending)
                         {
                             // Requires user action, save state and stop processing current activity

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Teams.AI
     /// <summary>
     /// Base class for adaptive card authentication that handles common logic
     /// </summary>
-    public abstract class AdaptiveCardsAuthenticationBase
+    internal abstract class AdaptiveCardsAuthenticationBase
     {
         /// <summary>
         /// Authenticate current user

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/OAuthAdaptiveCardsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/OAuthAdaptiveCardsAuthentication.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Handles authentication for Adaptive Cards in Teams using OAuth Connection.
     /// </summary>
-    public class OAuthAdaptiveCardsAuthentication : AdaptiveCardsAuthenticationBase
+    internal class OAuthAdaptiveCardsAuthentication : AdaptiveCardsAuthenticationBase
     {
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/TeamsSsoAdaptiveCardsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/TeamsSsoAdaptiveCardsAuthentication.cs
@@ -1,9 +1,0 @@
-﻿namespace Microsoft.Teams.AI
-{
-    /// <summary>
-    /// Handles authentication for Adaptive Cards in Teams based on Teams SSO.
-    /// </summary>
-    public class TeamsSsoAdaptiveCardsAuthentication : AdaptiveCardsAuthenticationBase
-    {
-    }
-}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
         /// <param name="handlerName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public async Task<SignInResponse> SignUserIn(ITurnContext context, TState state, string? handlerName = null)
+        public async Task<SignInResponse> SignUserInAsync(ITurnContext context, TState state, string? handlerName = null, CancellationToken cancellationToken = default)
         {
             if (handlerName == null)
             {
@@ -47,7 +48,7 @@ namespace Microsoft.Teams.AI
             }
 
             IAuthentication<TState> auth = Get(handlerName);
-            SignInResponse response = await auth.SignInUser(context, state);
+            SignInResponse response = await auth.SignInUserAsync(context, state, cancellationToken);
             if (response.Status == SignInStatus.Complete)
             {
                 AuthUtilities.SetTokenInState(state, handlerName, response.Token!);
@@ -61,7 +62,8 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
         /// <param name="handlerName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
-        public async Task SignOutUser(ITurnContext context, TState state, string? handlerName = null)
+        /// <param name="cancellationToken">The cancellation token</param>
+        public async Task SignOutUserAsync(ITurnContext context, TState state, string? handlerName = null, CancellationToken cancellationToken = default)
         {
             if (handlerName == null)
             {
@@ -69,7 +71,7 @@ namespace Microsoft.Teams.AI
             }
 
             IAuthentication<TState> auth = Get(handlerName);
-            await auth.SignOutUser(context, state);
+            await auth.SignOutUserAsync(context, state, cancellationToken);
             AuthUtilities.DeleteTokenFromState(state, handlerName);
         }
 
@@ -79,7 +81,7 @@ namespace Microsoft.Teams.AI
         /// <param name="context">Current turn context.</param>
         /// <param name="handlerName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
         /// <returns>True if current activity supports authentication. Otherwise, false.</returns>
-        public async Task<bool> IsValidActivity(ITurnContext context, string? handlerName = null)
+        public async Task<bool> IsValidActivityAsync(ITurnContext context, string? handlerName = null)
         {
             if (handlerName == null)
             {
@@ -87,7 +89,7 @@ namespace Microsoft.Teams.AI
             }
 
             IAuthentication<TState> auth = Get(handlerName);
-            return await auth.IsValidActivity(context);
+            return await auth.IsValidActivityAsync(context);
         }
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/OAuthBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/OAuthBotAuthentication.cs
@@ -26,8 +26,9 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
         /// <param name="dialogStateProperty">The property name for storing dialog state.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>Dialog turn result that contains token if sign in success</returns>
-        public override Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -38,8 +39,9 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
         /// <param name="dialogStateProperty">The property name for storing dialog state.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>Dialog turn result that contains token if sign in success</returns>
-        public override Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
@@ -43,8 +43,9 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
         /// <param name="dialogStateProperty">The property name for storing dialog state.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>Dialog turn result that contains token if sign in success</returns>
-        public override async Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override async Task<DialogTurnResult> ContinueDialog(ITurnContext context, TState state, string dialogStateProperty, CancellationToken cancellationToken = default)
         {
             DialogContext dialogContext = await CreateSsoDialogContext(context, state, dialogStateProperty);
             return await dialogContext.ContinueDialogAsync();
@@ -56,8 +57,9 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
         /// <param name="dialogStateProperty">The property name for storing dialog state.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>Dialog turn result that contains token if sign in success</returns>
-        public override async Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty)
+        public override async Task<DialogTurnResult> RunDialog(ITurnContext context, TState state, string dialogStateProperty, CancellationToken cancellationToken = default)
         {
             DialogContext dialogContext = await CreateSsoDialogContext(context, state, dialogStateProperty);
             DialogTurnResult result = await dialogContext.ContinueDialogAsync();
@@ -76,8 +78,8 @@ namespace Microsoft.Teams.AI
         /// <returns>True if the activity should be handled by current authentication hanlder. Otherwise, false.</returns>
         protected override async Task<bool> TokenExchangeRouteSelector(ITurnContext context, CancellationToken cancellationToken)
         {
-            JObject value = JObject.FromObject(context.Activity.Value);
-            JToken? id = value["id"];
+            JObject? value = context.Activity.Value as JObject;
+            JToken? id = value?["id"];
             string idStr = id?.ToString() ?? "";
             return await base.TokenExchangeRouteSelector(context, cancellationToken)
                 && this._tokenExchangeIdRegex.IsMatch(idStr);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
@@ -105,7 +105,12 @@ namespace Microsoft.Teams.AI
                 {
                     try
                     {
-                        AuthenticationResult exchangedToken = await _settings.MSAL.AcquireTokenOnBehalfOf(_settings.Scopes, new UserAssertion(ssoToken)).ExecuteAsync();
+                        string homeAccountId = $"{context.Activity.From.AadObjectId}.{context.Activity.Conversation.TenantId}";
+                        AuthenticationResult exchangedToken = await ((ILongRunningWebApi)_settings.MSAL).InitiateLongRunningProcessInWebApi(
+                                _settings.Scopes,
+                                ssoToken,
+                                ref homeAccountId
+                            ).ExecuteAsync();
 
                         tokenResponse = new TokenResponse
                         {
@@ -215,7 +220,7 @@ namespace Microsoft.Teams.AI
             return (context.Activity.Type == ActivityTypes.Invoke) && (context.Activity.Name == SignInConstants.TokenExchangeOperationName);
         }
 
-        private static async Task SendInvokeResponseAsync(ITurnContext turnContext, HttpStatusCode statusCode, object body, CancellationToken cancellationToken)
+        private static async Task SendInvokeResponseAsync(ITurnContext turnContext, HttpStatusCode statusCode, object? body, CancellationToken cancellationToken)
         {
             await turnContext.SendActivityAsync(
                 new Activity

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -56,22 +56,24 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">Current turn context.</param>
         /// <param name="state">Application state.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The authentication token if user is signed in.</returns>
-        Task<SignInResponse> SignInUser(ITurnContext context, TState state);
+        Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Signs out a user.
         /// </summary>
         /// <param name="context">Current turn context.</param>
         /// <param name="state">Application state.</param>
-        Task SignOutUser(ITurnContext context, TState state);
+        /// <param name="cancellationToken">The cancellation token</param>
+        Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Check whether current activity supports authentication.
         /// </summary>
         /// <param name="context">Current turn context.</param>
         /// <returns>True if current activity supports authentication. Otherwise, false.</returns>
-        Task<bool> IsValidActivity(ITurnContext context);
+        Task<bool> IsValidActivityAsync(ITurnContext context);
 
         /// <summary>
         /// Initialize the authentication class

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
@@ -8,14 +8,15 @@ namespace Microsoft.Teams.AI
     /// <summary>
     /// Base class for message extension authentication that handles common logic
     /// </summary>
-    public abstract class MessageExtensionsAuthenticationBase
+    internal abstract class MessageExtensionsAuthenticationBase
     {
         /// <summary>
         /// Authenticate current user
         /// </summary>
         /// <param name="context">The turn context</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public async Task<SignInResponse> AuthenticateAsync(ITurnContext context)
+        public async Task<SignInResponse> AuthenticateAsync(ITurnContext context, CancellationToken cancellationToken = default)
         {
             JObject value = JObject.FromObject(context.Activity.Value);
             JToken? tokenExchangeRequest = value["authentication"];
@@ -106,7 +107,7 @@ namespace Microsoft.Teams.AI
                 },
             };
 
-            await context.SendActivityAsync(ActivityUtilities.CreateInvokeResponseActivity(resposne));
+            await context.SendActivityAsync(ActivityUtilities.CreateInvokeResponseActivity(resposne), cancellationToken);
 
             return new SignInResponse(SignInStatus.Pending);
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
@@ -57,10 +57,13 @@ namespace Microsoft.Teams.AI
             {
                 try
                 {
-                    AuthenticationResult result = await _settings.MSAL.AcquireTokenOnBehalfOf(
-                        _settings.Scopes,
-                        new UserAssertion(token.ToString())
-                    ).ExecuteAsync();
+                    string homeAccountId = $"{context.Activity.From.AadObjectId}.{context.Activity.Conversation.TenantId}";
+                    AuthenticationResult result = await ((ILongRunningWebApi)_settings.MSAL).InitiateLongRunningProcessInWebApi(
+                    _settings.Scopes,
+                            token.ToString(),
+                            ref homeAccountId
+                        ).ExecuteAsync();
+
                     return new TokenResponse()
                     {
                         Token = result.AccessToken,

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>True if valid. Otherwise, false.</returns>
-        public Task<bool> IsValidActivity(ITurnContext context)
+        public Task<bool> IsValidActivityAsync(ITurnContext context)
         {
             throw new NotImplementedException();
         }
@@ -56,8 +56,9 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
+        /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public Task<SignInResponse> SignInUser(ITurnContext context, TState state)
+        public Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -67,7 +68,8 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
-        public Task SignOutUser(ITurnContext context, TState state)
+        /// <param name="cancellationToken">The cancellation token</param>
+        public Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
@@ -31,22 +31,25 @@ namespace Microsoft.Teams.AI
             return Task.CompletedTask;
         }
 
-        public Task<TState> GetAsync(ITurnContext turnContext, Func<TState> defaultValueFactory = null, CancellationToken cancellationToken = default)
+        public Task<TState> GetAsync(ITurnContext turnContext, Func<TState>? defaultValueFactory = null, CancellationToken cancellationToken = default)
         {
             if (_state.Value != null)
             {
-                if (!_state.Value.ContainsKey(_propertyName))
-                {
-                    _state.Value[_propertyName] = defaultValueFactory();
-                }
-
                 if (_state.Value.TryGetValue(_propertyName, out TState result))
                 {
                     return Task.FromResult(result);
                 }
                 else
                 {
+                    if (defaultValueFactory == null)
+                    {
+                        throw new ArgumentNullException(nameof(defaultValueFactory));
+                    }
                     TState defaultValue = defaultValueFactory();
+                    if (defaultValue == null)
+                    {
+                        throw new ArgumentNullException(nameof(defaultValue));
+                    }
                     _state.Value[_propertyName] = defaultValue;
                     return Task.FromResult(defaultValue);
                 }


### PR DESCRIPTION
## Linked issues

closes: #861 

## Details

1. Fix warnings in the code
2. Add cancellation token parameter to interface
3. Mark bot/message extension/adaptive card base class as internal - we can change them to public in the future if we want to developers to leverage them. For now, they should be internal implementation.
4. Add `Async` to function names
5. Fix a bug that cannot read token from MSAL OBO token cache by using the `ILongRunningWebApi` interface
6. Fix a bug that token exchange route selector may throw exception

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

