### PR TITLE
[JS] chore: Fix auth sample TTK F5 flow

### DIFF
--- a/js/samples/06.auth.oauth.adaptiveCard/README.md
+++ b/js/samples/06.auth.oauth.adaptiveCard/README.md
@@ -39,9 +39,10 @@ This sample requires creating an OAuth Connection in Azure Bot Service, which pr
 3. In a terminal, navigate to the sample root.
 
     ```bash
-    cd teams-ai/js/samples/06.auth.adaptiveCardSSO/
-    yarn start
+    cd teams-ai/js/samples/06.auth.oauth.adaptivecard
     ```
+
+4. Jump to [Multiple ways to test](#multiple-ways-to-test).
 
 ## Interacting with the bot
 
@@ -92,7 +93,7 @@ You can also use the Teams Toolkit CLI to run this sample.
 1. In the repository directory, run the Teams Toolkit CLI commands to automate the setup needed for the app
 
     ```bash
-    cd teams-ai/js/samples/06.auth.adaptiveCardSSO/
+    cd teams-ai/js/samples/06.auth.oauth.adaptivecard
     teamsfx provision --env local
 
     ```
@@ -113,10 +114,10 @@ You can also use the Teams Toolkit CLI to run this sample.
 
 > If you used Teams Toolkit in the above steps, you can [upload a custom app](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) to a desktop client using the `/appPackage/appPackage.local.zip` file created by the tools and skip to step 6.
 
-1. In a terminal, navigate to `teams-ai/js/samples/06.auth.adaptiveCardSSO/`
+1. In a terminal, navigate to `teams-ai/js/samples/06.auth.oauth.adaptivecard`
 
     ```bash
-    cd teams-ai/js/samples/06.auth.adaptiveCardSSO/
+    cd teams-ai/js/samples/06.auth.oauth.adaptivecard
     ```
 
 1. Run ngrok tunneling service - point to port 3978

--- a/js/samples/06.auth.oauth.adaptiveCard/teamsapp.local.yml
+++ b/js/samples/06.auth.oauth.adaptiveCard/teamsapp.local.yml
@@ -101,11 +101,6 @@ provision:
 # Defines what the `deploy` lifecycle step does with Teams Toolkit.
 # Runs after `provision` during Start Debugging (F5) or run manually using `teamsfx deploy --env local`.
 deploy:
-  # Ensures that the project dependnecies are installed.
-  - uses: cli/runNpmCommand
-    with:
-      args: install --no-audit
-
   # Provides the Teams Toolkit .env file values to the apps runtime so they can be accessed with `process.env`.
   - uses: file/createOrUpdateEnvironmentFile
     with:

--- a/js/samples/06.auth.oauth.bot/.vscode/tasks.json
+++ b/js/samples/06.auth.oauth.bot/.vscode/tasks.json
@@ -10,7 +10,7 @@
                 "Validate prerequisites",
                 "Start local tunnel",
                 "Provision",
-                // "Deploy",
+                "Deploy",
                 "Start application"
             ],
             "dependsOrder": "sequence"

--- a/js/samples/06.auth.oauth.bot/README.md
+++ b/js/samples/06.auth.oauth.bot/README.md
@@ -39,9 +39,11 @@ This sample requires creating an OAuth Connection in Azure Bot Service, which pr
 3. In a terminal, navigate to the sample root.
 
     ```bash
-    cd teams-ai/js/samples/01.messaging.a.SsoAuthBot/
-    yarn start
+    cd teams-ai/js/samples/06.auth.oauth.bot/
     ```
