### PR TITLE
[C#] fix: Simply Auth interface & other fixes

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationBuilderTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationBuilderTests.cs
@@ -55,10 +55,11 @@ namespace Microsoft.Teams.AI.Tests.Application
             {
                 Moderator = new TestModerator()
             };
-            AuthenticationOptions<TurnState> authOptions = new(new Dictionary<string, IAuthentication<TurnState>>()
+            AuthenticationOptions<TurnState> authOptions = new();
+            authOptions.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
             {
                 {"graph", new MockedAuthentication<TurnState>() }
-            });
+            };
 
             // Act
             var app = new ApplicationBuilder<TurnState>()

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationBuilderTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationBuilderTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.Bot.Schema;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.State;
-using Microsoft.Teams.AI.Tests.Application.Authentication;
 using Microsoft.Teams.AI.Tests.TestUtils;
 
 namespace Microsoft.Teams.AI.Tests.Application
@@ -56,10 +55,7 @@ namespace Microsoft.Teams.AI.Tests.Application
                 Moderator = new TestModerator()
             };
             AuthenticationOptions<TurnState> authOptions = new();
-            authOptions.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
-            {
-                {"graph", new MockedAuthentication<TurnState>() }
-            };
+            authOptions.AddAuthentication("graph", new OAuthSettings());
 
             // Act
             var app = new ApplicationBuilder<TurnState>()

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         {
             // arrange
             var graphToken = "graph token";
-            var authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            var options = new AuthenticationOptions<TurnState>();
+            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
             {
                 { "graph", new MockedAuthentication<TurnState>(mockedToken: graphToken) },
                 { "sharepoint", new MockedAuthentication<TurnState>() }
             };
-            var options = new AuthenticationOptions<TurnState>(authentications);
             var authManager = new AuthenticationManager<TurnState>(options);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
@@ -37,12 +37,12 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         {
             // arrange
             var sharepointToken = "sharepoint token";
-            var authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            var options = new AuthenticationOptions<TurnState>();
+            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
             {
                 { "graph", new MockedAuthentication<TurnState>() },
                 { "sharepoint", new MockedAuthentication<TurnState>(mockedToken: sharepointToken) }
             };
-            var options = new AuthenticationOptions<TurnState>(authentications);
             var authManager = new AuthenticationManager<TurnState>(options);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
@@ -61,12 +61,12 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         public async void Test_SignIn_Pending()
         {
             // arrange
-            var authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            var options = new AuthenticationOptions<TurnState>();
+            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
             {
                 { "graph", new MockedAuthentication<TurnState>(SignInStatus.Pending) },
                 { "sharepoint", new MockedAuthentication<TurnState>() }
             };
-            var options = new AuthenticationOptions<TurnState>(authentications);
             var authManager = new AuthenticationManager<TurnState>(options);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
@@ -83,12 +83,12 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         public async void Test_SignOut_DefaultHandler()
         {
             // arrange
-            var authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            var options = new AuthenticationOptions<TurnState>();
+            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
             {
                 { "graph", new MockedAuthentication<TurnState>() },
                 { "sharepoint", new MockedAuthentication<TurnState>() }
             };
-            var options = new AuthenticationOptions<TurnState>(authentications);
             var authManager = new AuthenticationManager<TurnState>(options);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
@@ -110,12 +110,12 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         public async void Test_SignOut_SpecificHandler()
         {
             // arrange
-            var authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            var options = new AuthenticationOptions<TurnState>();
+            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
             {
                 { "graph", new MockedAuthentication<TurnState>() },
                 { "sharepoint", new MockedAuthentication<TurnState>() }
             };
-            var options = new AuthenticationOptions<TurnState>(authentications);
             var authManager = new AuthenticationManager<TurnState>(options);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
@@ -131,46 +131,6 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             // assert
             Assert.False(turnState.Temp.AuthTokens.ContainsKey("sharepoint"));
             Assert.True(turnState.Temp.AuthTokens.ContainsKey("graph"));
-        }
-
-        [Fact]
-        public async void Test_IsValidActivity_DefaultHandler()
-        {
-            // arrange
-            var authentications = new Dictionary<string, IAuthentication<TurnState>>()
-            {
-                { "graph", new MockedAuthentication<TurnState>(validActivity: true) },
-                { "sharepoint", new MockedAuthentication<TurnState>(validActivity: false) }
-            };
-            var options = new AuthenticationOptions<TurnState>(authentications);
-            var authManager = new AuthenticationManager<TurnState>(options);
-            var turnContext = MockTurnContext();
-
-            // act
-            var validActivity = await authManager.IsValidActivityAsync(turnContext);
-
-            // assert
-            Assert.True(validActivity);
-        }
-
-        [Fact]
-        public async void Test_IsValidActivity_SpecificHandler()
-        {
-            // arrange
-            var authentications = new Dictionary<string, IAuthentication<TurnState>>()
-            {
-                { "graph", new MockedAuthentication<TurnState>(validActivity: false) },
-                { "sharepoint", new MockedAuthentication<TurnState>(validActivity: true) }
-            };
-            var options = new AuthenticationOptions<TurnState>(authentications);
-            var authManager = new AuthenticationManager<TurnState>(options);
-            var turnContext = MockTurnContext();
-
-            // act
-            var validActivity = await authManager.IsValidActivityAsync(turnContext, "sharepoint");
-
-            // assert
-            Assert.True(validActivity);
         }
 
         private static TurnContext MockTurnContext()

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
 
             // assert
             Assert.Equal(SignInStatus.Complete, response.Status);
-            Assert.Equal(graphToken, response.Token);
             Assert.True(turnState.Temp.AuthTokens.ContainsKey("graph"));
             Assert.Equal(graphToken, turnState.Temp.AuthTokens["graph"]);
         }
@@ -52,7 +51,6 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
 
             // assert
             Assert.Equal(SignInStatus.Complete, response.Status);
-            Assert.Equal(sharepointToken, response.Token);
             Assert.True(turnState.Temp.AuthTokens.ContainsKey("sharepoint"));
             Assert.Equal(sharepointToken, turnState.Temp.AuthTokens["sharepoint"]);
         }
@@ -76,7 +74,6 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
 
             // assert
             Assert.Equal(SignInStatus.Pending, response.Status);
-            Assert.Null(response.Token);
         }
 
         [Fact]

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
@@ -8,17 +8,18 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
     public class AuthenticationManagerTests
     {
         [Fact]
-        public async void Test_SignIn_DefaultHandler()
+        public async void Test_SignIn_DefaultSetting()
         {
             // arrange
             var graphToken = "graph token";
+            var app = new TestApplication(new TestApplicationOptions());
             var options = new AuthenticationOptions<TurnState>();
-            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            options._authenticationSettings = new Dictionary<string, object>()
             {
-                { "graph", new MockedAuthentication<TurnState>(mockedToken: graphToken) },
-                { "sharepoint", new MockedAuthentication<TurnState>() }
+                { "graph", new TestAuthenticationSettings(graphToken) },
+                { "sharepoint", new TestAuthenticationSettings() }
             };
-            var authManager = new AuthenticationManager<TurnState>(options);
+            var authManager = new TestAuthenticationManager(options, app);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
 
@@ -32,17 +33,18 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         }
 
         [Fact]
-        public async void Test_SignIn_SpecificHandler()
+        public async void Test_SignIn_SpecificSetting()
         {
             // arrange
-            var sharepointToken = "sharepoint token";
+            var sharepointToken = "graph token";
+            var app = new TestApplication(new TestApplicationOptions());
             var options = new AuthenticationOptions<TurnState>();
-            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            options._authenticationSettings = new Dictionary<string, object>()
             {
-                { "graph", new MockedAuthentication<TurnState>() },
-                { "sharepoint", new MockedAuthentication<TurnState>(mockedToken: sharepointToken) }
+                { "graph", new TestAuthenticationSettings() },
+                { "sharepoint", new TestAuthenticationSettings(sharepointToken) }
             };
-            var authManager = new AuthenticationManager<TurnState>(options);
+            var authManager = new TestAuthenticationManager(options, app);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
 
@@ -58,14 +60,14 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         [Fact]
         public async void Test_SignIn_Pending()
         {
-            // arrange
+            var app = new TestApplication(new TestApplicationOptions());
             var options = new AuthenticationOptions<TurnState>();
-            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            options._authenticationSettings = new Dictionary<string, object>()
             {
-                { "graph", new MockedAuthentication<TurnState>(SignInStatus.Pending) },
-                { "sharepoint", new MockedAuthentication<TurnState>() }
+                { "graph", new TestAuthenticationSettings() },
+                { "sharepoint", new TestAuthenticationSettings() }
             };
-            var authManager = new AuthenticationManager<TurnState>(options);
+            var authManager = new TestAuthenticationManager(options, app);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
 
@@ -80,13 +82,14 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         public async void Test_SignOut_DefaultHandler()
         {
             // arrange
+            var app = new TestApplication(new TestApplicationOptions());
             var options = new AuthenticationOptions<TurnState>();
-            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            options._authenticationSettings = new Dictionary<string, object>()
             {
-                { "graph", new MockedAuthentication<TurnState>() },
-                { "sharepoint", new MockedAuthentication<TurnState>() }
+                { "graph", new TestAuthenticationSettings() },
+                { "sharepoint", new TestAuthenticationSettings() }
             };
-            var authManager = new AuthenticationManager<TurnState>(options);
+            var authManager = new TestAuthenticationManager(options, app);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
             turnState.Temp.AuthTokens = new Dictionary<string, string>()
@@ -107,13 +110,15 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         public async void Test_SignOut_SpecificHandler()
         {
             // arrange
+            var graphToken = "graph token";
+            var app = new TestApplication(new TestApplicationOptions());
             var options = new AuthenticationOptions<TurnState>();
-            options.Authentications = new Dictionary<string, IAuthentication<TurnState>>()
+            options._authenticationSettings = new Dictionary<string, object>()
             {
-                { "graph", new MockedAuthentication<TurnState>() },
-                { "sharepoint", new MockedAuthentication<TurnState>() }
+                { "graph", new TestAuthenticationSettings() },
+                { "sharepoint", new TestAuthenticationSettings() }
             };
-            var authManager = new AuthenticationManager<TurnState>(options);
+            var authManager = new TestAuthenticationManager(options, app);
             var turnContext = MockTurnContext();
             var turnState = await TurnStateConfig.GetTurnStateWithConversationStateAsync(turnContext);
             turnState.Temp.AuthTokens = new Dictionary<string, string>()

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Teams.AI.Tests.TestUtils;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
 {
-    internal class MockedBotAuthentication<TState> : BotAuthenticationBase<TState>
+    internal sealed class MockedBotAuthentication<TState> : BotAuthenticationBase<TState>
         where TState : TurnState, new()
     {
         private List<DialogTurnResult> _runDialogResult;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
@@ -97,12 +97,12 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
 
             // act
-            var response = await botAuth.AuthenticateAsync(context, state);
+            var token = await botAuth.AuthenticateAsync(context, state);
 
             // assert
             var stateKey = "__fromId:test:Bot:AuthState__";
             var authState = state.Conversation[stateKey] as Dictionary<string, string>;
-            Assert.Equal(SignInStatus.Pending, response.Status);
+            Assert.Equal(null, token);
             Assert.NotNull(authState);
             Assert.True(authState.ContainsKey("message"));
             Assert.Equal("test text", authState["message"]);
@@ -118,11 +118,10 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
 
             // act
-            var response = await botAuth.AuthenticateAsync(context, state);
+            var token = await botAuth.AuthenticateAsync(context, state);
 
             // assert
-            Assert.Equal(SignInStatus.Complete, response.Status);
-            Assert.Equal("test token", response.Token);
+            Assert.Equal("test token", token);
         }
 
         [Fact]
@@ -135,10 +134,10 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             var state = await TurnStateConfig.GetTurnStateWithConversationStateAsync(context);
 
             // act
-            var response = await botAuth.AuthenticateAsync(context, state);
+            var token = await botAuth.AuthenticateAsync(context, state);
 
             // assert
-            Assert.Equal(SignInStatus.Pending, response.Status);
+            Assert.Equal(null, token);
         }
 
         [Fact]

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
@@ -72,8 +72,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
             var response = await meAuth.AuthenticateAsync(context);
 
             // assert
-            Assert.Equal(SignInStatus.Complete, response.Status);
-            Assert.Equal("test token", response.Token);
+            Assert.Equal("test token", response);
         }
 
         [Fact]
@@ -97,10 +96,10 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
             };
 
             // act
-            var response = await meAuth.AuthenticateAsync(context);
+            var token = await meAuth.AuthenticateAsync(context);
 
             // assert
-            Assert.Equal(SignInStatus.Pending, response.Status);
+            Assert.Equal(null, token);
             Assert.NotNull(activities);
             var sentActivity = activities.FirstOrDefault();
             Assert.NotNull(sentActivity);
@@ -117,11 +116,10 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
             context.Activity.Value = new MessagingExtensionQuery(state: "123456");
 
             // act
-            var response = await meAuth.AuthenticateAsync(context);
+            var token = await meAuth.AuthenticateAsync(context);
 
             // assert
-            Assert.Equal(SignInStatus.Complete, response.Status);
-            Assert.Equal("test token", response.Token);
+            Assert.Equal("test token", token);
         }
 
         [Fact]
@@ -139,10 +137,10 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
             context.Activity.Value = new MessagingExtensionQuery();
 
             // act
-            var response = await meAuth.AuthenticateAsync(context);
+            var token = await meAuth.AuthenticateAsync(context);
 
             // assert
-            Assert.Equal(SignInStatus.Pending, response.Status);
+            Assert.Equal(null, token);
             Assert.NotNull(activities);
             var sentActivity = activities.FirstOrDefault();
             Assert.NotNull(sentActivity);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
@@ -7,19 +7,16 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
     public class MockedAuthentication<TState> : IAuthentication<TState>
         where TState : TurnState, new()
     {
-        private string _mockedToken;
-        private SignInStatus _mockedStatus;
+        private string? _mockedToken;
 
-        public MockedAuthentication(SignInStatus mockedStatus = SignInStatus.Complete, string mockedToken = "mocked token")
+        public MockedAuthentication(TestAuthenticationSettings settings)
         {
-            _mockedToken = mockedToken;
-            _mockedStatus = mockedStatus;
+            if (settings != null)
+            {
+                _mockedToken = settings.MockedToken;
+            }
         }
 
-        public void Initialize(Application<TState> app, string name, IStorage? storage = null)
-        {
-            return;
-        }
 
         public Task<string?> IsUserSignedInAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
         {
@@ -38,17 +35,22 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
 
         public Task<string?> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
-            if (_mockedStatus == SignInStatus.Complete)
-            {
-                return Task.FromResult(_mockedToken)!;
-            }
-
-            return Task.FromResult<string?>(null)!;
+            return Task.FromResult(_mockedToken);
         }
 
         public Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
+        }
+    }
+
+    public class TestAuthenticationSettings
+    {
+        public string? MockedToken;
+
+        public TestAuthenticationSettings(string? token = null)
+        {
+            MockedToken = token;
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
@@ -9,13 +9,11 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
     {
         private string _mockedToken;
         private SignInStatus _mockedStatus;
-        private bool _validActivity;
 
-        public MockedAuthentication(SignInStatus mockedStatus = SignInStatus.Complete, string mockedToken = "mocked token", bool validActivity = true)
+        public MockedAuthentication(SignInStatus mockedStatus = SignInStatus.Complete, string mockedToken = "mocked token")
         {
             _mockedToken = mockedToken;
             _mockedStatus = mockedStatus;
-            _validActivity = validActivity;
         }
 
         public void Initialize(Application<TState> app, string name, IStorage? storage = null)
@@ -28,11 +26,6 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             return Task.FromResult<string?>(null);
         }
 
-        public Task<bool> IsValidActivityAsync(ITurnContext context)
-        {
-            return Task.FromResult(_validActivity);
-        }
-
         public IAuthentication<TState> OnUserSignInFailure(Func<ITurnContext, TState, AuthException, Task> handler)
         {
             return this;
@@ -43,14 +36,14 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
             return this;
         }
 
-        public Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
+        public Task<string?> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
-            var result = new SignInResponse(_mockedStatus);
             if (_mockedStatus == SignInStatus.Complete)
             {
-                result.Token = _mockedToken;
+                return Task.FromResult(_mockedToken)!;
             }
-            return Task.FromResult(result);
+
+            return Task.FromResult<string?>(null)!;
         }
 
         public Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TestAuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TestAuthenticationManager.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Bot.Builder;
+using Microsoft.Teams.AI.State;
+
+namespace Microsoft.Teams.AI.Tests.Application.Authentication
+{
+    internal class TestAuthenticationManager : AuthenticationManager<TurnState>
+    {
+        public TestAuthenticationManager(AuthenticationOptions<TurnState> options, Application<TurnState> app, IStorage? storage = null) : base(app, options, storage)
+        {
+            foreach (string key in options._authenticationSettings.Keys)
+            {
+                object setting = options._authenticationSettings[key];
+                if (setting is TestAuthenticationSettings mockSettings)
+                {
+                    _authentications.Add(key, new MockedAuthentication<TurnState>(mockSettings));
+                }
+            }
+        }
+    }
+}

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -88,13 +88,8 @@ namespace Microsoft.Teams.AI
 
             if (options.Authentication != null)
             {
-                // Initialize the authentication classes
-                foreach (KeyValuePair<string, IAuthentication<TState>> pair in options.Authentication.Authentications)
-                {
-                    pair.Value.Initialize(this, pair.Key, options.Storage);
-                }
+                _authentication = new AuthenticationManager<TState>(this, options.Authentication, options.Storage);
 
-                _authentication = new AuthenticationManager<TState>(options.Authentication);
                 if (options.Authentication.AutoSignIn != null)
                 {
                     _startSignIn = options.Authentication.AutoSignIn;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -52,10 +52,10 @@ namespace Microsoft.Teams.AI
             }
 
             IAuthentication<TState> auth = Get(settingName);
-            SignInResponse response;
+            string? token;
             try
             {
-                response = await auth.SignInUserAsync(context, state, cancellationToken);
+                token = await auth.SignInUserAsync(context, state, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -71,12 +71,12 @@ namespace Microsoft.Teams.AI
             }
 
 
-            if (response.Status == SignInStatus.Complete)
+            if (token != null)
             {
-                AuthUtilities.SetTokenInState(state, settingName, response.Token!);
+                AuthUtilities.SetTokenInState(state, settingName, token);
             }
 
-            return response;
+            return new SignInResponse(SignInStatus.Pending);
         }
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Teams.AI
             if (token != null)
             {
                 AuthUtilities.SetTokenInState(state, settingName, token);
+                return new SignInResponse(SignInStatus.Complete);
             }
 
             return new SignInResponse(SignInStatus.Pending);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -99,23 +99,6 @@ namespace Microsoft.Teams.AI
         }
 
         /// <summary>
-        /// Check whether current activity supports authentication.
-        /// </summary>
-        /// <param name="context">Current turn context.</param>
-        /// <param name="settingName">Optional. The name of the authentication handler to use. If not specified, the default handler name is used.</param>
-        /// <returns>True if current activity supports authentication. Otherwise, false.</returns>
-        public async Task<bool> IsValidActivityAsync(ITurnContext context, string? settingName = null)
-        {
-            if (settingName == null)
-            {
-                settingName = Default;
-            }
-
-            IAuthentication<TState> auth = Get(settingName);
-            return await auth.IsValidActivityAsync(context);
-        }
-
-        /// <summary>
         /// Get an authentication class via name
         /// </summary>
         /// <param name="name">The name of authentication class</param>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
@@ -39,16 +39,35 @@ namespace Microsoft.Teams.AI
         public SelectorAsync? AutoSignIn { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of this class.
+        /// Configures the options to add an OAuth authentication setting.
         /// </summary>
-        /// <param name="authentications">The authentication classes to sign-in and sign-out users.</param>
-        /// <param name="default">Describes the authentication class the bot should use if the user does not specify a authentication class name.</param>
-        /// <param name="autoSignIn">Indicates whether the bot should start the sign in flow when the user sends a message to the bot or triggers a message extension.</param>
-        public AuthenticationOptions(Dictionary<string, IAuthentication<TState>> authentications, string? @default = null, SelectorAsync? autoSignIn = null)
+        /// <param name="name">The authentication name.</param>
+        /// <param name="oauthSettings">The OAuth settings</param>
+        /// <returns>The object for chaining purposes.</returns>
+        public AuthenticationOptions<TState> AddAuthentication(string name, OAuthSettings oauthSettings)
         {
-            this.Authentications = authentications;
-            this.Default = @default;
-            this.AutoSignIn = autoSignIn;
+            Authentications.Add(name, new OAuthAuthentication<TState>(oauthSettings));
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the options to add an teams sso authentication setting.
+        /// </summary>
+        /// <param name="name">The authentication name.</param>
+        /// <param name="teamsSsoSettings">The OAuth settings</param>
+        /// <returns>The object for chaining purposes.</returns>
+        public AuthenticationOptions<TState> AddAuthentication(string name, TeamsSsoSettings teamsSsoSettings)
+        {
+            Authentications.Add(name, new TeamsSsoAuthentication<TState>(teamsSsoSettings));
+            return this;
+        }
+
+        /// <summary>
+        /// The authentication options constructor.
+        /// </summary>
+        public AuthenticationOptions()
+        {
+            Authentications = new Dictionary<string, IAuthentication<TState>>();
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Teams.AI
         where TState : TurnState, new()
     {
         /// <summary>
-        /// The authentication classes to sign-in and sign-out users.
+        /// The authentication settings to sign-in and sign-out users.
         /// Key uniquely identifies each authentication.
         /// </summary>
-        public Dictionary<string, IAuthentication<TState>> Authentications { get; set; }
+        internal Dictionary<string, object> _authenticationSettings { get; set; }
 
         /// <summary>
         /// Describes the authentication class the bot should use if the user does not specify a authentication class name.
@@ -46,7 +46,7 @@ namespace Microsoft.Teams.AI
         /// <returns>The object for chaining purposes.</returns>
         public AuthenticationOptions<TState> AddAuthentication(string name, OAuthSettings oauthSettings)
         {
-            Authentications.Add(name, new OAuthAuthentication<TState>(oauthSettings));
+            _authenticationSettings.Add(name, oauthSettings);
             return this;
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.Teams.AI
         /// <returns>The object for chaining purposes.</returns>
         public AuthenticationOptions<TState> AddAuthentication(string name, TeamsSsoSettings teamsSsoSettings)
         {
-            Authentications.Add(name, new TeamsSsoAuthentication<TState>(teamsSsoSettings));
+            _authenticationSettings.Add(name, teamsSsoSettings);
             return this;
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.Teams.AI
         /// </summary>
         public AuthenticationOptions()
         {
-            Authentications = new Dictionary<string, IAuthentication<TState>>();
+            _authenticationSettings = new Dictionary<string, object>();
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>True if the activity should be handled by current authentication hanlder. Otherwise, false.</returns>
+        /// <returns>True if the activity should be handled by current authentication handler. Otherwise, false.</returns>
         protected virtual Task<bool> VerifyStateRouteSelector(ITurnContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(context.Activity.Type == ActivityTypes.Invoke
@@ -214,7 +214,7 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>True if the activity should be handled by current authentication hanlder. Otherwise, false.</returns>
+        /// <returns>True if the activity should be handled by current authentication handler. Otherwise, false.</returns>
         protected virtual Task<bool> TokenExchangeRouteSelector(ITurnContext context, CancellationToken cancellationToken)
         {
             return Task.FromResult(context.Activity.Type == ActivityTypes.Invoke

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Teams.AI
         /// <param name="state">The turn state</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public async Task<SignInResponse> AuthenticateAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
+        public async Task<string?> AuthenticateAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             // Get property names to use
             string userAuthStatePropertyName = GetUserAuthStatePropertyName(context);
@@ -93,14 +93,11 @@ namespace Microsoft.Teams.AI
                 else
                 {
                     // Return token
-                    return new SignInResponse(SignInStatus.Complete)
-                    {
-                        Token = tokenResponse.Token
-                    };
+                    return tokenResponse.Token;
                 }
             }
 
-            return new SignInResponse(SignInStatus.Pending);
+            return null;
         }
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -36,11 +36,6 @@ namespace Microsoft.Teams.AI
         public SignInStatus Status { get; set; }
 
         /// <summary>
-        /// The access token. Only available when sign-in status is Complete.
-        /// </summary>
-        public string? Token { get; set; }
-
-        /// <summary>
         /// The exception object. Only available when sign-in status is Error.
         /// </summary>
         public Exception? Error { get; set; }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -80,14 +80,6 @@ namespace Microsoft.Teams.AI
         Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Initialize the authentication class
-        /// </summary>
-        /// <param name="app">The application object</param>
-        /// <param name="name">The name of the authentication handler</param>
-        /// <param name="storage">The storage to save turn state</param>
-        void Initialize(Application<TState> app, string name, IStorage? storage = null);
-
-        /// <summary>
         /// The handler function is called when the user has successfully signed in
         /// </summary>
         /// <param name="handler">The handler function to call when the user has successfully signed in</param>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -73,8 +73,8 @@ namespace Microsoft.Teams.AI
         /// <param name="context">Current turn context.</param>
         /// <param name="state">Application state.</param>
         /// <param name="cancellationToken">The cancellation token</param>
-        /// <returns>The authentication token if user is signed in.</returns>
-        Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default);
+        /// <returns>The authentication token if user is signed in. Otherwise returns null. In that case the bot will attempt to sign the user in.</returns>
+        Task<string?> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Signs out a user.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -85,19 +85,11 @@ namespace Microsoft.Teams.AI
         Task SignOutUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Check whether current activity supports authentication.
-        /// </summary>
-        /// <param name="context">Current turn context.</param>
-        /// <returns>True if current activity supports authentication. Otherwise, false.</returns>
-        Task<bool> IsValidActivityAsync(ITurnContext context);
-
-        /// <summary>
         /// Initialize the authentication class
         /// </summary>
         /// <param name="app">The application object</param>
         /// <param name="name">The name of the authentication handler</param>
         /// <param name="storage">The storage to save turn state</param>
-        /// 
         void Initialize(Application<TState> app, string name, IStorage? storage = null);
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Teams.AI
         /// <param name="context">The turn context</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public async Task<SignInResponse> AuthenticateAsync(ITurnContext context, CancellationToken cancellationToken = default)
+        public async Task<string?> AuthenticateAsync(ITurnContext context, CancellationToken cancellationToken = default)
         {
             JObject value = JObject.FromObject(context.Activity.Value);
             JToken? tokenExchangeRequest = value["authentication"];
@@ -32,10 +32,7 @@ namespace Microsoft.Teams.AI
                         TokenResponse tokenExchangeResponse = await HandleSsoTokenExchange(context);
                         if (!string.IsNullOrEmpty(tokenExchangeResponse.Token))
                         {
-                            return new SignInResponse(SignInStatus.Complete)
-                            {
-                                Token = tokenExchangeResponse.Token
-                            };
+                            return tokenExchangeResponse.Token;
                         }
                     }
                     catch (Exception ex)
@@ -56,7 +53,7 @@ namespace Microsoft.Teams.AI
                     };
                     await context.SendActivityAsync(response);
 
-                    return new SignInResponse(SignInStatus.Pending);
+                    return null;
                 }
             }
 
@@ -69,10 +66,7 @@ namespace Microsoft.Teams.AI
                     TokenResponse response = await HandleUserSignIn(context, state.ToString());
                     if (!string.IsNullOrEmpty(response.Token))
                     {
-                        return new SignInResponse(SignInStatus.Complete)
-                        {
-                            Token = response.Token
-                        };
+                        return response.Token;
                     }
                 }
                 catch
@@ -109,7 +103,7 @@ namespace Microsoft.Teams.AI
 
             await context.SendActivityAsync(ActivityUtilities.CreateInvokeResponseActivity(resposne), cancellationToken);
 
-            return new SignInResponse(SignInStatus.Pending);
+            return null;
         }
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -94,15 +94,12 @@ namespace Microsoft.Teams.AI
         /// <param name="state">The turn state</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public async Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
+        public async Task<string?> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             TokenResponse tokenResponse = await UserTokenClientWrapper.GetUserTokenAsync(context, _settings.ConnectionName, "", cancellationToken);
             if (tokenResponse != null && !string.IsNullOrEmpty(tokenResponse.Token))
             {
-                return new SignInResponse(SignInStatus.Complete)
-                {
-                    Token = tokenResponse.Token
-                };
+                return tokenResponse.Token;
             }
 
             if ((_messageExtensionAuth != null && _messageExtensionAuth.IsValidActivity(context)))

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -19,20 +19,13 @@ namespace Microsoft.Teams.AI
         /// <summary>
         /// Initializes the class
         /// </summary>
+        /// <param name="app">The application.</param>
+        /// <param name="name">The authentication name.</param>
         /// <param name="settings">The settings to initialize the class</param>
-        public OAuthAuthentication(OAuthSettings settings)
+        /// <param name="storage">The storage to use.</param>
+        public OAuthAuthentication(Application<TState> app, string name, OAuthSettings settings, IStorage? storage)
         {
             _settings = settings;
-        }
-
-        /// <summary>
-        /// Initialize the authentication class
-        /// </summary>
-        /// <param name="app">The application object</param>
-        /// <param name="name">The name of the authentication handler</param>
-        /// <param name="storage">The storage to save turn state</param>
-        public void Initialize(Application<TState> app, string name, IStorage? storage = null)
-        {
             _messageExtensionAuth = new OAuthMessageExtensionsAuthentication(_settings.ConnectionName);
             _botAuthentication = new OAuthBotAuthentication<TState>(app, _settings, name, storage);
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -56,19 +56,6 @@ namespace Microsoft.Teams.AI
         }
 
         /// <summary>
-        /// Whether the current activity is a valid activity that supports authentication
-        /// </summary>
-        /// <param name="context">The turn context</param>
-        /// <returns>True if valid. Otherwise, false.</returns>
-        public Task<bool> IsValidActivityAsync(ITurnContext context)
-        {
-            bool validMessageExtensionAuth = _messageExtensionAuth != null && _messageExtensionAuth.IsValidActivity(context);
-            bool validBotAuth = _botAuthentication != null && _botAuthentication.IsValidActivity(context);
-
-            return Task.FromResult(validBotAuth || validMessageExtensionAuth);
-        }
-
-        /// <summary>
         /// The handler function is called when the user sign in flow fails
         /// </summary>
         /// <param name="handler">The handler function to call when the user failed to signed in</param>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
@@ -38,18 +38,6 @@ namespace Microsoft.Teams.AI
         }
 
         /// <summary>
-        /// Whether the current activity is a valid activity that supports authentication
-        /// </summary>
-        /// <param name="context">The turn context</param>
-        /// <returns>True if valid. Otherwise, false.</returns>
-        public Task<bool> IsValidActivityAsync(ITurnContext context)
-        {
-            return Task.FromResult(
-                (_botAuth != null && _botAuth.IsValidActivity(context))
-                || (_messageExtensionsAuth != null && _messageExtensionsAuth.IsValidActivity(context)));
-        }
-
-        /// <summary>
         /// Sign in current user
         /// </summary>
         /// <param name="context">The turn context</param>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
@@ -44,15 +44,12 @@ namespace Microsoft.Teams.AI
         /// <param name="state">The turn state</param>
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The sign in response</returns>
-        public async Task<SignInResponse> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
+        public async Task<string?> SignInUserAsync(ITurnContext context, TState state, CancellationToken cancellationToken = default)
         {
             string token = await _TryGetUserToken(context);
             if (!string.IsNullOrEmpty(token))
             {
-                return new SignInResponse(SignInStatus.Complete)
-                {
-                    Token = token
-                };
+                return token;
             }
 
             if ((_botAuth != null && _botAuth.IsValidActivity(context)))

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Teams.AI
                 return await _messageExtensionsAuth.AuthenticateAsync(context);
             }
 
-            throw new TeamsAIException("Incoming activity is not a valid activity to initiate authentication flow.");
+            throw new AuthException("Incoming activity is not a valid activity to initiate authentication flow.", AuthExceptionReason.InvalidActivity);
         }
 
         /// <summary>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
@@ -19,20 +19,13 @@ namespace Microsoft.Teams.AI
         /// <summary>
         /// Initialize instance for current class
         /// </summary>
+        /// <param name="app">The application.</param>
+        /// <param name="name">The authentication name.</param>
         /// <param name="settings">The settings to initialize the class</param>
-        public TeamsSsoAuthentication(TeamsSsoSettings settings)
+        /// <param name="storage">The storage to use.</param>
+        public TeamsSsoAuthentication(Application<TState> app, string name, TeamsSsoSettings settings, IStorage? storage = null)
         {
             _settings = settings;
-        }
-
-        /// <summary>
-        /// Initialize the authentication class
-        /// </summary>
-        /// <param name="app">The application object</param>
-        /// <param name="name">The name of the authentication handler</param>
-        /// <param name="storage">The storage to save turn state</param>
-        public void Initialize(Application<TState> app, string name, IStorage? storage = null)
-        {
             _botAuth = new TeamsSsoBotAuthentication<TState>(app, name, _settings, storage);
             _messageExtensionsAuth = new TeamsSsoMessageExtensionsAuthentication(_settings);
         }

--- a/dotnet/samples/06.auth.oauth.bot/Program.cs
+++ b/dotnet/samples/06.auth.oauth.bot/Program.cs
@@ -37,22 +37,20 @@ builder.Services.AddTransient<IBot>(sp =>
     IStorage storage = sp.GetService<IStorage>();
     BotAdapter adapter = sp.GetService<CloudAdapter>();
 
+    AuthenticationOptions<AppState> options = new();
+    options.AddAuthentication("graph", new OAuthSettings()
+    {
+        ConnectionName = config.OAUTH_CONNECTION_NAME,
+        Title = "Sign In",
+        Text = "Please sign in to use the bot.",
+        EndOnInvalidMessage = true,
+    }
+    );
+
     Application<AppState> app = new ApplicationBuilder<AppState>()
         .WithStorage(storage)
         .WithTurnStateFactory(() => new AppState())
-        .WithAuthentication(adapter, new(new()
-        {
-            {
-                "graph",
-                new OAuthAuthentication<AppState>(new()
-                {
-                    ConnectionName = config.OAUTH_CONNECTION_NAME,
-                    Title = "Sign In",
-                    Text = "Please sign in to use the bot.",
-                    EndOnInvalidMessage = true,
-                })
-            },
-        }))
+        .WithAuthentication(adapter, options)
         .Build();
 
     // Listen for user to say "/reset" and then delete conversation state

--- a/dotnet/samples/06.auth.oauth.bot/README.md
+++ b/dotnet/samples/06.auth.oauth.bot/README.md
@@ -13,23 +13,12 @@ If you are using the Teams Toolkit to set up the bot (recommended) to set up thi
 
 1. Navigate to the `env/.env.local` file.
 1. Add the azure subscription id to the `AZURE_SUBSCRIPTION_ID` variable.
-1. Add the resource group name to the `AZURE_RESOURCE_GROUP_NAME` variable.
-1. Add an arbitrary name to `RESOURCE_SUFFIX`. For example: _"ssobot"_.
+1. Add the resource group name to the `AZURE_RESOURCE_GROUP_NAME` variable. The resource group should already exist in your Azure subscription.
+
+The support of selecting Azure subscription and resource group during "Prepare Teams App Dependencies" will come with Visual Studio 17.9 release in the future. You can skip above steps when using Visual Studio 17.9 or higher.
 
 Now you can follow the generic set up instructions here:
  [Setup Instructions](../README.md). 
- 
- #### Known set up bug
- There is currently a bug where after successfully executing `Teams Toolkit > Preparing Teams App Dependencies` the following warning shows:
-
- ![Dependency setup error](assets/error.png)
-
- When performing the F5 (Debug) you will see this error:
-
- ![Deployment error](assets/deployment-errors.png)
-
- You should click "Yes".
-
 
 ## Interacting with the Bot
 

--- a/dotnet/samples/06.auth.oauth.bot/infra/azure.parameters.json
+++ b/dotnet/samples/06.auth.oauth.bot/infra/azure.parameters.json
@@ -18,7 +18,7 @@
       "value": "SsoAuthBotInfra"
     },
     "oauthConnectionName": {
-      "value": "${{OAUTH_CONNECTION_NAME}}"
+      "value": "graph-connection"
     }
   }
 }

--- a/dotnet/samples/06.auth.oauth.bot/infra/azure.parameters.local.json
+++ b/dotnet/samples/06.auth.oauth.bot/infra/azure.parameters.local.json
@@ -18,7 +18,7 @@
       "value": "${{BOT_DOMAIN}}"
     },
     "oauthConnectionName": {
-      "value": "${{OAUTH_CONNECTION_NAME}}"
+      "value": "graph-connection"
     }
   }
 }

