### PR TITLE
[C#] feat: Implement `GetTokenOrStartSignInAsync` method public interface

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthUtilitiesTest.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthUtilitiesTest.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Teams.AI.State;
+using Microsoft.Teams.AI.Tests.TestUtils;
+
+namespace Microsoft.Teams.AI.Tests.Application.Authentication
+{
+    public class AuthUtilitiesTest
+    {
+        [Fact]
+        public async void Test_SetTokenInState()
+        {
+            // Arrange
+            TurnContext context = TurnStateConfig.CreateConfiguredTurnContext();
+            TurnState state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
+            string settingName = "settingName";
+            string token = "token";
+
+            // Act
+            AuthUtilities.SetTokenInState(state, settingName, token);
+
+            // Assert
+            Assert.True(state.Temp.AuthTokens.ContainsKey(settingName));
+        }
+
+        [Fact]
+        public async void Test_DeleteTokenFromState()
+        {
+            // Arrange
+            TurnContext context = TurnStateConfig.CreateConfiguredTurnContext();
+            TurnState state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
+            string settingName = "settingName";
+            string token = "token";
+
+            // Act
+            state.Temp.AuthTokens[settingName] = token;
+            AuthUtilities.DeleteTokenFromState(state, settingName);
+
+            // Assert
+            Assert.False(state.Temp.AuthTokens.ContainsKey(settingName));
+        }
+
+        [Fact]
+        public async void Test_UserInSignInFlow()
+        {
+            // Arrange
+            TurnContext context = TurnStateConfig.CreateConfiguredTurnContext();
+            TurnState state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
+            string settingName = "settingName";
+
+            // Act
+            state.User.Set(AuthUtilities.IS_SIGNED_IN_KEY, settingName);
+            string? response = AuthUtilities.UserInSignInFlow(state);
+
+            // Assert
+            Assert.True(response == settingName);
+
+        }
+
+        [Fact]
+        public async void Test_SetUserInSignInFlow()
+        {
+            // Arrange
+            TurnContext context = TurnStateConfig.CreateConfiguredTurnContext();
+            TurnState state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
+            string settingName = "settingName";
+
+            // Act
+            AuthUtilities.SetUserInSignInFlow(state, settingName);
+
+            // Assert
+            Assert.True(state.User.Get<string>(AuthUtilities.IS_SIGNED_IN_KEY) == settingName);
+        }
+
+        [Fact]
+        public async void Test_DeleteUserInSignInFlow()
+        {
+            // Arrange
+            TurnContext context = TurnStateConfig.CreateConfiguredTurnContext();
+            TurnState state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
+            string settingName = "settingName";
+
+            // Act
+            state.User.Set(AuthUtilities.IS_SIGNED_IN_KEY, settingName);
+            AuthUtilities.DeleteUserInSignInFlow(state);
+
+            // Assert
+            Assert.False(state.User.ContainsKey(AuthUtilities.IS_SIGNED_IN_KEY));
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
         {
             if (_throwExceptionWhenContinue)
             {
-                throw new TeamsAIAuthException("mocked error");
+                throw new AuthException("mocked error");
             }
             return Task.FromResult(_continueDialogResult);
         }
@@ -161,7 +161,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
                 messageText = context.Activity.Text;
                 return Task.CompletedTask;
             });
-            botAuth.OnUserSignInFailure((context, state, exception) => { throw new TeamsAIAuthException("sign in failure handler should not be called"); });
+            botAuth.OnUserSignInFailure((context, state, exception) => { throw new AuthException("sign in failure handler should not be called"); });
 
             // act
             await botAuth.HandleSignInActivity(context, state, new CancellationToken());
@@ -179,8 +179,8 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             var botAuth = new MockedBotAuthentication<TurnState>(app, "test", continueDialogResult: new DialogTurnResult(DialogTurnStatus.Complete));
             var context = MockTurnContext();
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
-            TeamsAIAuthException? authException = null;
-            botAuth.OnUserSignInSuccess((context, state) => { throw new TeamsAIAuthException("sign in success handler should not be called"); });
+            AuthException? authException = null;
+            botAuth.OnUserSignInSuccess((context, state) => { throw new AuthException("sign in success handler should not be called"); });
             botAuth.OnUserSignInFailure((context, state, exception) => { authException = exception; return Task.CompletedTask; });
 
             // act
@@ -199,8 +199,8 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             var botAuth = new MockedBotAuthentication<TurnState>(app, "test", throwExceptionWhenContinue: true);
             var context = MockTurnContext();
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
-            TeamsAIAuthException? authException = null;
-            botAuth.OnUserSignInSuccess((context, state) => { throw new TeamsAIAuthException("sign in success handler should not be called"); });
+            AuthException? authException = null;
+            botAuth.OnUserSignInSuccess((context, state) => { throw new AuthException("sign in success handler should not be called"); });
             botAuth.OnUserSignInFailure((context, state, exception) => { authException = exception; return Task.CompletedTask; });
 
             // act

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         {
             if (_signInResponse == null)
             {
-                throw new TeamsAIAuthException("HandlerUserSignIn failed");
+                throw new AuthException("HandlerUserSignIn failed");
             }
             return Task.FromResult(_signInResponse);
         }
@@ -36,7 +36,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         {
             if (_tokenExchangeResponse == null)
             {
-                throw new TeamsAIAuthException("HandleSsoTokenExchange failed");
+                throw new AuthException("HandleSsoTokenExchange failed");
             }
             return Task.FromResult(_tokenExchangeResponse);
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Teams.AI.Exceptions;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
 {
-    internal class MockedMessageExtensionsAuthentication : MessageExtensionsAuthenticationBase
+    internal sealed class MockedMessageExtensionsAuthentication : MessageExtensionsAuthenticationBase
     {
         private TokenResponse? _tokenExchangeResponse;
         private TokenResponse? _signInResponse;
@@ -42,12 +42,12 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         }
     }
 
-    internal class TokenExchangeRequest
+    internal sealed class TokenExchangeRequest
     {
         public Authentication? authentication { get; set; }
     }
 
-    internal class Authentication
+    internal sealed class Authentication
     {
         public string? token { get; set; }
     }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
@@ -23,12 +23,17 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             return;
         }
 
+        public Task<string?> IsUserSignedInAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
         public Task<bool> IsValidActivityAsync(ITurnContext context)
         {
             return Task.FromResult(_validActivity);
         }
 
-        public IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler)
+        public IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, AuthException, Task> handler)
         {
             return this;
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -859,17 +859,17 @@ namespace Microsoft.Teams.AI
 
                 // If user is in sign in flow, return the authentication setting name
                 string? settingName = AuthUtilities.UserInSignInFlow(turnState);
-                bool shouldStartSignIn = _startSignIn != null && await _startSignIn(turnContext, cancellationToken;
+                bool shouldStartSignIn = _startSignIn != null && await _startSignIn(turnContext, cancellationToken);
 
                 // Sign the user in
-                if (Authentication != null && (shouldStartSignIn || settingName != null))
+                if (this._authentication != null && (shouldStartSignIn || settingName != null))
                 {
                     if (settingName == null)
                     {
-                        settingName = this.Authentication.Default;
+                        settingName = this._authentication.Default;
                     }
 
-                    SignInResponse response = await Authentication.SignUserInAsync(turnContext, turnState, settingName);
+                    SignInResponse response = await this._authentication.SignUserInAsync(turnContext, turnState, settingName);
 
                     if (response.Status == SignInStatus.Complete)
                     {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthUtilities.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthUtilities.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Teams.AI
     /// </summary>
     internal class AuthUtilities
     {
+        public const string IS_SIGNED_IN_KEY = "__InSignInFlow__";
+
         /// <summary>
         /// Set token in state
         /// </summary>
@@ -35,6 +37,45 @@ namespace Microsoft.Teams.AI
             {
                 state.Temp.AuthTokens.Remove(name);
             }
+        }
+
+        /// <summary>
+        /// Determines if the user is in the sign in flow.
+        /// </summary>
+        /// <typeparam name="TState">The turn state.</typeparam>
+        /// <param name="state">The turn state.</param>
+        /// <returns>The connection setting name if the user is in sign in flow. Otherwise null.</returns>
+        public static string? UserInSignInFlow<TState>(TState state) where TState : TurnState, new()
+        {
+            string? value = state.User.Get<string>(IS_SIGNED_IN_KEY);
+
+            if (value == string.Empty || value == null)
+            {
+                return null;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Update the turn state to indicate the user is in the sign in flow by providing the authentication setting name used.
+        /// </summary>
+        /// <typeparam name="TState">The turn state.</typeparam>
+        /// <param name="state">The turn state.</param>
+        /// <param name="settingName">The connection setting name defined when configuring the authentication options within the application class.</param>
+        public static void SetUserInSignInFlow<TState>(TState state, string settingName) where TState : TurnState, new()
+        {
+            state.User.Set(IS_SIGNED_IN_KEY, settingName);
+        }
+
+        /// <summary>
+        /// Delete the user in sign in flow state from the turn state.
+        /// </summary>
+        /// <typeparam name="TState">The turn state.</typeparam>
+        /// <param name="state">The turn state.</param>
+        public static void DeleteUserInSignInFlow<TState>(TState state) where TState : TurnState, new()
+        {
+            state.User.Remove(IS_SIGNED_IN_KEY);
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Teams.AI
         where TState : TurnState, new()
     {
         private Dictionary<string, IAuthentication<TState>> _authentications { get; }
-        private string _default { get; set; }
+
+        /// <summary>
+        /// The default authentication setting name.
+        /// </summary>
+        public string Default { get; }
 
         /// <summary>
         /// Creates a new instance of the class
@@ -27,7 +31,7 @@ namespace Microsoft.Teams.AI
             }
 
             // If developer does not specify default authentication, set default to the first one in the options
-            _default = options.Default ?? options.Authentications.First().Key;
+            Default = options.Default ?? options.Authentications.First().Key;
 
             _authentications = options.Authentications;
         }
@@ -44,7 +48,7 @@ namespace Microsoft.Teams.AI
         {
             if (handlerName == null)
             {
-                handlerName = _default;
+                handlerName = Default;
             }
 
             IAuthentication<TState> auth = Get(handlerName);
@@ -67,7 +71,7 @@ namespace Microsoft.Teams.AI
         {
             if (handlerName == null)
             {
-                handlerName = _default;
+                handlerName = Default;
             }
 
             IAuthentication<TState> auth = Get(handlerName);
@@ -85,7 +89,7 @@ namespace Microsoft.Teams.AI
         {
             if (handlerName == null)
             {
-                handlerName = _default;
+                handlerName = Default;
             }
 
             IAuthentication<TState> auth = Get(handlerName);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -37,62 +37,62 @@ namespace Microsoft.Teams.AI
         }
 
         /// <summary>
-        /// Sign in a user
+        /// Sign in a user.
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
-        /// <param name="handlerName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
+        /// <param name="settingName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public async Task<SignInResponse> SignUserInAsync(ITurnContext context, TState state, string? handlerName = null, CancellationToken cancellationToken = default)
+        public async Task<SignInResponse> SignUserInAsync(ITurnContext context, TState state, string? settingName = null, CancellationToken cancellationToken = default)
         {
-            if (handlerName == null)
+            if (settingName == null)
             {
-                handlerName = Default;
+                settingName = Default;
             }
 
-            IAuthentication<TState> auth = Get(handlerName);
+            IAuthentication<TState> auth = Get(settingName);
             SignInResponse response = await auth.SignInUserAsync(context, state, cancellationToken);
             if (response.Status == SignInStatus.Complete)
             {
-                AuthUtilities.SetTokenInState(state, handlerName, response.Token!);
+                AuthUtilities.SetTokenInState(state, settingName, response.Token!);
             }
             return response;
         }
 
         /// <summary>
-        /// Signs out a user
+        /// Signs out a user.
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
-        /// <param name="handlerName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
+        /// <param name="settingName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
         /// <param name="cancellationToken">The cancellation token</param>
-        public async Task SignOutUserAsync(ITurnContext context, TState state, string? handlerName = null, CancellationToken cancellationToken = default)
+        public async Task SignOutUserAsync(ITurnContext context, TState state, string? settingName = null, CancellationToken cancellationToken = default)
         {
-            if (handlerName == null)
+            if (settingName == null)
             {
-                handlerName = Default;
+                settingName = Default;
             }
 
-            IAuthentication<TState> auth = Get(handlerName);
+            IAuthentication<TState> auth = Get(settingName);
             await auth.SignOutUserAsync(context, state, cancellationToken);
-            AuthUtilities.DeleteTokenFromState(state, handlerName);
+            AuthUtilities.DeleteTokenFromState(state, settingName);
         }
 
         /// <summary>
         /// Check whether current activity supports authentication.
         /// </summary>
         /// <param name="context">Current turn context.</param>
-        /// <param name="handlerName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
+        /// <param name="settingName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
         /// <returns>True if current activity supports authentication. Otherwise, false.</returns>
-        public async Task<bool> IsValidActivityAsync(ITurnContext context, string? handlerName = null)
+        public async Task<bool> IsValidActivityAsync(ITurnContext context, string? settingName = null)
         {
-            if (handlerName == null)
+            if (settingName == null)
             {
-                handlerName = Default;
+                settingName = Default;
             }
 
-            IAuthentication<TState> auth = Get(handlerName);
+            IAuthentication<TState> auth = Get(settingName);
             return await auth.IsValidActivityAsync(context);
         }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Teams.AI
         /// <summary>
         /// Callback when user sign in fail
         /// </summary>
-        protected Func<ITurnContext, TState, TeamsAIAuthException, Task>? _userSignInFailureHandler;
+        protected Func<ITurnContext, TState, AuthException, Task>? _userSignInFailureHandler;
 
         /// <summary>
         /// Initializes the class
@@ -163,7 +163,7 @@ namespace Microsoft.Teams.AI
                         // Failed sign in
                         if (_userSignInFailureHandler != null)
                         {
-                            await _userSignInFailureHandler(context, state, new TeamsAIAuthException("Authentication flow completed without a token.", TeamsAIAuthExceptionReason.CompletionWithoutToken));
+                            await _userSignInFailureHandler(context, state, new AuthException("Authentication flow completed without a token.", AuthExceptionReason.CompletionWithoutToken));
                         }
                     }
                 }
@@ -174,7 +174,7 @@ namespace Microsoft.Teams.AI
 
                 if (_userSignInFailureHandler != null)
                 {
-                    await _userSignInFailureHandler(context, state, new TeamsAIAuthException(message));
+                    await _userSignInFailureHandler(context, state, new AuthException(message));
                 }
             }
         }
@@ -192,7 +192,7 @@ namespace Microsoft.Teams.AI
         /// The handler function is called when the user sign in flow fails
         /// </summary>
         /// <param name="handler">The handler function to call when the user failed to signed in</param>
-        public void OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler)
+        public void OnUserSignInFailure(Func<ITurnContext, TState, AuthException, Task> handler)
         {
             _userSignInFailureHandler = handler;
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Teams.AI
             if (context == null || context.Activity == null
                 || context.Activity.Conversation == null)
             {
-                throw new TeamsAIAuthException("Invalid context, can not get storage key!");
+                throw new AuthException("Invalid context, can not get storage key!");
             }
 
             Activity activity = context.Activity;
@@ -149,13 +149,13 @@ namespace Microsoft.Teams.AI
             string conversationId = activity.Conversation.Id;
             if (activity.Type != ActivityTypes.Invoke || activity.Name != SignInConstants.TokenExchangeOperationName)
             {
-                throw new TeamsAIAuthException("TokenExchangeState can only be used with Invokes of signin/tokenExchange.");
+                throw new AuthException("TokenExchangeState can only be used with Invokes of signin/tokenExchange.");
             }
             JObject value = JObject.FromObject(activity.Value);
             JToken? id = value["id"];
             if (id == null)
             {
-                throw new TeamsAIAuthException("Invalid signin/tokenExchange. Missing activity.value.id.");
+                throw new AuthException("Invalid signin/tokenExchange. Missing activity.value.id.");
             }
             return $"{channelId}/{conversationId}/{id}";
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Teams.AI
                     catch (Exception ex)
                     {
                         string message = $"Failed to get access token with error: {ex.Message}";
-                        throw new TeamsAIAuthException(message);
+                        throw new AuthException(message);
                     }
                 }
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -13,10 +13,16 @@ namespace Microsoft.Teams.AI
         /// Sign-in not complete and requires user interaction
         /// </summary>
         Pending,
+
         /// <summary>
         /// Sign-in complete
         /// </summary>
-        Complete
+        Complete,
+
+        /// <summary>
+        /// Error occurred during sign-in
+        /// </summary>
+        Error
     }
 
     /// <summary>
@@ -33,6 +39,16 @@ namespace Microsoft.Teams.AI
         /// The access token. Only available when sign-in status is Complete.
         /// </summary>
         public string? Token { get; set; }
+
+        /// <summary>
+        /// The exception object. Only available when sign-in status is Error.
+        /// </summary>
+        public Exception? Error { get; set; }
+
+        /// <summary>
+        /// The cause of error. Only available when sign-in status is Error.
+        /// </summary>
+        public AuthExceptionReason? Cause { get; set; }
 
         /// <summary>
         /// Initialize an instance of current class
@@ -96,6 +112,14 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="handler">The handler function to call when the user failed to signed in</param>
         /// <returns>The class itself for chaining purpose</returns>
-        IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler);
+        IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, AuthException, Task> handler);
+
+        /// <summary>
+        /// Check if the user is signed, if they are then return the token.
+        /// </summary>
+        /// <param name="turnContext">The turn context.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The token if the user is signed. Otherwise null.</returns>
+        Task<string?> IsUserSignedInAsync(ITurnContext turnContext, CancellationToken cancellationToken = default);
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Teams.AI
                 catch (Exception ex)
                 {
                     string message = $"Failed to exchange access token with error: {ex.Message}";
-                    throw new TeamsAIAuthException(message);
+                    throw new AuthException(message);
                 }
             }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Teams.AI
     /// <summary>
     /// Handles authentication using OAuth Connection.
     /// </summary>
