### PR TITLE
[C#] chore: Fix turn state bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ env/.env.*.user
 env/.env.local
 env/.env.staging
 .env*
+/dotnet/samples/NuGet.Config

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnState.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnState.cs
@@ -311,7 +311,8 @@ namespace Microsoft.Teams.AI.State
                         }
 
                         // Add the temp scope
-                        this._scopes[TEMP_SCOPE] = new TurnStateEntry(new TempState());
+                        Record tempStateValue = ScopeDefaults.ContainsKey(TEMP_SCOPE) ? ScopeDefaults[TEMP_SCOPE] : new TempState();
+                        this._scopes[TEMP_SCOPE] = new TurnStateEntry(tempStateValue);
 
                         // Clear loading task
                         this._isLoaded = true;

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/appPackage/manifest.json
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/appPackage/manifest.json
@@ -47,16 +47,6 @@
             "canUpdateConfiguration": true
         }
     ],
-    "bots": [
-        {
-            "botId": "${{BOT_ID}}",
-            "scopes": ["personal", "team", "groupChat"],
-            "isNotificationOnly": false,
-            "supportsCalling": false,
-            "supportsVideo": false,
-            "supportsFiles": false
-        }
-    ],
     "permissions": ["identity", "messageTeamMembers"],
     "validDomains": [
         "${{BOT_DOMAIN}}"

--- a/js/samples/04.ai.b.messageExtensions.AI-ME/appPackage/manifest.json
+++ b/js/samples/04.ai.b.messageExtensions.AI-ME/appPackage/manifest.json
@@ -47,16 +47,6 @@
             "canUpdateConfiguration": true
         }
     ],
-    "bots": [
-        {
-            "botId": "${{BOT_ID}}",
-            "scopes": ["personal", "team", "groupChat"],
-            "isNotificationOnly": false,
-            "supportsCalling": false,
-            "supportsVideo": false,
-            "supportsFiles": false
-        }
-    ],
     "permissions": ["identity", "messageTeamMembers"],
     "validDomains": ["${{BOT_DOMAIN}}"]
 }


### PR DESCRIPTION
## Linked issues

closes: #848  (issue number)

## Details

- C# turn state implementation had a bug where it didn't allow for custom `TempState`.
- Removed "bot" object from gpt-me bot manifest. This will prevent users from being able to message the bot - the behavior of which is undefined.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes