### PR TITLE
[C#] feat: add OAuthPrompt based message extension auth

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.AI
 {
@@ -8,14 +9,22 @@ namespace Microsoft.Teams.AI
     /// </summary>
     internal class OAuthMessageExtensionsAuthentication : MessageExtensionsAuthenticationBase
     {
+        private string _oauthConnectionName;
+
+        public OAuthMessageExtensionsAuthentication(string oauthConnectionName)
+        {
+            _oauthConnectionName = oauthConnectionName;
+        }
+
         /// <summary>
         /// Gets the sign in link for the user.
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>The sign in link</returns>
-        public override Task<string> GetSignInLink(ITurnContext context)
+        public override async Task<string> GetSignInLink(ITurnContext context)
         {
-            throw new NotImplementedException();
+            SignInResource signInResource = await UserTokenClientWrapper.GetSignInResourceAsync(context, _oauthConnectionName);
+            return signInResource.SignInLink;
         }
 
         /// <summary>
@@ -24,9 +33,9 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="magicCode">The magic code from user sign-in.</param>
         /// <returns>The token response if successfully verified the magic code</returns>
-        public override Task<TokenResponse> HandleUserSignIn(ITurnContext context, string magicCode)
+        public override async Task<TokenResponse> HandleUserSignIn(ITurnContext context, string magicCode)
         {
-            throw new NotImplementedException();
+            return await UserTokenClientWrapper.GetUserTokenAsync(context, _oauthConnectionName, magicCode);
         }
 
         /// <summary>
@@ -34,9 +43,16 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>The token response if token exchange success</returns>
-        public override Task<TokenResponse> HandleSsoTokenExchange(ITurnContext context)
+        public override async Task<TokenResponse> HandleSsoTokenExchange(ITurnContext context)
         {
-            throw new NotImplementedException();
+            JObject value = JObject.FromObject(context.Activity.Value);
+            TokenExchangeRequest? tokenExchangeRequest = value["authentication"]?.ToObject<TokenExchangeRequest>();
+            if (tokenExchangeRequest != null && !string.IsNullOrEmpty(tokenExchangeRequest.Token))
+            {
+                return await UserTokenClientWrapper.ExchangeTokenAsync(context, _oauthConnectionName, tokenExchangeRequest);
+            }
+
+            return new TokenResponse();
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 
@@ -10,6 +12,18 @@ namespace Microsoft.Teams.AI
     public class OAuthAuthentication<TState> : IAuthentication<TState>
         where TState : TurnState, new()
     {
+        private OAuthPromptSettings _settings;
+        private OAuthMessageExtensionsAuthentication? _messageExtensionAuth;
+
+        /// <summary>
+        /// Initializes the class
+        /// </summary>
+        /// <param name="settings">The settings to initialize the class</param>
+        public OAuthAuthentication(OAuthPromptSettings settings)
+        {
+            _settings = settings;
+        }
+
         /// <summary>
         /// Initialize the authentication class
         /// </summary>
@@ -18,7 +32,7 @@ namespace Microsoft.Teams.AI
         /// <param name="storage">The storage to save turn state</param>
         public void Initialize(Application<TState> app, string name, IStorage? storage = null)
         {
-            throw new NotImplementedException();
+            _messageExtensionAuth = new OAuthMessageExtensionsAuthentication(_settings.ConnectionName);
         }
 
         /// <summary>
@@ -28,7 +42,7 @@ namespace Microsoft.Teams.AI
         /// <returns>True if valid. Otherwise, false.</returns>
         public Task<bool> IsValidActivityAsync(ITurnContext context)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(_messageExtensionAuth != null && _messageExtensionAuth.IsValidActivity(context));
         }
 
         /// <summary>
@@ -58,9 +72,23 @@ namespace Microsoft.Teams.AI
         /// <param name="state">The turn state</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
+        public async Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            TokenResponse tokenResponse = await UserTokenClientWrapper.GetUserTokenAsync(context, _settings.ConnectionName, "", cancellationToken);
+            if (tokenResponse != null && !string.IsNullOrEmpty(tokenResponse.Token))
+            {
+                return new SignInResponse(SignInStatus.Complete)
+                {
+                    Token = tokenResponse.Token
+                };
+            }
+
+            if ((_messageExtensionAuth != null && _messageExtensionAuth.IsValidActivity(context)))
+            {
+                return await _messageExtensionAuth.AuthenticateAsync(context);
+            }
+
+            throw new TeamsAIException("Incoming activity is not a valid activity to initiate authentication flow.");
         }
 
         /// <summary>
@@ -69,9 +97,9 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="state">The turn state</param>
         /// <param name="cancellationToken">The cancellation token</param>
-        public Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
+        public async Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            await UserTokenClientWrapper.SignoutUserAsync(context, _settings.ConnectionName, cancellationToken);
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/UserTokenClientWrapper.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/UserTokenClientWrapper.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Microsoft.Teams.AI.Exceptions;
+
+namespace Microsoft.Teams.AI
+{
+    internal class UserTokenClientWrapper
+    {
+        public static async Task<SignInResource> GetSignInResourceAsync(ITurnContext context, string connectionName, CancellationToken cancellationToken = default)
+        {
+            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            return await userTokenClient.GetSignInResourceAsync(connectionName, context.Activity, "", cancellationToken);
+        }
+
+        public static async Task<TokenResponse> GetUserTokenAsync(ITurnContext context, string connectionName, string magicCode, CancellationToken cancellationToken = default)
+        {
+            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            return await userTokenClient.GetUserTokenAsync(context.Activity.From.Id, connectionName, context.Activity.ChannelId, magicCode, cancellationToken);
+        }
+
+        public static async Task<TokenResponse> ExchangeTokenAsync(ITurnContext context, string connectionName, TokenExchangeRequest tokenExchangeRequest, CancellationToken cancellationToken = default)
+        {
+            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            return await userTokenClient.ExchangeTokenAsync(context.Activity.From.Id, connectionName, context.Activity.ChannelId, tokenExchangeRequest, cancellationToken);
+        }
+
+        public static async Task SignoutUserAsync(ITurnContext context, string connectionName, CancellationToken cancellationToken = default)
+        {
+            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            await userTokenClient.SignOutUserAsync(context.Activity.From.Id, connectionName, context.Activity.ChannelId, cancellationToken);
+        }
+
+        private static UserTokenClient GetUserTokenClient(ITurnContext context)
+        {
+            UserTokenClient userTokenClient = context.TurnState.Get<UserTokenClient>();
+            if (userTokenClient == null)
+            {
+                throw new TeamsAIException("OAuth Connection is not supported by the current adapter");
+            }
+            return userTokenClient;
+        }
+    }
+}


### PR DESCRIPTION
## Linked issues

closes: #965

## Details

Add OAuthPrompt based message extension auth

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below

UT is blocked by not able to mock the function that acquires UserTokenClient. Did manual test against the code.