--- a/dotnet/samples/06.auth.oauth.bot/teamsapp.local.yml
+++ b/dotnet/samples/06.auth.oauth.bot/teamsapp.local.yml
@@ -39,9 +39,6 @@ provision:
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 
   - uses: arm/deploy # Deploy given ARM templates parallelly.
-    env:
-      # an arbitrary name for the connection
-      OAUTH_CONNECTION_NAME: graph-connection
     with:
       # AZURE_SUBSCRIPTION_ID is a built-in environment variable,
       # if its value is empty, TeamsFx will prompt you to select a subscription.
@@ -66,15 +63,12 @@ provision:
 
   # Generate runtime appsettings to JSON file
   - uses: file/createOrUpdateJsonFile
-    env:
-      # an arbitrary name for the connection
-      OAUTH_CONNECTION_NAME: graph-connection
     with:
       target: ./appsettings.Development.json
       content:
         BOT_ID: ${{BOT_ID}}
         BOT_PASSWORD: ${{SECRET_BOT_PASSWORD}}
-        OAUTH_CONNECTION_NAME: ${{OAUTH_CONNECTION_NAME}}
+        OAUTH_CONNECTION_NAME: graph-connection
         BOT_DOMAIN: ${{BOT_DOMAIN}}
         AAD_APP_CLIENT_ID: ${{BOT_ID}}
         AAD_APP_CLIENT_SECRET: ${{SECRET_BOT_PASSWORD}}