+
+4. Jump to [Multiple ways to test](#multiple-ways-to-test).
+
 
 ## Interacting with the bot
 
@@ -92,7 +94,7 @@ You can also use the Teams Toolkit CLI to run this sample.
 1. In the repository directory, run the Teams Toolkit CLI commands to automate the setup needed for the app
 
     ```bash
-    cd teams-ai/js/samples/01.messaging.a.SsoAuthBot/
+    cd teams-ai/js/samples/06.auth.oauth.bot/
     teamsfx provision --env local
 
     ```
@@ -113,10 +115,10 @@ You can also use the Teams Toolkit CLI to run this sample.
 
 > If you used Teams Toolkit in the above steps, you can [upload a custom app](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) to a desktop client using the `/appPackage/appPackage.local.zip` file created by the tools and skip to step 6.
 
-1. In a terminal, navigate to `teams-ai/js/samples/01.messaging.a.SsoAuthBot/`
+1. In a terminal, navigate to `teams-ai/js/samples/06.auth.oauth.bot/`
 
     ```bash
-    cd teams-ai/js/samples/01.messaging.a.SsoAuthBot/
+    cd teams-ai/js/samples/06.auth.oauth.bot/
     ```
 
 1. Run ngrok tunneling service - point to port 3978

--- a/js/samples/06.auth.oauth.bot/teamsapp.local.yml
+++ b/js/samples/06.auth.oauth.bot/teamsapp.local.yml
@@ -101,11 +101,6 @@ provision:
 # Defines what the `deploy` lifecycle step does with Teams Toolkit.
 # Runs after `provision` during Start Debugging (F5) or run manually using `teamsfx deploy --env local`.
 deploy:
-  # Ensures that the project dependnecies are installed.
-  - uses: cli/runNpmCommand
-    with:
-      args: install --no-audit
-
   # Provides the Teams Toolkit .env file values to the apps runtime so they can be accessed with `process.env`.
   - uses: file/createOrUpdateEnvironmentFile
     with:

--- a/js/samples/06.auth.oauth.messageExtension/README.md
+++ b/js/samples/06.auth.oauth.messageExtension/README.md
@@ -39,9 +39,10 @@ This sample requires creating an OAuth Connection in Azure Bot Service, which pr
 3. In a terminal, navigate to the sample root.
 
     ```bash
-    cd teams-ai/js/samples/06.auth.messageExtensionSSO/
-    yarn start
+    cd teams-ai-/js/samples/06.auth.oauth.messageExtension
     ```
+
+4. Jump to [Multiple ways to test](#multiple-ways-to-test).
 
 ## Interacting with the bot
 
@@ -92,7 +93,7 @@ You can also use the Teams Toolkit CLI to run this sample.
 1. In the repository directory, run the Teams Toolkit CLI commands to automate the setup needed for the app
 
     ```bash
-    cd teams-ai/js/samples/06.auth.messageExtensionSSO/
+    cd teams-ai-/js/samples/06.auth.oauth.messageExtension
     teamsfx provision --env local
 
     ```
@@ -113,10 +114,10 @@ You can also use the Teams Toolkit CLI to run this sample.
 
 > If you used Teams Toolkit in the above steps, you can [upload a custom app](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload) to a desktop client using the `/appPackage/appPackage.local.zip` file created by the tools and skip to step 6.
 
-1. In a terminal, navigate to `teams-ai/js/samples/06.auth.messageExtensionSSO/`
+1. In a terminal, navigate to `teams-ai-/js/samples/06.auth.oauth.messageExtension`
 
     ```bash
-    cd teams-ai/js/samples/06.auth.messageExtensionSSO/
+    cd teams-ai-/js/samples/06.auth.oauth.messageExtension
     ```
 
 1. Run ngrok tunneling service - point to port 3978

--- a/js/samples/06.auth.oauth.messageExtension/teamsapp.local.yml
+++ b/js/samples/06.auth.oauth.messageExtension/teamsapp.local.yml
@@ -101,12 +101,7 @@ provision:
 # Defines what the `deploy` lifecycle step does with Teams Toolkit.
 # Runs after `provision` during Start Debugging (F5) or run manually using `teamsfx deploy --env local`.
 deploy:
-  # Ensures that the project dependnecies are installed.
-  - uses: cli/runNpmCommand
-    with:
-      args: install --no-audit
-
-  # Provides the Teams Toolkit .env file values to the apps runtime so they can be accessed with `process.env`.
+# Provides the Teams Toolkit .env file values to the apps runtime so they can be accessed with `process.env`.
   - uses: file/createOrUpdateEnvironmentFile
     with:
       target: ./.env


### PR DESCRIPTION
## Linked issues

closes: #955 (issue number)

## Details
samples fixed: oauth bot, message extension & adaptive card 
- Fix readme
- remove `npm install` in the F5 flow since users will use yarn and do install & build before. Plus the re-build happens through nodemon once in debug mode.
- uncomment "Deploy" in the oauth bot.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