-    public class OAuthAuthentication<TState> : IAuthentication<TState>
+    internal class OAuthAuthentication<TState> : IAuthentication<TState>
         where TState : TurnState, new()
     {
         /// <summary>
@@ -17,6 +17,17 @@ namespace Microsoft.Teams.AI
         /// <param name="name">The name of the authentication handler</param>
         /// <param name="storage">The storage to save turn state</param>
         public void Initialize(Application<TState> app, string name, IStorage? storage = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Check if the user is signed, if they are then return the token.
+        /// </summary>
+        /// <param name="turnContext">The turn context.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <returns>The token if the user is signed. Otherwise null.</returns>
+        public Task<string?> IsUserSignedInAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -36,7 +47,7 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="handler">The handler function to call when the user failed to signed in</param>
         /// <returns>The class itself for chaining purpose</returns>
-        public IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, TeamsAIAuthException, Task> handler)
+        public IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, AuthException, Task> handler)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
@@ -1,9 +1,15 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Exceptions;
+using Microsoft.Bot.Builder.Dialogs;
 
 namespace Microsoft.Teams.AI
 {
+    /// <summary>
+    /// Maps the turn state property to a bot State property.
+    /// Note: Used to inject data into <seealso cref="DialogSet"/>.
+    /// </summary>
+    /// <typeparam name="TState"></typeparam>
     internal class TurnStateProperty<TState> : IStatePropertyAccessor<TState>
         where TState : new()
     {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Exceptions/AuthException.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Exceptions/AuthException.cs
@@ -1,14 +1,20 @@
 ﻿namespace Microsoft.Teams.AI.Exceptions
 {
     /// <summary>
-    /// Cause of an authentication exception.
+    /// Cause of user authentication exception.
     /// </summary>
-    public enum TeamsAIAuthExceptionReason
+    public enum AuthExceptionReason
     {
         /// <summary>
         /// The authentication flow completed without a token.
         /// </summary>
         CompletionWithoutToken,
+
+        /// <summary>
+        /// The incomming activity is not valid for sign in flow.
+        /// </summary>
+        InvalidActivity,
+
         /// <summary>
         /// Other error.
         /// </summary>
@@ -16,21 +22,21 @@
     }
 
     /// <summary>
-    /// An exception thrown when an authentication error occurs.
+    /// An exception thrown when user authentication error occurs.
     /// </summary>
-    public class TeamsAIAuthException : Exception
+    public class AuthException : Exception
     {
         /// <summary>
         /// The cause of the exception.
         /// </summary>
-        public TeamsAIAuthExceptionReason Cause { get; }
+        public AuthExceptionReason Cause { get; }
 
         /// <summary>
         /// Initializes the class
         /// </summary>
         /// <param name="message">The exception message</param>
         /// <param name="reason">The cause of the exception</param>
-        public TeamsAIAuthException(string message, TeamsAIAuthExceptionReason reason = TeamsAIAuthExceptionReason.Other) : base(message)
+        public AuthException(string message, AuthExceptionReason reason = AuthExceptionReason.Other) : base(message)
         {
             Cause = reason;
         }


### PR DESCRIPTION
## Linked issues

closes: #894  (issue number)

## Details

- Rename `TeamsAIAuthException` to `AuthException`
- Rename `TeamsAIAuthReason` to `AuthExceptionReason`
- Implement helper methods in `AuthUtilities`
- Implement `GetTokenOrStartSignInAsync`.
- Add `IsUserSignedIn` to `IAuthentication` interface - this is needed so it can be called in the `Application` class.
- Make `AuthenticationManager._default` private property public `Default`.

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [ ] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
