### PR TITLE
[JS] chore: UserAccessToken, DataSourceSection, FunctionCallMessage, FunctionResponseMessage Unit Tests 

### DIFF
--- a/js/packages/teams-ai/src/authentication/UserTokenAccess.spec.ts
+++ b/js/packages/teams-ai/src/authentication/UserTokenAccess.spec.ts
@@ -6,6 +6,7 @@ import assert from 'assert';
 
 describe('UserTokenAccess', () => {
     let context: TurnContext;
+    let contextWithNoClient: TurnContext;
     let userTokenClient: TestUserTokenClient;
     let userTokenClientStub: Sinon.SinonStub;
 
@@ -13,34 +14,64 @@ describe('UserTokenAccess', () => {
         context = new TurnContext(new TestAdapter(), {});
         userTokenClient = new TestUserTokenClient();
         userTokenClientStub = sinon.stub(context.turnState, 'get').returns(userTokenClient);
+        contextWithNoClient = new TurnContext(new TestAdapter(), {});
+        sinon.stub(contextWithNoClient.turnState, 'get').returns(null);
     });
 
-    it('getUserToken', async () => {
+    it('valid getUserToken', async () => {
         await getUserToken(context, { title: 'title', connectionName: 'test' }, '1234');
 
         assert(userTokenClientStub.calledOnce);
         assert(userTokenClient.lastMethodCalled === 'getUserToken');
     });
 
-    it('getSignInResource', async () => {
+    it('should throw error for getUserToken due to empty token client', async () => {
+        await assert.rejects(
+            () => getUserToken(contextWithNoClient, { title: 'title', connectionName: 'test' }, '1234'),
+            new Error(`OAuth prompt is not supported by the current adapter`)
+        );
+    });
+
+    it('valid getSignInResource', async () => {
         await getSignInResource(context, { title: 'title', connectionName: 'test' });
 
         assert(userTokenClientStub.calledOnce);
         assert(userTokenClient.lastMethodCalled === 'getSignInResource');
     });
 
-    it('signOutUser', async () => {
+    it('should throw error for getSignInResource due to empty token client', async () => {
+        await assert.rejects(
+            () => getSignInResource(contextWithNoClient, { title: 'title', connectionName: 'test' }),
+            new Error(`OAuth prompt is not supported by the current adapter`)
+        );
+    });
+
+    it('valid signOutUser', async () => {
         await signOutUser(context, { title: 'title', connectionName: 'test' });
 
         assert(userTokenClientStub.calledOnce);
         assert(userTokenClient.lastMethodCalled === 'signOutUser');
     });
 
-    it('exchangeToken', async () => {
+    it('should throw error for signOutUser due to empty token client', async () => {
+        await assert.rejects(
+            () => signOutUser(contextWithNoClient, { title: 'title', connectionName: 'test' }),
+            new Error(`OAuth prompt is not supported by the current adapter`)
+        );
+    });
+
+    it('valid exchangeToken', async () => {
         await exchangeToken(context, { title: 'title', connectionName: 'test' }, {});
 
         assert(userTokenClientStub.calledOnce);
         assert(userTokenClient.lastMethodCalled === 'exchangeToken');
+    });
+
+    it('should throw error for exchangeToken due to empty token client', async () => {
+        await assert.rejects(
+            () => exchangeToken(contextWithNoClient, { title: 'title', connectionName: 'test' }, {}),
+            new Error(`OAuth prompt is not supported by the current adapter`)
+        );
     });
 });
 

--- a/js/packages/teams-ai/src/prompts/DataSourceSection.spec.ts
+++ b/js/packages/teams-ai/src/prompts/DataSourceSection.spec.ts
@@ -1,0 +1,39 @@
+import assert from 'assert';
+import { TextDataSource } from '../dataSources/TextDataSource';
+import { DataSourceSection } from './DataSourceSection';
+import { TestAdapter } from 'botbuilder-core';
+import { TestTurnState } from '../TestTurnState';
+import { GPT3Tokenizer } from '../tokenizers';
+import { TestPromptManager } from './TestPromptManager';
+
+describe('DataSourceSection', () => {
+    const textDataSource = new TextDataSource('testname', 'Hello World!');
+    const adapter = new TestAdapter();
+    const functions = new TestPromptManager();
+    const tokenizer = new GPT3Tokenizer();
+
+    describe('constructor', () => {
+        it('should create a DataSourceSection', () => {
+            const section = new DataSourceSection(textDataSource, -2);
+            assert.notEqual(section, undefined);
+            assert.equal(section.tokens, -2);
+            assert.equal(section.required, true);
+            assert.equal(section.separator, '\n\n');
+            assert.equal(section.textPrefix, '');
+        });
+    });
+
+    describe('renderAsMessages', () => {
+        it('should render a DataSourceSection', async () => {
+            await adapter.sendTextToBot('test', async (context) => {
+                const state = await TestTurnState.create(context);
+                const section = new DataSourceSection(textDataSource, -2);
+                const rendered = await section.renderAsMessages(context, state, functions, tokenizer, 100);
+
+                assert.deepEqual(rendered.output, [{ role: 'system', content: 'Hello World!' }]);
+                assert.equal(rendered.length, 3);
+                assert.equal(rendered.tooLong, false);
+            });
+        });
+    });
+});

--- a/js/packages/teams-ai/src/prompts/FunctionCallMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/FunctionCallMessage.spec.ts
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import { FunctionCallMessage } from './FunctionCallMessage';
+import { FunctionCall } from './Message';
+import { TestAdapter } from 'botbuilder-core';
+import { TestTurnState } from '../TestTurnState';
+import { GPT3Tokenizer } from '../tokenizers';
+import { TestPromptManager } from './TestPromptManager';
+
+describe('FunctionCallMessage', () => {
+    const functionCall: FunctionCall = {
+        name: 'test',
+        arguments: '{"foo":"bar"}'
+    };
+    const adapter = new TestAdapter();
+    const functions = new TestPromptManager();
+    const tokenizer = new GPT3Tokenizer();
+
+    describe('constructor', () => {
+        it('should create a FunctionCallMessage', () => {
+            const section = new FunctionCallMessage(functionCall);
+
+            assert.notEqual(section, undefined);
+            assert.equal(section.tokens, -1);
+            assert.equal(section.required, true);
+            assert.equal(section.separator, '\n');
+            assert.equal(section.textPrefix, 'assistant: ');
+            assert.equal(section.function_call, functionCall);
+        });
+    });
+
+    describe('renderAsMessages', () => {
+        it('should render a FunctionCallMessage', async () => {
+            await adapter.sendTextToBot('test', async (context) => {
+                const state = await TestTurnState.create(context);
+                const section = new FunctionCallMessage(functionCall);
+                const rendered = await section.renderAsMessages(context, state, functions, tokenizer, 100);
+
+                assert.deepEqual(rendered.output, [
+                    { role: 'assistant', content: undefined, function_call: functionCall }
+                ]);
+                assert.equal(rendered.length, 17);
+                assert.equal(rendered.tooLong, false);
+            });
+        });
+    });
+});

--- a/js/packages/teams-ai/src/prompts/FunctionResponseMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/FunctionResponseMessage.spec.ts
@@ -1,0 +1,42 @@
+import assert from 'assert';
+import { FunctionResponseMessage } from './FunctionResponseMessage';
+import { TestAdapter } from 'botbuilder-core';
+import { TestTurnState } from '../TestTurnState';
+import { GPT3Tokenizer } from '../tokenizers';
+import { TestPromptManager } from './TestPromptManager';
+
+describe('FunctionResponseMessage', () => {
+    const functionName = 'foo';
+    const response = 'bar';
+    const adapter = new TestAdapter();
+    const functions = new TestPromptManager();
+    const tokenizer = new GPT3Tokenizer();
+
+    describe('constructor', () => {
+        it('should create a FunctionResponseMessage', () => {
+            const section = new FunctionResponseMessage(functionName, response);
+
+            assert.notEqual(section, undefined);
+            assert.equal(section.name, functionName);
+            assert.equal(section.response, response);
+            assert.equal(section.tokens, -1);
+            assert.equal(section.required, true);
+            assert.equal(section.separator, '\n');
+            assert.equal(section.textPrefix, 'user: ');
+        });
+    });
+
+    describe('renderAsMessages', () => {
+        it('should render a FunctionResponseMessage', async () => {
+            await adapter.sendTextToBot('test', async (context) => {
+                const state = await TestTurnState.create(context);
+                const section = new FunctionResponseMessage(functionName, response);
+                const rendered = await section.renderAsMessages(context, state, functions, tokenizer, 100);
+
+                assert.deepEqual(rendered.output, [{ role: 'function', name: functionName, content: response }]);
+                assert.equal(rendered.length, 2);
+                assert.equal(rendered.tooLong, false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Linked issues

closes: #54 

## Details

- Added error test cases for `UserAccessToken`
- Added tests for `DataSourceSection`, `FunctionCallMessage`, `FunctionResponseMessage `

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
