### PR TITLE
[C#] fix: Calls to OpenAI trace logs format is malformed.

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Teams.AI.AI.Models
 
         private readonly OpenAIClient _openAIClient;
         private string _deploymentName;
+        private static JsonSerializerOptions _serializerOptions = new()
+        {
+            WriteIndented = true,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
 
         private static readonly string _userAgent = "AlphaWave";
 
@@ -190,12 +195,12 @@ namespace Microsoft.Teams.AI.AI.Models
                     _logger.LogTrace($"duration {(DateTime.UtcNow - startTime).TotalMilliseconds} ms");
                     if (promptResponse.Status == PromptResponseStatus.Success)
                     {
-                        _logger.LogTrace(JsonSerializer.Serialize(completionsResponse!.Value));
+                        _logger.LogTrace(JsonSerializer.Serialize(completionsResponse!.Value, _serializerOptions));
                     }
                     if (promptResponse.Status == PromptResponseStatus.RateLimited)
                     {
                         _logger.LogTrace("HEADERS:");
-                        _logger.LogTrace(JsonSerializer.Serialize(rawResponse.Headers));
+                        _logger.LogTrace(JsonSerializer.Serialize(rawResponse.Headers, _serializerOptions));
                     }
                 }
 
@@ -221,7 +226,7 @@ namespace Microsoft.Teams.AI.AI.Models
                 {
                     // TODO: Colorize
                     _logger.LogTrace("CHAT PROMPT:");
-                    _logger.LogTrace(JsonSerializer.Serialize(prompt.Output));
+                    _logger.LogTrace(JsonSerializer.Serialize(prompt.Output, _serializerOptions));
                 }
 
                 // Call chat completion API
@@ -269,12 +274,12 @@ namespace Microsoft.Teams.AI.AI.Models
                     _logger.LogTrace($"duration {(DateTime.UtcNow - startTime).TotalMilliseconds} ms");
                     if (promptResponse.Status == PromptResponseStatus.Success)
                     {
-                        _logger.LogTrace(JsonSerializer.Serialize(chatCompletionsResponse!.Value));
+                        _logger.LogTrace(JsonSerializer.Serialize(chatCompletionsResponse!.Value, _serializerOptions));
                     }
                     if (promptResponse.Status == PromptResponseStatus.RateLimited)
                     {
                         _logger.LogTrace("HEADERS:");
-                        _logger.LogTrace(JsonSerializer.Serialize(rawResponse.Headers));
+                        _logger.LogTrace(JsonSerializer.Serialize(rawResponse.Headers, _serializerOptions));
                     }
                 }
 

--- a/dotnet/samples/.workflows/build-samples.sh
+++ b/dotnet/samples/.workflows/build-samples.sh
@@ -63,7 +63,7 @@ dotnet nuget locals global-packages -c
 
 # If var is empty, conditions is true
 if [ -z $SAMPLE_FOLDER ]; then
-  for p in $(find . -name "*.csproj"); do dotnet build $p; done
+  for p in $(find . -name "*.csproj"); do dotnet build -c Debug $p; done
 else
   dotnet build $SAMPLE_FOLDER;
 fi


### PR DESCRIPTION
## Linked issues

closes: #1140 

## Details
This is how the OpenAI call trace logs are currently formatted:


![Image](https://github.com/microsoft/teams-ai/assets/115390646/69b0750f-dbfe-4367-af2f-385b012c79ff)

This is how it should be:



![Image](https://github.com/microsoft/teams-ai/assets/115390646/895d2cc2-33e9-4504-bc16-2fc610e8cf19)



## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