--- a/dotnet/samples/06.auth.oauth.bot/teamsapp.yml
+++ b/dotnet/samples/06.auth.oauth.bot/teamsapp.yml
@@ -42,9 +42,6 @@ provision:
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 
   - uses: arm/deploy # Deploy given ARM templates parallelly.
-    env:
-      # an arbitrary name for the connection
-      OAUTH_CONNECTION_NAME: graph-connection
     with:
       # AZURE_SUBSCRIPTION_ID is a built-in environment variable,
       # if its value is empty, TeamsFx will prompt you to select a subscription.
@@ -69,15 +66,12 @@ provision:
 
   # Generate runtime appsettings to JSON file
   - uses: file/createOrUpdateJsonFile
-    env:
-      # an arbitrary name for the connection
-      OAUTH_CONNECTION_NAME: graph-connection
     with:
       target: ./appsettings.Development.json
       content:
         BOT_ID: ${{BOT_ID}}
         BOT_PASSWORD: ${{SECRET_BOT_PASSWORD}}
-        OAUTH_CONNECTION_NAME: ${{OAUTH_CONNECTION_NAME}}
+        OAUTH_CONNECTION_NAME: graph-connection
         BOT_DOMAIN: ${{BOT_DOMAIN}}
         AAD_APP_TENANT_ID: ${{AAD_APP_TENANT_ID}}
         AAD_APP_OAUTH_AUTHORITY_HOST: ${{AAD_APP_OAUTH_AUTHORITY_HOST}}
