### PR TITLE
[C#] chore: remove history from default temp state

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TempState.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TempState.cs
@@ -20,11 +20,6 @@ namespace Microsoft.Teams.AI.State
         public const string OutputKey = "output";
 
         /// <summary>
-        /// Name of the history property.
-        /// </summary>
-        public const string HistoryKey = "history";
-
-        /// <summary>
         /// Name of the action outputs property.
         /// </summary>
         public const string ActionOutputsKey = "actionOutputs";
@@ -47,7 +42,6 @@ namespace Microsoft.Teams.AI.State
         {
             this[InputKey] = string.Empty;
             this[OutputKey] = string.Empty;
-            this[HistoryKey] = string.Empty;
             this[ActionOutputsKey] = new Dictionary<string, string>();
             this[AuthTokenKey] = new Dictionary<string, string>();
             this[DuplicateTokenExchangeKey] = false;
@@ -70,16 +64,6 @@ namespace Microsoft.Teams.AI.State
         {
             get => Get<string>(OutputKey)!;
             set => Set(OutputKey, value);
-        }
-
-
-        /// <summary>
-        /// Formatted conversation history for embedding in an AI prompt
-        /// </summary>
-        public string History
-        {
-            get => Get<string>(HistoryKey)!;
-            set => Set(HistoryKey, value);
         }
 
         /// <summary>


### PR DESCRIPTION
## Linked issues

closes: #1020

## Details

Align with JS changes to remove `History` from default temp state.
It seems there's already 0 reference on `TempState.History` so safe to remove.

#### Change details

- Remove `History` and `HistoryKey` from temp state
- No unit test reference
- No sample reference

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
