### PR TITLE
[C#] chore: Bump .NET library to `1.0.0-preview-4`

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Teams.AI
     /// <summary>
     /// Handles authentication based on Teams SSO.
     /// </summary>
-    internal class TeamsSsoAuthentication<TState> : IAuthentication<TState>
+    public class TeamsSsoAuthentication<TState> : IAuthentication<TState>
         where TState : TurnState, new()
     {
         private TeamsSsoBotAuthentication<TState>? _botAuth;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Microsoft.Teams.AI</PackageId>
     <Product>Microsoft Teams AI SDK</Product>
-    <Version>1.0.0-preview-3</Version>
+    <Version>1.0.0-preview-4</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>


### PR DESCRIPTION
## Linked issues

closes: #993 (issue number)

## Details
- Bump .NET library to `1.0.0-preview-4`
- Fix access modifier bug