@@ -127,4 +121,3 @@ deploy:
       # You can replace it with your existing Azure Resource id
       # or add it to your environment variable file.
       resourceId: ${{BOT_AZURE_APP_SERVICE_RESOURCE_ID}}
-projectId: c8807ca9-53b9-45c4-9bba-20d6f2d80ff6

--- a/dotnet/samples/06.auth.oauth.messageExtension/Program.cs
+++ b/dotnet/samples/06.auth.oauth.messageExtension/Program.cs
@@ -43,22 +43,22 @@ builder.Services.AddSingleton<Utilities>();
 builder.Services.AddTransient<IBot>(sp =>
 {
     IStorage storage = sp.GetService<IStorage>()!;
-    ApplicationOptions<TurnState> applicationOptions = new()
-    {
-        Storage = storage,
-        Authentication = new AuthenticationOptions<TurnState>(
-            new Dictionary<string, IAuthentication<TurnState>>()
-            {
-                { "graph", new OAuthAuthentication<TurnState>(new OAuthSettings()
-                    {
-                        ConnectionName = config.OAUTH_CONNECTION_NAME
-                    }
-                )}
-            }
-        )
-    };
+    BotAdapter adapter = sp.GetService<CloudAdapter>()!;
 
-    Application<TurnState> app = new(applicationOptions);
+    AuthenticationOptions<TurnState> options = new();
+    options.AddAuthentication("graph", new OAuthSettings()
+    {
+        ConnectionName = config.OAUTH_CONNECTION_NAME,
+        Title = "Sign In",
+        Text = "Please sign in to use the bot.",
+        EndOnInvalidMessage = true,
+    }
+    );
+
+    Application<TurnState> app = new ApplicationBuilder<TurnState>()
+        .WithStorage(storage)
+        .WithAuthentication(adapter, options)
+        .Build();
 
     Utilities utilities = sp.GetService<Utilities>()!;
 


### PR DESCRIPTION
## Linked issues

closes: #1022

## Details

- Remove `isValidActivity` method for `IAuthentication` interface
- Simplify orchestrating authentication settings
- Add bash script to batch build dotnet samples.
- Support for both local and hosted library consumption.
- Fix Oauth messaging extension sample
- Suppress some sample warnings 
- Remove `Initialize()` method from `IAuthentication` interface.
- Internalize `AuthenticationOptions.Authentications` property as `_authenticationSettings`.
- Move auth initialization logic from `Application` class into `AuthenticationManager` class.

Manual testing:
- Oauth bot sample works

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
