### PR TITLE
[JS] chore: authentication & adaptive cards unit tests

### DIFF
--- a/js/.vscode/launch.json
+++ b/js/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Mocha",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "--require",
+                "ts-node/register",
+                "${workspaceRoot}/src/**/*.spec.ts"
+            ],
+            "cwd": "${workspaceRoot}",
+            "protocol": "inspector"
+        },
+        {
+            "name": "Attach to Local Service",
+            "type": "node",
+            "request": "attach",
+            "port": 9239,
+            "restart": true,
+            "presentation": {
+                "group": "all",
+                "hidden": true
+            },
+            "internalConsoleOptions": "neverOpen"
+        }
+    ],
+}

--- a/js/packages/teams-ai/src/AdaptiveCards.spec.ts
+++ b/js/packages/teams-ai/src/AdaptiveCards.spec.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import { AdaptiveCard, AdaptiveCardSearchResult, AdaptiveCards, AdaptiveCardsSearchParams, TurnState } from '.';
 import assert from 'assert';
 
-describe.only('AdaptiveCards', () => {
+describe('AdaptiveCards', () => {
     let adaptiveCards: AdaptiveCards<TurnState>;
     let app: Application;
     let selector: RouteSelector;
@@ -531,7 +531,7 @@ describe.only('AdaptiveCards', () => {
                         type: 'invoke',
                         name: 'application/search',
                         value: {
-                            dataset: 'test'
+                            dataset: 'NotEqualToTest'
                         }
                     };
                     const context = createTurnContext(activity);

--- a/js/packages/teams-ai/src/AdaptiveCards.spec.ts
+++ b/js/packages/teams-ai/src/AdaptiveCards.spec.ts
@@ -1,0 +1,269 @@
+import { ActivityTypes, InvokeResponse, TestAdapter, TurnContext } from 'botbuilder';
+import { Application, RouteSelector } from './Application';
+import * as sinon from 'sinon';
+import { AdaptiveCard, AdaptiveCards, TurnState } from '.';
+import assert from 'assert';
+
+describe.only('AdaptiveCards', () => {
+    let adaptiveCards: AdaptiveCards<TurnState>;
+    let app: Application;
+    let selector: RouteSelector;
+    let handler: any;
+    let addRouteStub: sinon.SinonStub;
+    const testVerb = 'testVerb';
+    const testHandler = (context: TurnContext, state: TurnState, data: Record<string, any>) => Promise.resolve('test');
+
+    const createTurnContext = (activity: any) => {
+        return new TurnContext(new TestAdapter(), activity);
+    };
+
+    beforeEach(() => {
+        app = new Application();
+        adaptiveCards = new AdaptiveCards(app);
+        selector = null as unknown as RouteSelector;
+        handler = undefined;
+        sinon.restore();
+        addRouteStub = sinon.stub(app, 'addRoute').callsFake((s, h) => {
+            selector = s;
+            handler = h;
+
+            return app;
+        });
+    });
+
+    describe('actionExecute()', () => {
+        it('should call application addRoute', () => {
+            adaptiveCards.actionExecute(testVerb, testHandler);
+
+            assert(addRouteStub.calledOnce);
+        });
+
+        describe('createActionExecuteSelector()', () => {
+            it('verb is a function', () => {
+                const verb: RouteSelector = () => Promise.resolve(true);
+
+                adaptiveCards.actionExecute(verb, testHandler);
+
+                assert(selector === verb);
+            });
+
+            describe('verb is a regular expression', () => {
+                const verb = new RegExp('test');
+
+                beforeEach(() => {
+                    adaptiveCards.actionExecute(verb, testHandler);
+                });
+
+                it('incomming activity is valid invoke type', async () => {
+                    const activity = {
+                        type: 'invoke',
+                        name: 'adaptiveCard/action',
+                        value: {
+                            action: {
+                                type: 'Action.Execute',
+                                verb: 'test'
+                            }
+                        }
+                    };
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == true);
+                });
+
+                it('incomming activity is invalid', async () => {
+                    const activity = {
+                        type: 'NotInvoke'
+                    };
+
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == false);
+                });
+            });
+
+            describe('verb is a regular expression', () => {
+                const verb = 'test';
+
+                beforeEach(() => {
+                    adaptiveCards.actionExecute(verb, testHandler);
+                });
+
+                it('activity is valid invoke type', async () => {
+                    const activity = {
+                        type: 'invoke',
+                        name: 'adaptiveCard/action',
+                        value: {
+                            action: {
+                                type: 'Action.Execute',
+                                verb: 'test'
+                            }
+                        }
+                    };
+
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == true);
+                });
+
+                it('activity is invalid', async () => {
+                    const activity = {
+                        type: 'NotInvoke'
+                    };
+
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == false);
+                });
+            });
+        });
+
+        describe('handler creation logic', () => {
+            it('should create handler', () => {
+                adaptiveCards.actionExecute(testVerb, testHandler);
+
+                assert(typeof handler === 'function');
+            });
+
+            it('should throw error if incomming activity is not valid', async () => {
+                adaptiveCards.actionExecute(testVerb, testHandler);
+
+                const activity = {
+                    type: 'invalidActivityType'
+                };
+
+                const context = createTurnContext(activity);
+                const state = new TurnState();
+                const errorMsg = `Unexpected AdaptiveCards.actionExecute() triggered for activity type: invalidActivityType`;
+
+                assert.rejects(async () => await handler(context, state), errorMsg);
+            });
+
+            it('should call the test handler with the correct parameters', async () => {
+                const testHandlerStub = sinon.spy(testHandler);
+
+                adaptiveCards.actionExecute(testVerb, testHandlerStub);
+
+                const activity = {
+                    type: 'invoke',
+                    name: 'adaptiveCard/action',
+                    value: {
+                        action: {
+                            type: 'Action.Execute',
+                            verb: 'verb',
+                            data: {
+                                test: 'test'
+                            }
+                        }
+                    }
+                };
+
+                const context = createTurnContext(activity);
+                const state = new TurnState();
+
+                // this is the handler that is registered as an app route.
+                await handler(context, state);
+
+                assert(testHandlerStub.calledOnce);
+                assert(testHandlerStub.calledWith(context, state, activity.value.action.data));
+            });
+
+            it('should send an invoke response value adaptive card if handler returns adaptive card.', async () => {
+                const returnedAdaptiveCard = {
+                    type: 'AdaptiveCard',
+                    body: [
+                        {
+                            type: 'TextBlock',
+                            text: 'test'
+                        }
+                    ]
+                };
+
+                const testHandler = (
+                    context: TurnContext,
+                    state: TurnState,
+                    data: Record<string, any>
+                ): Promise<AdaptiveCard | string> => {
+                    return Promise.resolve(returnedAdaptiveCard) as any;
+                };
+
+                adaptiveCards.actionExecute(testVerb, testHandler);
+
+                const activity = {
+                    type: 'invoke',
+                    name: 'adaptiveCard/action',
+                    value: {
+                        action: {
+                            type: 'Action.Execute',
+                            verb: 'verb'
+                        }
+                    }
+                };
+
+                const context = createTurnContext(activity);
+                const contextSendActivityStub = sinon.stub(context, 'sendActivity');
+                const state = new TurnState();
+
+                // this is the handler that is registered as an app route.
+                await handler(context, state);
+
+                const response = {
+                    statusCode: 200,
+                    type: 'application/vnd.microsoft.card.adaptive',
+                    value: returnedAdaptiveCard
+                };
+
+                assert(
+                    contextSendActivityStub.calledOnceWith({
+                        value: { body: response, status: 200 } as InvokeResponse,
+                        type: ActivityTypes.InvokeResponse
+                    })
+                );
+            });
+
+            it('should send an invoke response value as message if handler returns string.', async () => {
+                const returnedString = 'returnedString';
+
+                const testHandler = (
+                    context: TurnContext,
+                    state: TurnState,
+                    data: Record<string, any>
+                ): Promise<AdaptiveCard | string> => {
+                    return Promise.resolve(returnedString) as any;
+                };
+
+                adaptiveCards.actionExecute(testVerb, testHandler);
+
+                const activity = {
+                    type: 'invoke',
+                    name: 'adaptiveCard/action',
+                    value: {
+                        action: {
+                            type: 'Action.Execute',
+                            verb: 'verb'
+                        }
+                    }
+                };
+
+                const context = createTurnContext(activity);
+                const contextSendActivityStub = sinon.stub(context, 'sendActivity');
+                const state = new TurnState();
+
+                // this is the handler that is registered as an app route.
+                await handler(context, state);
+
+                const response = {
+                    statusCode: 200,
+                    type: 'application/vnd.microsoft.activity.message',
+                    value: returnedString
+                };
+
+                assert(
+                    contextSendActivityStub.calledOnceWith({
+                        value: { body: response, status: 200 } as InvokeResponse,
+                        type: ActivityTypes.InvokeResponse
+                    })
+                );
+            });
+        });
+    });
+});

--- a/js/packages/teams-ai/src/AdaptiveCards.spec.ts
+++ b/js/packages/teams-ai/src/AdaptiveCards.spec.ts
@@ -1,7 +1,7 @@
 import { ActivityTypes, InvokeResponse, TestAdapter, TurnContext } from 'botbuilder';
-import { Application, RouteSelector } from './Application';
+import { Application, Query, RouteSelector } from './Application';
 import * as sinon from 'sinon';
-import { AdaptiveCard, AdaptiveCards, TurnState } from '.';
+import { AdaptiveCard, AdaptiveCardSearchResult, AdaptiveCards, AdaptiveCardsSearchParams, TurnState } from '.';
 import assert from 'assert';
 
 describe.only('AdaptiveCards', () => {
@@ -269,7 +269,7 @@ describe.only('AdaptiveCards', () => {
         });
     });
 
-    describe.only('actionSubmit()', () => {
+    describe('actionSubmit()', () => {
         const testVerb = 'testVerb';
         const testHandler = (context: TurnContext, state: TurnState, data: Record<string, any>) => Promise.resolve();
 
@@ -343,7 +343,7 @@ describe.only('AdaptiveCards', () => {
                     adaptiveCards.actionSubmit(verb, testHandler);
                 });
 
-                it('activity is valid invoke type and verb matches', async () => {
+                it('activity is valid action submit type and verb matches', async () => {
                     // a valid action submit type is a message activity with a value property and no text.
                     const activity = {
                         type: 'message',
@@ -358,7 +358,7 @@ describe.only('AdaptiveCards', () => {
                     assert((await selector(context)) == true);
                 });
 
-                it('activity is valid invoke type and verbs are not equal', async () => {
+                it('activity is valid action submit type and verbs are not equal', async () => {
                     // a valid action submit type is a message activity with a value property.
                     const activity = {
                         type: 'message',
@@ -427,6 +427,229 @@ describe.only('AdaptiveCards', () => {
 
                 assert(testHandlerStub.calledOnce);
                 assert(testHandlerStub.calledWith(context, state, activity.value));
+            });
+        });
+    });
+
+    describe('search()', () => {
+        const testDataset = 'testDataSet';
+        const testHandler = (
+            context: TurnContext,
+            state: TurnState,
+            query: Query<AdaptiveCardsSearchParams>
+        ): Promise<AdaptiveCardSearchResult[]> =>
+            Promise.resolve([
+                {
+                    title: 'title',
+                    value: 'value'
+                }
+            ]);
+
+        it('should call application addRoute', () => {
+            adaptiveCards.search(testDataset, testHandler);
+
+            assert(addRouteStub.calledOnce);
+        });
+
+        describe('createSearchSelector()', () => {
+            it('dataset is a function', () => {
+                const dataset: RouteSelector = () => Promise.resolve(true);
+
+                adaptiveCards.search(dataset, testHandler);
+
+                assert(selector === dataset);
+            });
+
+            describe('dataset is a regular expression', () => {
+                const datasetRegex = new RegExp('test');
+
+                beforeEach(() => {
+                    adaptiveCards.search(datasetRegex, testHandler);
+                });
+
+                it('incomming activity is valid application/search type and should match regex', async () => {
+                    const activity = {
+                        type: 'invoke',
+                        name: 'application/search',
+                        value: {
+                            dataset: 'test'
+                        }
+                    };
+                    const context = createTurnContext(activity);
+
+                    // the selector should be testing if `value.dataset` matches the regex `datasetRegex`.
+                    assert((await selector(context)) == true);
+                });
+
+                it('incomming activity is valid application/search type and should not match regex ', async () => {
+                    const activity = {
+                        type: 'invoke',
+                        name: 'application/search',
+                        value: {
+                            dataset: 'DoesNotMatchRegex'
+                        }
+                    };
+                    const context = createTurnContext(activity);
+
+                    // the selector should be testing if `value.dataset` matches the regex `datasetRegex`.
+                    assert((await selector(context)) == false);
+                });
+
+                it('incomming activity is invalid', async () => {
+                    const activity = {
+                        type: 'NotInvoke'
+                    };
+
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == false);
+                });
+            });
+
+            describe('dataset is a string', () => {
+                const dataset = 'test';
+
+                beforeEach(() => {
+                    adaptiveCards.search(dataset, testHandler);
+                });
+
+                it('activity is valid application/search type and dataset matches', async () => {
+                    const activity = {
+                        type: 'invoke',
+                        name: 'application/search',
+                        value: {
+                            dataset: 'test'
+                        }
+                    };
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == true);
+                });
+
+                it('activity is valid application/search type and datasets are not equal', async () => {
+                    const activity = {
+                        type: 'invoke',
+                        name: 'application/search',
+                        value: {
+                            dataset: 'test'
+                        }
+                    };
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == false);
+                });
+
+                it('activity is invalid', async () => {
+                    const activity = {
+                        type: 'NotApplicationSearch'
+                    };
+
+                    const context = createTurnContext(activity);
+
+                    assert((await selector(context)) == false);
+                });
+            });
+        });
+
+        describe('handler creation logic', () => {
+            it('should create handler', () => {
+                adaptiveCards.search(testDataset, testHandler);
+
+                assert(typeof handler === 'function');
+            });
+
+            it('should throw error if incomming activity is not valid', async () => {
+                adaptiveCards.search(testDataset, testHandler);
+
+                const activity = {
+                    type: 'invalidActivityType'
+                };
+
+                const context = createTurnContext(activity);
+                const state = new TurnState();
+                const errorMsg = `Unexpected AdaptiveCards.search() triggered for activity type: invalidActivityType`;
+
+                assert.rejects(async () => await handler(context, state), errorMsg);
+            });
+
+            it('should call the test handler with the correct parameters', async () => {
+                const testHandlerStub = sinon.spy(testHandler);
+
+                adaptiveCards.search(testDataset, testHandlerStub);
+
+                const query = {
+                    count: 1,
+                    skip: 1,
+                    parameters: {
+                        queryText: 'queryText',
+                        dataset: 'testDataSet'
+                    }
+                };
+
+                const activity = {
+                    type: 'invoke',
+                    name: 'application/search',
+                    value: {
+                        queryOptions: {
+                            top: query.count,
+                            skip: query.skip
+                        },
+                        queryText: query.parameters.queryText,
+                        dataset: query.parameters.dataset
+                    }
+                };
+
+                const context = createTurnContext(activity);
+                const state = new TurnState();
+
+                // this is the handler that is registered as an app route.
+                await handler(context, state);
+
+                assert(testHandlerStub.calledOnce);
+                assert(testHandlerStub.calledWith(context, state, query));
+            });
+
+            it('should send an invoke search response with handler result.', async () => {
+                const returnedSearchResult = [
+                    {
+                        title: 'title',
+                        value: 'value'
+                    }
+                ];
+
+                const testHandler = (
+                    context: TurnContext,
+                    state: TurnState,
+                    query: Query<AdaptiveCardsSearchParams>
+                ): Promise<AdaptiveCardSearchResult[]> => Promise.resolve(returnedSearchResult);
+
+                adaptiveCards.search(testDataset, testHandler);
+
+                const activity = {
+                    type: 'invoke',
+                    name: 'application/search'
+                };
+
+                const context = createTurnContext(activity);
+                const contextSendActivityStub = sinon.stub(context, 'sendActivity');
+                const state = new TurnState();
+
+                // this is the handler that is registered as an app route.
+                await handler(context, state);
+
+                const response = {
+                    type: 'application/vnd.microsoft.search.searchResponse',
+                    value: {
+                        results: returnedSearchResult
+                    }
+                };
+
+                assert(
+                    contextSendActivityStub.calledOnceWith({
+                        value: { body: response, status: 200 } as InvokeResponse,
+                        type: ActivityTypes.InvokeResponse
+                    })
+                );
             });
         });
     });

--- a/js/packages/teams-ai/src/AdaptiveCards.ts
+++ b/js/packages/teams-ai/src/AdaptiveCards.ts
@@ -35,7 +35,7 @@ const DEFAULT_ACTION_SUBMIT_FILTER = 'verb';
 /**
  * @private
  */
-const SEARCH_INvOKE_NAME = `application/search`;
+const SEARCH_INVOKE_NAME = `application/search`;
 
 /**
  * Strongly typed Adaptive Card.
@@ -245,7 +245,7 @@ export class AdaptiveCards<TState extends TurnState> {
                 async (context, state) => {
                     // Insure that we're in an Action.Execute as expected
                     const a = context?.activity;
-                    if (a?.type !== ActivityTypes.Invoke || a?.name !== SEARCH_INvOKE_NAME) {
+                    if (a?.type !== ActivityTypes.Invoke || a?.name !== SEARCH_INVOKE_NAME) {
                         throw new Error(`Unexpected AdaptiveCards.search() triggered for activity type: ${a?.type}`);
                     }
 
@@ -369,7 +369,7 @@ function createSearchSelector(dataset: string | RegExp | RouteSelector): RouteSe
         // Return a function that matches the dataset using a RegExp
         return (context: TurnContext) => {
             const a = context?.activity;
-            const isSearch = a?.type == ActivityTypes.Invoke && a?.name === SEARCH_INvOKE_NAME;
+            const isSearch = a?.type == ActivityTypes.Invoke && a?.name === SEARCH_INVOKE_NAME;
             if (isSearch && typeof a?.value?.dataset == 'string') {
                 return Promise.resolve(dataset.test(a.value.dataset));
             } else {
@@ -380,7 +380,7 @@ function createSearchSelector(dataset: string | RegExp | RouteSelector): RouteSe
         // Return a function that attempts to match dataset
         return (context: TurnContext) => {
             const a = context?.activity;
-            const isSearch = a?.type == ActivityTypes.Invoke && a?.name === SEARCH_INvOKE_NAME;
+            const isSearch = a?.type == ActivityTypes.Invoke && a?.name === SEARCH_INVOKE_NAME;
             return Promise.resolve(isSearch && a?.value?.dataset === dataset);
         };
     }

--- a/js/packages/teams-ai/src/authentication/Authentication.ts
+++ b/js/packages/teams-ai/src/authentication/Authentication.ts
@@ -120,9 +120,9 @@ export class Authentication<TState extends TurnState> {
 
         // Signout flow is agnostic of the activity type.
         if (this.isOAuthSettings(this.settings)) {
-            return UserTokenAccess.signOutUser(context, this.settings);
+            return await UserTokenAccess.signOutUser(context, this.settings);
         } else {
-            return this.removeTokenFromMsalCache(context);
+            return await this.removeTokenFromMsalCache(context);
         }
     }
 

--- a/js/packages/teams-ai/src/authentication/OAuthAdaptiveCardAuthentication.spec.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthAdaptiveCardAuthentication.spec.ts
@@ -319,4 +319,45 @@ describe('AdaptiveCardAuthenticaion', () => {
             assert(!result);
         });
     });
+
+    describe('handleSsoTokenExchange()', () => {
+        it('should perform token exchange if the activity.value.authentication exists', async () => {
+            const tokenResponse = {
+                token: 'token',
+                connectionName: 'connectionName',
+                expiration: 'expiration'
+            };
+            const exchangeTokenStub = sinon
+                .stub(UserTokenAccess, 'exchangeToken')
+                .returns(Promise.resolve(tokenResponse));
+            const [context, _] = await createTurnContextAndState({
+                type: ActivityTypes.Invoke,
+                name: 'adaptiveCard/action',
+                value: {
+                    authentication: {
+                        token: 'token'
+                    }
+                }
+            });
+
+            const acAuth = new OAuthAdaptiveCardAuthentication(settings);
+            const response = await acAuth.handleSsoTokenExchange(context);
+
+            assert(exchangeTokenStub.calledOnce);
+            assert(response == tokenResponse);
+        });
+
+        it('should not perform token exchange if the activity.value.authentication does not exist', async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: ActivityTypes.Invoke,
+                name: 'adaptiveCard/action',
+                value: {}
+            });
+
+            const acAuth = new OAuthAdaptiveCardAuthentication(settings);
+            const response = await acAuth.handleSsoTokenExchange(context);
+
+            assert(response == undefined);
+        });
+    });
 });

--- a/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.spec.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.spec.ts
@@ -1,13 +1,21 @@
 /* eslint-disable security/detect-object-injection */
-import { Activity, TestAdapter, TurnContext } from 'botbuilder';
+import { Activity, MemoryStorage, TestAdapter, TurnContext } from 'botbuilder';
 import { Application, RouteSelector } from '../Application';
-import { DialogTurnResult, DialogTurnStatus, OAuthPromptSettings } from 'botbuilder-dialogs';
+import {
+    DialogSet,
+    DialogState,
+    DialogTurnResult,
+    DialogTurnStatus,
+    OAuthPrompt,
+    OAuthPromptSettings
+} from 'botbuilder-dialogs';
 import { BotAuthenticationBase } from './BotAuthenticationBase';
 import * as sinon from 'sinon';
 import assert from 'assert';
 import { TurnState } from '../TurnState';
 import { AuthError } from './Authentication';
-import { OAuthBotAuthentication } from './OAuthBotAuthentication';
+import { FilteredTeamsSSOTokenExchangeMiddleware, OAuthBotAuthentication } from './OAuthBotAuthentication';
+import { TurnStateProperty } from '../TurnStateProperty';
 
 describe('BotAuthentication', () => {
     const adapter = new TestAdapter();
@@ -308,5 +316,77 @@ describe('BotAuthentication', () => {
             assert(error.cause == 'completionWithoutToken');
             assert(error.message == 'Authentication flow completed without a token.');
         });
+    });
+
+    describe('runDialog', () => {
+        beforeEach(() => {
+            sinon.reset();
+        });
+
+        it('should begin dialog if status is empty', async () => {
+            const [context, state] = await createTurnContextAndState({
+                type: 'message',
+                from: {
+                    id: 'test',
+                    name: 'test'
+                }
+            });
+            const dialogStateProperty = 'dialogStateProperty';
+            const accessor = new TurnStateProperty<DialogState>(state, 'conversation', dialogStateProperty);
+            const dialogSet = new DialogSet(accessor);
+            dialogSet.add(new OAuthPrompt('OAuthPrompt', settings));
+            const dialogContext = await dialogSet.createContext(context);
+            const beginDialogStub = sinon.stub(dialogContext, 'beginDialog');
+            const continueDialogStub = sinon
+                .stub(dialogContext, 'continueDialog')
+                .returns(Promise.resolve({ status: DialogTurnStatus.empty }));
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const createDialogContextStub = sinon.stub(botAuth, <any>'createDialogContext').returns(dialogContext);
+
+            const result = await botAuth.runDialog(context, state, dialogStateProperty);
+
+            assert(result == undefined);
+            assert(beginDialogStub.calledOnce);
+            assert(continueDialogStub.calledOnce);
+            assert(createDialogContextStub.calledOnce);
+        });
+
+        it('calling run dialog for the first time should return status waiting', async () => {
+            const [context, state] = await createTurnContextAndState({
+                type: 'message',
+                from: {
+                    id: 'test',
+                    name: 'test'
+                }
+            });
+            const dialogStateProperty = 'dialogStateProperty2';
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+
+            const result = await botAuth.runDialog(context, state, dialogStateProperty);
+
+            assert(result.status == DialogTurnStatus.waiting);
+        });
+    });
+});
+
+describe('FilteredTeamsSSOTokenExchangeMiddleware', () => {
+    it('should call next() if activity.value.connectionName is not equal to connectionName', async () => {
+        const middleware = new FilteredTeamsSSOTokenExchangeMiddleware(new MemoryStorage(), 'connectionName');
+
+        const context = new TurnContext(new TestAdapter(), {
+            type: 'invoke',
+            name: 'signin/tokenExchange',
+            value: {
+                connectionName: 'otherConnectionName'
+            }
+        });
+
+        let nextCalled = false;
+        middleware.onTurn(context, () => {
+            nextCalled = true;
+            return Promise.resolve();
+        });
+
+        assert(nextCalled);
     });
 });

--- a/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.ts
@@ -107,7 +107,7 @@ export class OAuthBotAuthentication<TState extends TurnState> extends BotAuthent
  * @internal
  * SSO Token Exchange Middleware for Teams that filters based on the connection name.
  */
-class FilteredTeamsSSOTokenExchangeMiddleware extends TeamsSSOTokenExchangeMiddleware {
+export class FilteredTeamsSSOTokenExchangeMiddleware extends TeamsSSOTokenExchangeMiddleware {
     private readonly _oauthConnectionName: string;
 
     public constructor(storage: Storage, oauthConnectionName: string) {

--- a/js/packages/teams-ai/src/authentication/UserTokenAccess.spec.ts
+++ b/js/packages/teams-ai/src/authentication/UserTokenAccess.spec.ts
@@ -1,0 +1,97 @@
+import { Activity, TestAdapter, TokenResponse, TurnContext } from 'botbuilder';
+import { SignInUrlResponse, TokenExchangeRequest, TokenStatus, UserTokenClient } from 'botframework-connector';
+import Sinon, * as sinon from 'sinon';
+import { exchangeToken, getSignInResource, getUserToken, signOutUser } from './UserTokenAccess';
+import assert from 'assert';
+
+describe('UserTokenAccess', () => {
+    let context: TurnContext;
+    let userTokenClient: TestUserTokenClient;
+    let userTokenClientStub: Sinon.SinonStub;
+
+    beforeEach(() => {
+        context = new TurnContext(new TestAdapter(), {});
+        userTokenClient = new TestUserTokenClient();
+        userTokenClientStub = sinon.stub(context.turnState, 'get').returns(userTokenClient);
+    });
+
+    it('getUserToken', async () => {
+        await getUserToken(context, { title: 'title', connectionName: 'test' }, '1234');
+
+        assert(userTokenClientStub.calledOnce);
+        assert(userTokenClient.lastMethodCalled === 'getUserToken');
+    });
+
+    it('getSignInResource', async () => {
+        await getSignInResource(context, { title: 'title', connectionName: 'test' });
+
+        assert(userTokenClientStub.calledOnce);
+        assert(userTokenClient.lastMethodCalled === 'getSignInResource');
+    });
+
+    it('signOutUser', async () => {
+        await signOutUser(context, { title: 'title', connectionName: 'test' });
+
+        assert(userTokenClientStub.calledOnce);
+        assert(userTokenClient.lastMethodCalled === 'signOutUser');
+    });
+
+    it('exchangeToken', async () => {
+        await exchangeToken(context, { title: 'title', connectionName: 'test' }, {});
+
+        assert(userTokenClientStub.calledOnce);
+        assert(userTokenClient.lastMethodCalled === 'exchangeToken');
+    });
+});
+
+class TestUserTokenClient implements UserTokenClient {
+    public lastMethodCalled: string;
+
+    constructor() {
+        this.lastMethodCalled = '';
+    }
+
+    public getUserToken(
+        userId: string,
+        connectionName: string,
+        channelId: string,
+        magicCode: string
+    ): Promise<TokenResponse> {
+        this.lastMethodCalled = 'getUserToken';
+        return Promise.resolve({} as TokenResponse);
+    }
+    public getSignInResource(
+        connectionName: string,
+        activity: Activity,
+        finalRediect: string
+    ): Promise<SignInUrlResponse> {
+        this.lastMethodCalled = 'getSignInResource';
+        return Promise.resolve({} as SignInUrlResponse);
+    }
+    public signOutUser(userId: string, connectionName: string, channelId: string): Promise<void> {
+        this.lastMethodCalled = 'signOutUser';
+        return Promise.resolve();
+    }
+    public getTokenStatus(userId: string, channelId: string, includeFilter: string): Promise<TokenStatus[]> {
+        this.lastMethodCalled = 'getTokenStatus';
+        return Promise.resolve([]);
+    }
+    public getAadTokens(
+        userId: string,
+        connectionName: string,
+        resourceUrls: string[],
+        channelId: string
+    ): Promise<Record<string, TokenResponse>> {
+        this.lastMethodCalled = 'getAadTokens';
+        return Promise.resolve({});
+    }
+    public exchangeToken(
+        userId: string,
+        connectionName: string,
+        channelId: string,
+        exchangeRequest: TokenExchangeRequest
+    ): Promise<TokenResponse> {
+        this.lastMethodCalled = 'exchangeToken';
+        return Promise.resolve({} as TokenResponse);
+    }
+}


### PR DESCRIPTION
## Linked issues

closes: #54  (issue number)

## Details

Summary
- `src/authentication/` files coverage is above 80%
- `TeamsSsoAdaptiveCardAuthentication.ts` is an internal stub class that will be implemented very soon.

Unit tests
 - [x] `AdaptiveCards.ts` unit tests - coverage: 100%
- [x] Authentication.ts
- [x] OAuthAdaptiveCardAuthentication.ts
- [x] OAuthBotAuthentication.ts
- [x] ~TeamsSsoAdaptiveCardAuthentication.ts~ - not applicable as it's an internal stub

Other
- [x] vscode launch configuration to debug Mocha tests easily

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes