### PR TITLE
[JS] docs: Added reminder to configure VS Code auto attach for debugging

### DIFF
--- a/js/samples/04.ai.a.teamsChefBot/.vscode/launch.json
+++ b/js/samples/04.ai.a.teamsChefBot/.vscode/launch.json
@@ -90,6 +90,18 @@
                 "order": 2
             },
             "stopAll": true
+        },
+        {
+            "name": "Debug Local",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start application",
+            "presentation": {
+                "group": "all",
+                "order": 2
+            },
+            "stopAll": true
         }
     ]
 }

--- a/js/samples/README.md
+++ b/js/samples/README.md
@@ -114,7 +114,7 @@ You can also use the Teams Toolkit CLI to run this sample.
 
 1. Download and install [Bot Framework Emulator](https://github.com/microsoft/BotFramework-Emulator)
 2. Launch Bot Framework Emulator
-3. Run the app you are in the directory for.
+3. Run the app you are in the directory for. Make sure [Auto Attach](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_auto-attach) is set to `Smart` or `Always` to debug locally.
 
 ```bash
 yarn start


### PR DESCRIPTION
## Linked issues

#minor

## Details

small reminder to configure VSCode auto attach behavior in js/samples/README.md


## Attestation Checklist

- [ X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information


