### PR TITLE
[JS] feat: added bot framework debugger config

### DIFF
--- a/js/samples/04.ai.a.teamsChefBot/.vscode/launch.json
+++ b/js/samples/04.ai.a.teamsChefBot/.vscode/launch.json
@@ -90,6 +90,18 @@
                 "order": 2
             },
             "stopAll": true
+        },
+        {
+            "name": "Debug Local",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start application",
+            "presentation": {
+                "group": "all",
+                "order": 2
+            },
+            "stopAll": true
         }
     ]
 }


### PR DESCRIPTION
## Linked issues

#minor

## Details

added configuration to only start the bot to use with the bot framework emulator to launch.json in Teams Chef `js/samples /04.ai.a.teamsChefBot/.vscode/launch.json`

#### Change details

New launch config that does not start a brower and tried to sideload to teams.

**code snippets**:

        {
            "name": "Debug Local",
            "configurations": [
                "Attach to Local Service"
            ],
            "preLaunchTask": "Start application",
            "presentation": {
                "group": "all",
                "order": 2
            },
            "stopAll": true
        }

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
