### PR TITLE
[C#] chore: Push `appsettings` file to fix failing build

### DIFF
--- a/dotnet/samples/06.auth.teamsSSO.bot/.gitignore
+++ b/dotnet/samples/06.auth.teamsSSO.bot/.gitignore
@@ -3,7 +3,6 @@ build
 appPackage/build
 env/.env.*.user
 env/.env.local
-appsettings.Development.json
 .deployment
 
 # User-specific files

--- a/dotnet/samples/06.auth.teamsSSO.bot/appsettings.Development.json
+++ b/dotnet/samples/06.auth.teamsSSO.bot/appsettings.Development.json
@@ -1,0 +1,17 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "BOT_ID": "",
+  "BOT_PASSWORD": "",
+  "BOT_DOMAIN": "",
+  "AAD_APP_CLIENT_ID": "",
+  "AAD_APP_CLIENT_SECRET": "",
+  "AAD_APP_TENANT_ID": "",
+  "AAD_APP_OAUTH_AUTHORITY_HOST": ""
+}

--- a/dotnet/samples/06.auth.teamsSSO.messageExtension/.gitignore
+++ b/dotnet/samples/06.auth.teamsSSO.messageExtension/.gitignore
@@ -22,5 +22,4 @@ appPackage/build
 build
 .deployment
 # Teams Toolkit Local Development
-appsettings.Development.json
 env/.env.local

--- a/dotnet/samples/06.auth.teamsSSO.messageExtension/appsettings.Development.json
+++ b/dotnet/samples/06.auth.teamsSSO.messageExtension/appsettings.Development.json
@@ -1,0 +1,17 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "BOT_ID": "",
+  "BOT_PASSWORD": "",
+  "BOT_DOMAIN": "",
+  "AAD_APP_CLIENT_ID": "",
+  "AAD_APP_CLIENT_SECRET": "",
+  "AAD_APP_TENANT_ID": "",
+  "AAD_APP_OAUTH_AUTHORITY_HOST": ""
+}


### PR DESCRIPTION
## Linked issues

closes: #836  (issue number)

## Details

`06.auth.teamsSSO.bot` build was failing due to missing `appsettings.Development.json` file. Fixed
`06.auth.teamsSSO.messageExtension` build was failing due to missing `appsettings.Development.json` file. Fixed

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
