### PR TITLE
[C#] chore: enable AI log on .net samples

### DIFF
--- a/dotnet/samples/04.ai.a.teamsChefBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.a.teamsChefBot/appsettings.Development.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Teams.AI": "Trace"
     }
   },
   "AllowedHosts": "*",

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/appsettings.Development.json
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/appsettings.Development.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Information",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.Teams.AI": "Trace"
     }
   },
   "AllowedHosts": "*",

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/appsettings.Development.json
@@ -3,7 +3,8 @@
 		"LogLevel": {
 			"Default": "Information",
 			"Microsoft": "Information",
-			"Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.Teams.AI": "Trace"
 		}
 	},
 	"AllowedHosts": "*",

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/appsettings.Development.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Teams.AI": "Trace"
     }
   },
   "AllowedHosts": "*",

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/appsettings.Development.json
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/appsettings.Development.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Information",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.Teams.AI": "Trace"
     }
   },
   "AllowedHosts": "*",

--- a/dotnet/samples/04.e.twentyQuestions/Program.cs
+++ b/dotnet/samples/04.e.twentyQuestions/Program.cs
@@ -33,22 +33,32 @@ builder.Services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>()!);
 // Create singleton instances for bot application
 builder.Services.AddSingleton<IStorage, MemoryStorage>();
 
-OpenAIModel? model = null;
-
+// Create AI Model
 if (!string.IsNullOrEmpty(config.OpenAI?.ApiKey))
 {
-    model = new(new OpenAIModelOptions(config.OpenAI.ApiKey, "gpt-3.5-turbo"));
+    builder.Services.AddSingleton<OpenAIModel>(sp => new(
+        new OpenAIModelOptions(config.OpenAI.ApiKey, "gpt-3.5-turbo")
+        {
+            LogRequests = true
+        },
+        sp.GetService<ILoggerFactory>()
+    ));
 }
 else if (!string.IsNullOrEmpty(config.Azure?.OpenAIApiKey) && !string.IsNullOrEmpty(config.Azure.OpenAIEndpoint))
 {
-    model = new(new AzureOpenAIModelOptions(
-        config.Azure.OpenAIApiKey,
-        "gpt-35-turbo",
-        config.Azure.OpenAIEndpoint
+    builder.Services.AddSingleton<OpenAIModel>(sp => new(
+        new AzureOpenAIModelOptions(
+            config.Azure.OpenAIApiKey,
+            "gpt-35-turbo",
+            config.Azure.OpenAIEndpoint
+        )
+        {
+            LogRequests = true
+        },
+        sp.GetService<ILoggerFactory>()
     ));
 }
-
-if (model == null)
+else
 {
     throw new Exception("please configure settings for either OpenAI or Azure");
 }
@@ -68,7 +78,7 @@ builder.Services.AddTransient<IBot>(sp =>
     // Create ActionPlanner
     ActionPlanner<GameState> planner = new(
         options: new(
-            model: model,
+            model: sp.GetService<OpenAIModel>()!,
             prompts: prompts,
             defaultPrompt: async (context, state, planner) =>
             {

--- a/dotnet/samples/04.e.twentyQuestions/appsettings.Development.json
+++ b/dotnet/samples/04.e.twentyQuestions/appsettings.Development.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Information",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.Teams.AI": "Trace"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## Linked issues

closes: #1033

## Details

Enable prompt request and response logs on `OpenAIModel` samples.

#### Change details

- Add `LogRequests = true` to model options
- Add model as singleton and pass `loggerFactory` when creating new model
- Set log level to `Trace` in *appsettings.development.json*

**screenshots**:
<img width="848" alt="image" src="https://github.com/microsoft/teams-ai/assets/7642967/d86d66aa-a621-4211-8b83-89812686c367">

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
