### PR TITLE
[C#] chore: bump .NET library to v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ env/.env.local
 env/.env.staging
 .env*
 /dotnet/samples/NuGet.Config
+/dotnet/samples/LocalPkg/

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Microsoft.Teams.AI</PackageId>
     <Product>Microsoft Teams AI SDK</Product>
-    <Version>1.0.0-preview-6</Version>
+    <Version>1.0.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/dotnet/samples/06.auth.oauth.bot/BotAuth.csproj
+++ b/dotnet/samples/06.auth.oauth.bot/BotAuth.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.21.1" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.0.0-preview-4" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.0.*-*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.oauth.messageExtension/MessageExtensionAuth.csproj
+++ b/dotnet/samples/06.auth.oauth.messageExtension/MessageExtensionAuth.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.21.1" />
     <PackageReference Include="Microsoft.Graph" Version="4.54.0" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.0.0-preview-4" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.0.*-*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->


### PR DESCRIPTION
## Linked issues

closes: #737  (issue number)

## Details

Bump .NET library to version 1.0.0