### PR TITLE
[C#] chore: remove project id from teamsapp yml

### DIFF
--- a/dotnet/samples/06.auth.oauth.messageExtension/teamsapp.yml
+++ b/dotnet/samples/06.auth.oauth.messageExtension/teamsapp.yml
@@ -121,4 +121,3 @@ deploy:
       # You can replace it with your existing Azure Resource id
       # or add it to your environment variable file.
       resourceId: ${{BOT_AZURE_APP_SERVICE_RESOURCE_ID}}
-projectId: 49dc7f06-646f-44ce-9173-4d6b196cb986

--- a/dotnet/samples/06.auth.teamsSSO.bot/teamsapp.yml
+++ b/dotnet/samples/06.auth.teamsSSO.bot/teamsapp.yml
@@ -11,7 +11,7 @@ provision:
   # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty  
   - uses: aadApp/create
     with:
-  # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
+      # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       name: BotAuth-aad
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
@@ -26,7 +26,7 @@ provision:
       tenantId: AAD_APP_TENANT_ID
       authority: AAD_APP_OAUTH_AUTHORITY
       authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
-      
+
   # Creates a Teams app
   - uses: teamsApp/create
     with:


### PR DESCRIPTION
## Linked issues

closes: #1037

## Details

1. Remove project id from teamsapp.yml. Teams Toolkit will generate a new one for it so we can better distinguish different projects.
2. Fix formatting

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

