### PR TITLE
[C#] fix: teams sso auth error with invalid activity

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Teams.AI
                 return await _messageExtensionsAuth.AuthenticateAsync(context);
             }
 
-            throw new TeamsAIException("Incoming activity is not a valid activity to initiate authentication flow.");
+            throw new AuthException("Incoming activity is not a valid activity to initiate authentication flow.", AuthExceptionReason.InvalidActivity);
         }
 
         /// <summary>


### PR DESCRIPTION
## Linked issues

closes: #1013

## Details

The application class now requires underlying implementation to throw an AuthException with invalid activity reason, throw expected exception to make the application class work as expected.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

UT was blocked due to mock issue, which will be solved after GA. Manually tested the code.
