### PR TITLE
[PY] feat: python prompts layout engine

### DIFF
--- a/python/packages/ai/teams/ai/promptsv2/__init__.py
+++ b/python/packages/ai/teams/ai/promptsv2/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from .layout_engine import LayoutEngine
+from .prompt_section import PromptSection
+from .text_section import TextSection

--- a/python/packages/ai/teams/ai/promptsv2/__init__.py
+++ b/python/packages/ai/teams/ai/promptsv2/__init__.py
@@ -3,6 +3,10 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from .function_call import FunctionCall
 from .layout_engine import LayoutEngine
+from .message import ImageContentPart, Message, TextContentPart
 from .prompt_section import PromptSection
+from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
 from .text_section import TextSection

--- a/python/packages/ai/teams/ai/promptsv2/function_call.py
+++ b/python/packages/ai/teams/ai/promptsv2/function_call.py
@@ -9,5 +9,10 @@ from typing import Optional
 
 @dataclass
 class FunctionCall:
+    """A named function to call."""
+
     name: Optional[str]
+    """Name of the function to call."""
+
     arguments: Optional[str]
+    """Arguments to pass to the function. Must be deserialized."""

--- a/python/packages/ai/teams/ai/promptsv2/function_call.py
+++ b/python/packages/ai/teams/ai/promptsv2/function_call.py
@@ -1,0 +1,13 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class FunctionCall:
+    name: Optional[str]
+    arguments: Optional[str]

--- a/python/packages/ai/teams/ai/promptsv2/layout_engine.py
+++ b/python/packages/ai/teams/ai/promptsv2/layout_engine.py
@@ -1,0 +1,210 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+from typing import Any, Awaitable, Callable, List, Optional, Union
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from .message import Message
+from .prompt_functions import PromptFunctions
+
+from .prompt_section import PromptSection
+from .prompt_section_layout import PromptSectionLayout
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class LayoutEngine(PromptSection):
+    _sections: List[PromptSection]
+    _required: bool
+    _tokens: int
+    _separator: str
+
+    @property
+    def sections(self) -> List[PromptSection]:
+        return self._sections
+
+    @property
+    def required(self) -> bool:
+        return self._required
+
+    @property
+    def tokens(self) -> int:
+        return self._tokens
+
+    @property
+    def separator(self) -> str:
+        return self._separator
+
+    def __init__(self, sections: List[PromptSection], tokens: int, required: bool, separator: str):
+        self._sections = sections
+        self._required = required
+        self._tokens = tokens
+        self._separator = separator
+
+    async def render_as_text(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[str]:
+        # Start a new layout
+        layout: List[PromptSectionLayout[str]] = []
+        # Adds all sections from the current LayoutEngine hierarchy to a flat array
+        self._add_sections_to_layout(self.sections, layout)
+
+        # Layout sections
+        remaining = await self._layout_sections(
+            layout,
+            max_tokens,
+            lambda section: section.render_as_text(
+                context, memory, functions, tokenizer, max_tokens
+            ),
+            lambda section, remaining: section.render_as_text(
+                context, memory, functions, tokenizer, remaining
+            ),
+            True,
+            tokenizer,
+        )
+
+        # Build output
+        output = [section.layout.output for section in layout if section.layout]
+        text = self.separator.join(output)
+        return RenderedPromptSection(
+            output=text, length=len(tokenizer.encode(text)), too_long=remaining < 0
+        )
+
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[List[Message]]:
+        # Start a new layout
+        layout: List[PromptSectionLayout[List[Message]]] = []
+        # Adds all sections from the current LayoutEngine hierarchy to a flat array
+        self._add_sections_to_layout(self.sections, layout)
+
+        # Layout sections
+        remaining = await self._layout_sections(
+            layout,
+            max_tokens,
+            lambda section: section.render_as_messages(
+                context, memory, functions, tokenizer, max_tokens
+            ),
+            lambda section, remaining: section.render_as_messages(
+                context, memory, functions, tokenizer, remaining
+            ),
+        )
+
+        # Build output
+        output = [
+            message for section in layout if section.layout for message in section.layout.output
+        ]
+        return RenderedPromptSection(
+            output=output, length=self._get_layout_length(layout), too_long=remaining < 0
+        )
+
+    def _add_sections_to_layout(
+        self, sections: List[PromptSection], layout: List[PromptSectionLayout[Any]]
+    ):
+        for section in sections:
+            if isinstance(section, LayoutEngine):
+                self._add_sections_to_layout(section.sections, layout)
+            else:
+                layout.append(PromptSectionLayout(section=section))
+
+    async def _layout_sections(
+        self,
+        layout: List[PromptSectionLayout[Any]],
+        max_tokens: int,
+        cb_fixed: Callable[[PromptSection], Awaitable[RenderedPromptSection[Any]]],
+        cb_proportional: Callable[[PromptSection, int], Awaitable[RenderedPromptSection[Any]]],
+        text_layout: bool = False,
+        tokenizer: Optional[Tokenizer] = None,
+    ) -> int:
+        # Layout fixed sections
+        await self._layout_fixed_sections(layout, cb_fixed)
+
+        # Get tokens remaining and drop optional sections if too long
+        remaining = max_tokens - self._get_layout_length(layout, text_layout, tokenizer)
+        while remaining < 0 and self._drop_last_optional_section(layout):
+            remaining = max_tokens - self._get_layout_length(layout, text_layout, tokenizer)
+
+        # Layout proportional sections
+        if self._needs_more_layout(layout) and remaining > 0:
+            # Layout proportional sections
+            await self._layout_proportional_sections(
+                layout, lambda section: cb_proportional(section, remaining)
+            )
+
+            # Get tokens remaining and drop optional sections if too long
+            remaining = max_tokens - self._get_layout_length(layout, text_layout, tokenizer)
+            while remaining < 0 and self._drop_last_optional_section(layout):
+                remaining = max_tokens - self._get_layout_length(layout, text_layout, tokenizer)
+
+        return remaining
+
+    async def _layout_fixed_sections(
+        self,
+        layouts: List[PromptSectionLayout[Any]],
+        callback: Callable[[PromptSection], Awaitable[RenderedPromptSection[Any]]],
+    ) -> None:
+        tasks: List[Awaitable] = []
+        for layout in layouts:
+            if layout.section.tokens < 0 or layout.section.tokens > 1.0:
+
+                async def task() -> None:
+                    output = await callback(layout.section)
+                    layout.layout = output
+
+                tasks.append(task())
+
+        await asyncio.gather(*tasks)
+
+    async def _layout_proportional_sections(
+        self,
+        layouts: List[PromptSectionLayout[Any]],
+        callback: Callable[[PromptSection], Awaitable[RenderedPromptSection[Any]]],
+    ) -> None:
+        tasks: List[Awaitable] = []
+        for layout in layouts:
+            if 0.0 <= layout.section.tokens <= 1.0:
+
+                async def task() -> None:
+                    output = await callback(layout.section)
+                    layout.layout = output
+
+                tasks.append(task())
+
+        await asyncio.gather(*tasks)
+
+    def _get_layout_length(
+        self,
+        layout: List[PromptSectionLayout[Any]],
+        text_layout: bool = False,
+        tokenizer: Optional[Tokenizer] = None,
+    ) -> int:
+        if text_layout and tokenizer:
+            output = [section.layout.output for section in layout if section.layout]
+            return len(tokenizer.encode(self.separator.join(output)))
+        else:
+            return sum(section.layout.length for section in layout if section.layout)
+
+    def _drop_last_optional_section(self, layout: List[PromptSectionLayout[Any]]) -> bool:
+        for i in reversed(range(len(layout))):
+            if not layout[i].section.required:
+                del layout[i]
+                return True
+        return False
+
+    def _needs_more_layout(self, layout: List[PromptSectionLayout[Any]]) -> bool:
+        return any(not section.layout for section in layout)

--- a/python/packages/ai/teams/ai/promptsv2/layout_engine.py
+++ b/python/packages/ai/teams/ai/promptsv2/layout_engine.py
@@ -13,14 +13,20 @@ from ..tokenizers import Tokenizer
 from .message import Message
 from .prompt_functions import PromptFunctions
 from .prompt_section import PromptSection
-from .prompt_section_layout import PromptSectionLayout
+from .prompt_section_layout import _PromptSectionLayout
 from .rendered_prompt_section import RenderedPromptSection
 
 
 class LayoutEngine(PromptSection):
+    """
+    Base layout engine that renders a set of `auto`, `fixed`, or `proportional` length sections.
+    This class is used internally by the `Prompt` and `GroupSection` classes to
+    render their sections.
+    """
+
     _sections: List[PromptSection]
     _required: bool
-    _tokens: int
+    _tokens: float
     _separator: str
 
     @property
@@ -32,14 +38,23 @@ class LayoutEngine(PromptSection):
         return self._required
 
     @property
-    def tokens(self) -> int:
+    def tokens(self) -> float:
         return self._tokens
 
     @property
     def separator(self) -> str:
         return self._separator
 
-    def __init__(self, sections: List[PromptSection], tokens: int, required: bool, separator: str):
+    def __init__(
+        self, sections: List[PromptSection], tokens: float, required: bool, separator: str
+    ):
+        """
+        Args:
+            sections (List[PromptSection]): List of sections to layout.
+            tokens (float): Sizing strategy for this section.
+            required (bool): Indicates if this section is required.
+            separator (str): Separator to use between sections when rendering as text.
+        """
         self._sections = sections
         self._required = required
         self._tokens = tokens
@@ -54,8 +69,22 @@ class LayoutEngine(PromptSection):
         tokenizer: Tokenizer,
         max_tokens: int,
     ) -> RenderedPromptSection[str]:
+        """
+        Renders the sections as text.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): The current memory.
+            functions (PromptFunctions): The functions available to use in the prompt.
+            tokenizer (Tokenizer): Tokenizer to use when rendering as text.
+            max_tokens (int): Maximum number of tokens allowed.
+
+        Returns:
+            RenderedPromptSection[str]: The rendered sections as text.
+        """
+
         # Start a new layout
-        layout: List[PromptSectionLayout[str]] = []
+        layout: List[_PromptSectionLayout[str]] = []
         # Adds all sections from the current LayoutEngine hierarchy to a flat array
         self._add_sections_to_layout(self.sections, layout)
 
@@ -91,8 +120,22 @@ class LayoutEngine(PromptSection):
         tokenizer: Tokenizer,
         max_tokens: int,
     ) -> RenderedPromptSection[List[Message]]:
+        """
+        Renders the sections as messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): The current memory.
+            functions (PromptFunctions): The functions available to use in the prompt.
+            tokenizer (Tokenizer): Tokenizer to use when rendering as text.
+            max_tokens (int): Maximum number of tokens allowed.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered sections as messages.
+        """
+
         # Start a new layout
-        layout: List[PromptSectionLayout[List[Message]]] = []
+        layout: List[_PromptSectionLayout[List[Message]]] = []
         # Adds all sections from the current LayoutEngine hierarchy to a flat array
         self._add_sections_to_layout(self.sections, layout)
 
@@ -119,18 +162,18 @@ class LayoutEngine(PromptSection):
     # pylint: enable=too-many-arguments
 
     def _add_sections_to_layout(
-        self, sections: List[PromptSection], layout: List[PromptSectionLayout[Any]]
+        self, sections: List[PromptSection], layout: List[_PromptSectionLayout[Any]]
     ):
         for section in sections:
             if isinstance(section, LayoutEngine):
                 self._add_sections_to_layout(section.sections, layout)
             else:
-                layout.append(PromptSectionLayout(section=section))
+                layout.append(_PromptSectionLayout(section=section))
 
     # pylint: disable=too-many-arguments # No argument can be removed based on the design
     async def _layout_sections(
         self,
-        layout: List[PromptSectionLayout[Any]],
+        layout: List[_PromptSectionLayout[Any]],
         max_tokens: int,
         callback_fixed: Callable[[PromptSection], Awaitable[RenderedPromptSection[Any]]],
         callback_proportional: Callable[
@@ -165,14 +208,14 @@ class LayoutEngine(PromptSection):
 
     async def _layout_fixed_sections(
         self,
-        layouts: List[PromptSectionLayout[Any]],
+        layouts: List[_PromptSectionLayout[Any]],
         callback: Callable[[PromptSection], Awaitable[RenderedPromptSection[Any]]],
     ) -> None:
         tasks: List[Awaitable] = []
         for layout in layouts:
             if layout.section.tokens < 0 or layout.section.tokens > 1.0:
 
-                async def task(layout: PromptSectionLayout[Any]) -> None:
+                async def task(layout: _PromptSectionLayout[Any]) -> None:
                     output = await callback(layout.section)
                     layout.layout = output
 
@@ -182,14 +225,14 @@ class LayoutEngine(PromptSection):
 
     async def _layout_proportional_sections(
         self,
-        layouts: List[PromptSectionLayout[Any]],
+        layouts: List[_PromptSectionLayout[Any]],
         callback: Callable[[PromptSection], Awaitable[RenderedPromptSection[Any]]],
     ) -> None:
         tasks: List[Awaitable] = []
         for layout in layouts:
             if 0.0 <= layout.section.tokens <= 1.0:
 
-                async def task(layout: PromptSectionLayout[Any]) -> None:
+                async def task(layout: _PromptSectionLayout[Any]) -> None:
                     output = await callback(layout.section)
                     layout.layout = output
 
@@ -199,7 +242,7 @@ class LayoutEngine(PromptSection):
 
     def _get_layout_length(
         self,
-        layout: List[PromptSectionLayout[Any]],
+        layout: List[_PromptSectionLayout[Any]],
         text_layout: bool = False,
         tokenizer: Optional[Tokenizer] = None,
     ) -> int:
@@ -209,12 +252,12 @@ class LayoutEngine(PromptSection):
 
         return sum(section.layout.length for section in layout if section.layout)
 
-    def _drop_last_optional_section(self, layout: List[PromptSectionLayout[Any]]) -> bool:
+    def _drop_last_optional_section(self, layout: List[_PromptSectionLayout[Any]]) -> bool:
         for i in reversed(range(len(layout))):
             if not layout[i].section.required:
                 del layout[i]
                 return True
         return False
 
-    def _needs_more_layout(self, layout: List[PromptSectionLayout[Any]]) -> bool:
+    def _needs_more_layout(self, layout: List[_PromptSectionLayout[Any]]) -> bool:
         return any(not section.layout for section in layout)

--- a/python/packages/ai/teams/ai/promptsv2/message.py
+++ b/python/packages/ai/teams/ai/promptsv2/message.py
@@ -13,6 +13,16 @@ T = TypeVar("T")
 
 @dataclass
 class Message(Generic[T]):
+    """
+    A message object sent to or received from an LLM.
+
+    Attributes:
+        role (str): The messages role. Typically 'system', 'user', 'assistant', 'function'.
+        content (Optional[T]): Text of the message.
+        function_call (Optional[FunctionCall]): A named function to call.
+        name (Optional[str]): Name of the function that was called.
+    """
+
     role: str
     content: Optional[T] = None
     function_call: Optional[FunctionCall] = None
@@ -21,19 +31,43 @@ class Message(Generic[T]):
 
 @dataclass
 class ImageUrl:
+    """
+    Url for an image
+
+    Attributes:
+        url (str): Url of the image
+    """
+
     url: str
 
 
 @dataclass
 class TextContentPart:
+    """
+    Represents text content part of a message
+
+    Attributes:
+        text (str): Text content
+    """
+
     type: Literal["text"]
     text: str
 
 
 @dataclass
 class ImageContentPart:
+    """
+    Represents image content part of a message
+
+    Attributes:
+        image_url (Union[str, ImageUrl]): Url for the image
+    """
+
     type: Literal["image_url"]
     image_url: Union[str, ImageUrl]
 
 
 MessageContentParts = Union[TextContentPart, ImageContentPart]
+"""
+Represents part of the message's content
+"""

--- a/python/packages/ai/teams/ai/promptsv2/message.py
+++ b/python/packages/ai/teams/ai/promptsv2/message.py
@@ -1,0 +1,19 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
+
+from .function_call import FunctionCall
+
+T = TypeVar("T")
+
+
+@dataclass
+class Message(Generic[T]):
+    role: str
+    content: Optional[T]
+    function_call: Optional[FunctionCall]
+    name: Optional[str]

--- a/python/packages/ai/teams/ai/promptsv2/message.py
+++ b/python/packages/ai/teams/ai/promptsv2/message.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 from dataclasses import dataclass
-from typing import Generic, Optional, TypeVar
+from typing import Generic, Literal, Optional, TypeVar, Union
 
 from .function_call import FunctionCall
 
@@ -15,5 +15,25 @@ T = TypeVar("T")
 class Message(Generic[T]):
     role: str
     content: Optional[T]
-    function_call: Optional[FunctionCall]
-    name: Optional[str]
+    function_call: Optional[FunctionCall] = None
+    name: Optional[str] = None
+
+
+@dataclass
+class ImageUrl:
+    url: str
+
+
+@dataclass
+class TextContentPart:
+    type: Literal["text"]
+    text: str
+
+
+@dataclass
+class ImageContentPart:
+    type: Literal["image_url"]
+    image_url: Union[str, ImageUrl]
+
+
+MessageContentParts = Union[TextContentPart, ImageContentPart]

--- a/python/packages/ai/teams/ai/promptsv2/message.py
+++ b/python/packages/ai/teams/ai/promptsv2/message.py
@@ -14,7 +14,7 @@ T = TypeVar("T")
 @dataclass
 class Message(Generic[T]):
     role: str
-    content: Optional[T]
+    content: Optional[T] = None
     function_call: Optional[FunctionCall] = None
     name: Optional[str] = None
 

--- a/python/packages/ai/teams/ai/promptsv2/prompt_functions.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_functions.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+
+"""
+A function that can be called from a prompt template string.
+
+Parameters:
+    context (TurnContext): Context for the current turn of conversation.
+    memory (Memory): Interface used to access state variables.
+    functions (PromptFunctions): Collection of functions that can be called from a prompt template string.
+    tokenizer (Tokenizer): Tokenizer used to encode/decode strings.
+    args (List[str]): Arguments to the function as an array of strings.
+
+Returns:
+    Any: The return type is not specified, so it can be any type.
+"""
+PromptFunction = Callable[[TurnContext, Memory, "PromptFunctions", Tokenizer, List[str]], Any]
+
+
+class PromptFunctions(ABC):
+    """A collection of functions that can be called from a prompt template string."""
+
+    @abstractmethod
+    def has_function(self, name: str) -> bool:
+        """
+        Checks if a function is defined.
+
+        Args:
+            name (str): Name of the function to lookup.
+
+        Returns:
+            bool: True if the function is defined, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def get_function(self, name: str) -> PromptFunction:
+        """
+        Looks up a given function.
+
+        Args:
+            name (str): Name of the function to lookup.
+
+        Raises:
+            Error: If the function is not defined.
+
+        Returns:
+            PromptFunction: The function associated with the given name.
+        """
+        pass
+
+    @abstractmethod
+    def invoke_function(
+        self, name: str, context: TurnContext, memory: Memory, tokenizer: Tokenizer, args: List[str]
+    ):
+        """
+        Calls the given function.
+
+        Args:
+            name (str): Name of the function to invoke.
+            context (TurnContext): Context for the current turn of conversation.
+            memory (Memory): Interface used to access state variables.
+            tokenizer (Tokenizer): Tokenizer used to encode/decode strings.
+            args (List[str]): Arguments to pass to the function as an array of strings.
+
+        Raises:
+            Error: If the function is not defined.
+        """
+        pass

--- a/python/packages/ai/teams/ai/promptsv2/prompt_functions.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_functions.py
@@ -4,27 +4,30 @@ Licensed under the MIT License.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List
+from typing import Any, Awaitable, Callable, List
 
 from botbuilder.core import TurnContext
 
 from ...state import Memory
 from ..tokenizers import Tokenizer
 
+PromptFunction = Callable[
+    [TurnContext, Memory, "PromptFunctions", Tokenizer, List[str]], Awaitable[Any]
+]
 """
 A function that can be called from a prompt template string.
 
 Parameters:
     context (TurnContext): Context for the current turn of conversation.
     memory (Memory): Interface used to access state variables.
-    functions (PromptFunctions): Collection of functions that can be called from a prompt template string.
+    functions (PromptFunctions): Collection of functions that can be called
+      from a prompt template string.
     tokenizer (Tokenizer): Tokenizer used to encode/decode strings.
     args (List[str]): Arguments to the function as an array of strings.
 
 Returns:
     Any: The return type is not specified, so it can be any type.
 """
-PromptFunction = Callable[[TurnContext, Memory, "PromptFunctions", Tokenizer, List[str]], Any]
 
 
 class PromptFunctions(ABC):
@@ -41,7 +44,6 @@ class PromptFunctions(ABC):
         Returns:
             bool: True if the function is defined, False otherwise.
         """
-        pass
 
     @abstractmethod
     def get_function(self, name: str) -> PromptFunction:
@@ -57,8 +59,8 @@ class PromptFunctions(ABC):
         Returns:
             PromptFunction: The function associated with the given name.
         """
-        pass
 
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
     @abstractmethod
     def invoke_function(
         self, name: str, context: TurnContext, memory: Memory, tokenizer: Tokenizer, args: List[str]
@@ -76,4 +78,5 @@ class PromptFunctions(ABC):
         Raises:
             Error: If the function is not defined.
         """
-        pass
+
+    # pylint: enable=too-many-arguments

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section.py
@@ -1,0 +1,87 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class PromptSection(ABC):
+    """
+    A section that can be rendered to a prompt as either text or an array of `Message` objects.
+    """
+
+    @property
+    @abstractmethod
+    def required(self) -> bool:
+        """
+        If true the section is mandatory otherwise it can be safely dropped.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def tokens(self) -> float:
+        """
+        The requested token budget for this section.
+        - Values between 0.0 and 1.0 represent a percentage of the total budget and the section will be layed out proportionally to all other sections.
+        - Values greater than 1.0 represent the max number of tokens the section should be allowed to consume.
+        """
+        pass
+
+    @abstractmethod
+    async def render_as_text(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> "RenderedPromptSection[str]":
+        """
+        Renders the section as a string of text.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[str]: The rendered prompt section as a string.
+        """
+        pass
+
+    @abstractmethod
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> "RenderedPromptSection[List[Message]]":
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
+        pass

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section.py
@@ -26,18 +26,19 @@ class PromptSection(ABC):
         """
         If true the section is mandatory otherwise it can be safely dropped.
         """
-        pass
 
     @property
     @abstractmethod
     def tokens(self) -> float:
         """
         The requested token budget for this section.
-        - Values between 0.0 and 1.0 represent a percentage of the total budget and the section will be layed out proportionally to all other sections.
-        - Values greater than 1.0 represent the max number of tokens the section should be allowed to consume.
+        - Values between 0.0 and 1.0 represent a percentage of the total budget and
+          the section will be layed out proportionally to all other sections.
+        - Values greater than 1.0 represent the max number of tokens the section
+          should be allowed to consume.
         """
-        pass
 
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
     @abstractmethod
     async def render_as_text(
         self,
@@ -60,8 +61,10 @@ class PromptSection(ABC):
         Returns:
             RenderedPromptSection[str]: The rendered prompt section as a string.
         """
-        pass
 
+    # pylint: enable=too-many-arguments
+
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
     @abstractmethod
     async def render_as_messages(
         self,
@@ -84,4 +87,5 @@ class PromptSection(ABC):
         Returns:
             RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
         """
-        pass
+
+    # pylint: enable=too-many-arguments

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
@@ -19,6 +19,19 @@ from .rendered_prompt_section import RenderedPromptSection
 
 
 class PromptSectionBase(PromptSection):
+    """
+    Abstract Base class for most prompt sections.
+
+    This class provides a default implementation of `renderAsText()` so that derived classes only
+    need to implement `renderAsMessages()`.
+
+    Attributes:
+        required (bool): If true the section is mandatory otherwise it can be safely dropped.
+        tokens (float): The requested token budget for this section.
+        separator (str): The separator to use between messages when rendering as text.
+        text_prefix (str): The prefix to use when rendering as text.
+    """
+
     def __init__(
         self,
         tokens: float = -1,
@@ -26,6 +39,15 @@ class PromptSectionBase(PromptSection):
         separator: str = "\n",
         text_prefix: str = "",
     ):
+        """Initializes the PromptSectionBase.
+
+        Args:
+            tokens (float, optional): Sizing strategy for this section. Defaults to `auto`.
+            required (bool, optional): Indicates if this section is required. Defaults to `true`.
+            separator (str, optional): Separator to use between sections when rendering as text.
+              Defaults to `\n`.
+            text_prefix (str, optional): Prefix to use for text output. Defaults to ``.
+        """
         self._required = required
         self._tokens = tokens
         self._separator = separator
@@ -73,7 +95,19 @@ class PromptSectionBase(PromptSection):
         tokenizer: Tokenizer,
         max_tokens: int,
     ) -> RenderedPromptSection[List[Message]]:
-        pass
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
 
     # pylint: enable=too-many-arguments
 
@@ -86,6 +120,20 @@ class PromptSectionBase(PromptSection):
         tokenizer: Tokenizer,
         max_tokens: int,
     ) -> RenderedPromptSection[str]:
+        """
+        Renders the section as a string of text.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[str]: The rendered prompt section as a string.
+        """
+
         # Render as messages
         as_messages: RenderedPromptSection[List[Message[Any]]] = await self.render_as_messages(
             context, memory, functions, tokenizer, max_tokens
@@ -138,6 +186,15 @@ class PromptSectionBase(PromptSection):
 
     @staticmethod
     def get_message_text(message: Message) -> str:
+        """
+        Returns the content of a message as a string.
+
+        Args:
+            message (Message): Message to get the text of.
+
+        Returns:
+            str: The message content as a string.
+        """
         text: Union[List[MessageContentParts], str] = message.content or ""
         if isinstance(text, list):
             text = " ".join([part.text for part in text if isinstance(part, TextContentPart)])

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
@@ -1,0 +1,147 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from abc import abstractmethod
+from typing import Any, List, Union
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from .message import Message, MessageContentParts, TextContentPart
+from .prompt_functions import PromptFunctions
+from .prompt_section import PromptSection
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class PromptSectionBase(PromptSection):
+    def __init__(
+        self,
+        tokens: float = -1,
+        required: bool = True,
+        separator: str = "\n",
+        text_prefix: str = "",
+    ):
+        self._required = required
+        self._tokens = tokens
+        self._separator = separator
+        self._text_prefix = text_prefix
+
+    @property
+    def required(self) -> bool:
+        """
+        If true the section is mandatory otherwise it can be safely dropped.
+        """
+        return self._required
+
+    @property
+    def tokens(self) -> float:
+        """
+        The requested token budget for this section.
+        - Values between 0.0 and 1.0 represent a percentage of the total budget
+          and the section will be layed out proportionally to all other sections.
+        - Values greater than 1.0 represent the max number of tokens the section
+          should be allowed to consume.
+        """
+        return self._tokens
+
+    @property
+    def separator(self) -> str:
+        """
+        The separator to use between messages when rendering as text.
+        """
+        return self._separator
+
+    @property
+    def text_prefix(self) -> str:
+        """
+        The prefix to use when rendering as text.
+        """
+        return self._text_prefix
+
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
+    @abstractmethod
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection:
+        pass
+
+    # pylint: enable=too-many-arguments
+
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
+    async def render_as_text(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection:
+        # Render as messages
+        as_messages: RenderedPromptSection[List[Message[Any]]] = await self.render_as_messages(
+            context, memory, functions, tokenizer, max_tokens
+        )
+        if len(as_messages.output) == 0:
+            return RenderedPromptSection("", 0, False)
+
+        # Convert to text
+        text = self.separator.join(
+            [PromptSectionBase.get_message_text(message) for message in as_messages.output]
+        )
+
+        # Calculate length
+        prefix_length = len(tokenizer.encode(self.text_prefix))
+        separator_length = len(tokenizer.encode(self.separator))
+        length = (
+            prefix_length + as_messages.length + (len(as_messages.output) - 1) * separator_length
+        )
+
+        # Truncate if fixed length
+        text = self.text_prefix + text
+        if self.tokens > 1.0 and length > self.tokens:
+            encoded = tokenizer.encode(text)
+            text = tokenizer.decode(encoded[: int(self.tokens)])
+            length = int(self.tokens)
+
+        return RenderedPromptSection(text, length, length > max_tokens)
+
+    # pylint: enable=too-many-arguments
+
+    def _get_token_budget(self, max_tokens: int) -> int:
+        return min(int(self.tokens), max_tokens) if self.tokens > 1.0 else max_tokens
+
+    def return_messages(
+        self, output: List[Message], length: int, tokenizer: Tokenizer, max_tokens: int
+    ) -> RenderedPromptSection:
+        # Truncate if fixed length
+        if self.tokens > 1.0:
+            while length > self.tokens:
+                msg = output.pop()
+                encoded = tokenizer.encode(PromptSectionBase.get_message_text(msg))
+                length -= len(encoded)
+                if length < self.tokens:
+                    delta = self.tokens - length
+                    truncated = tokenizer.decode(encoded[: int(delta)])
+                    output.append(Message(msg.role, truncated))
+                    length += int(delta)
+
+        return RenderedPromptSection(output, length, length > max_tokens)
+
+    @staticmethod
+    def get_message_text(message: Message) -> str:
+        text: Union[List[MessageContentParts], str] = message.content or ""
+        if isinstance(text, list):
+            text = " ".join([part.text for part in text if isinstance(part, TextContentPart)])
+        elif message.function_call:
+            text = str(message.function_call)
+        elif message.name:
+            text = f"{message.name} returned {text}"
+
+        return text

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
@@ -72,7 +72,7 @@ class PromptSectionBase(PromptSection):
         functions: PromptFunctions,
         tokenizer: Tokenizer,
         max_tokens: int,
-    ) -> RenderedPromptSection:
+    ) -> RenderedPromptSection[List[Message]]:
         pass
 
     # pylint: enable=too-many-arguments
@@ -85,7 +85,7 @@ class PromptSectionBase(PromptSection):
         functions: PromptFunctions,
         tokenizer: Tokenizer,
         max_tokens: int,
-    ) -> RenderedPromptSection:
+    ) -> RenderedPromptSection[str]:
         # Render as messages
         as_messages: RenderedPromptSection[List[Message[Any]]] = await self.render_as_messages(
             context, memory, functions, tokenizer, max_tokens

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section_base.py
@@ -3,7 +3,9 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import json
 from abc import abstractmethod
+from dataclasses import asdict
 from typing import Any, List, Union
 
 from botbuilder.core import TurnContext
@@ -117,7 +119,7 @@ class PromptSectionBase(PromptSection):
     def _get_token_budget(self, max_tokens: int) -> int:
         return min(int(self.tokens), max_tokens) if self.tokens > 1.0 else max_tokens
 
-    def return_messages(
+    def _return_messages(
         self, output: List[Message], length: int, tokenizer: Tokenizer, max_tokens: int
     ) -> RenderedPromptSection:
         # Truncate if fixed length
@@ -140,7 +142,7 @@ class PromptSectionBase(PromptSection):
         if isinstance(text, list):
             text = " ".join([part.text for part in text if isinstance(part, TextContentPart)])
         elif message.function_call:
-            text = str(message.function_call)
+            text = json.dumps(asdict(message.function_call))
         elif message.name:
             text = f"{message.name} returned {text}"
 

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section_layout.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section_layout.py
@@ -13,6 +13,6 @@ T = TypeVar("T")
 
 
 @dataclass
-class PromptSectionLayout(Generic[T]):
+class _PromptSectionLayout(Generic[T]):
     section: PromptSection
     layout: Optional[RenderedPromptSection[T]] = None

--- a/python/packages/ai/teams/ai/promptsv2/prompt_section_layout.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_section_layout.py
@@ -1,0 +1,18 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass
+from typing import Generic, Optional, TypeVar
+
+from .prompt_section import PromptSection
+from .rendered_prompt_section import RenderedPromptSection
+
+T = TypeVar("T")
+
+
+@dataclass
+class PromptSectionLayout(Generic[T]):
+    section: PromptSection
+    layout: Optional[RenderedPromptSection[T]] = None

--- a/python/packages/ai/teams/ai/promptsv2/rendered_prompt_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/rendered_prompt_section.py
@@ -1,0 +1,16 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class RenderedPromptSection(Generic[T]):
+    output: T
+    length: int
+    too_long: bool

--- a/python/packages/ai/teams/ai/promptsv2/rendered_prompt_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/rendered_prompt_section.py
@@ -11,6 +11,15 @@ T = TypeVar("T")
 
 @dataclass
 class RenderedPromptSection(Generic[T]):
+    """
+    The result of rendering a section.
+
+    Attributes:
+        output (T): The section that was rendered.
+        length (int): The number of tokens that were rendered.
+        too_long (bool): If true the section was truncated because it exceeded the maxTokens budget.
+    """
+
     output: T
     length: int
     too_long: bool

--- a/python/packages/ai/teams/ai/promptsv2/text_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/text_section.py
@@ -12,6 +12,7 @@ from ..tokenizers import Tokenizer
 from .message import Message
 from .prompt_functions import PromptFunctions
 from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
 
 
 class TextSection(PromptSectionBase):
@@ -52,7 +53,7 @@ class TextSection(PromptSectionBase):
         functions: PromptFunctions,
         tokenizer: Tokenizer,
         max_tokens: int,
-    ):
+    ) -> RenderedPromptSection[List[Message]]:
         # Calculate and cache length
         if self._length < 0:
             self._length = len(tokenizer.encode(self.text))

--- a/python/packages/ai/teams/ai/promptsv2/text_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/text_section.py
@@ -59,6 +59,6 @@ class TextSection(PromptSectionBase):
 
         # Return output
         messages: List[Message] = [Message(self.role, self.text)] if self._length > 0 else []
-        return self.return_messages(messages, self._length, tokenizer, max_tokens)
+        return self._return_messages(messages, self._length, tokenizer, max_tokens)
 
     # pylint: enable=too-many-arguments

--- a/python/packages/ai/teams/ai/promptsv2/text_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/text_section.py
@@ -16,6 +16,15 @@ from .rendered_prompt_section import RenderedPromptSection
 
 
 class TextSection(PromptSectionBase):
+    """
+    A section of text that will be rendered as a message.
+
+    Attributes:
+        text (str): Text to use for this section.
+        role (str): Message role to use for this section.
+
+    """
+
     _text: str
     _role: str
     _length: int
@@ -30,6 +39,19 @@ class TextSection(PromptSectionBase):
         separator: str = "\n",
         text_prefix: str = "",
     ):
+        """
+        Creates a new 'TextSection' instance.
+
+        Args:
+            text (str): Text to use for this section.
+            role (str): Message role to use for this section.
+            tokens (float, optional): Sizing strategy for this section. Defaults to `auto`.
+            required (bool, optional): Indicates if this section is required. Defaults to `true`.
+            separator (str, optional): Separator to use between sections when rendering as text.
+              Defaults to `\n`.
+            text_prefix (str, optional): Prefix to use for text output. Defaults to ``.
+
+        """
         super().__init__(tokens, required, separator, text_prefix)
         self._text = text
         self._role = role
@@ -39,10 +61,12 @@ class TextSection(PromptSectionBase):
 
     @property
     def text(self):
+        """Text to use for this section."""
         return self._text
 
     @property
     def role(self):
+        """Message role to use for this section."""
         return self._role
 
     # pylint: disable=too-many-arguments # No argument can be removed based on the design
@@ -54,6 +78,19 @@ class TextSection(PromptSectionBase):
         tokenizer: Tokenizer,
         max_tokens: int,
     ) -> RenderedPromptSection[List[Message]]:
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
         # Calculate and cache length
         if self._length < 0:
             self._length = len(tokenizer.encode(self.text))

--- a/python/packages/ai/teams/ai/promptsv2/text_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/text_section.py
@@ -1,0 +1,64 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .prompt_section_base import PromptSectionBase
+
+
+class TextSection(PromptSectionBase):
+    _text: str
+    _role: str
+    _length: int
+
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
+    def __init__(
+        self,
+        text: str,
+        role: str,
+        tokens: float = -1,
+        required: bool = True,
+        separator: str = "\n",
+        text_prefix: str = "",
+    ):
+        super().__init__(tokens, required, separator, text_prefix)
+        self._text = text
+        self._role = role
+        self._length = -1
+
+    # pylint: enable=too-many-arguments
+
+    @property
+    def text(self):
+        return self._text
+
+    @property
+    def role(self):
+        return self._role
+
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ):
+        # Calculate and cache length
+        if self._length < 0:
+            self._length = len(tokenizer.encode(self.text))
+
+        # Return output
+        messages: List[Message] = [Message(self.role, self.text)] if self._length > 0 else []
+        return self.return_messages(messages, self._length, tokenizer, max_tokens)
+
+    # pylint: enable=too-many-arguments

--- a/python/packages/ai/tests/ai/prompts/test_layout_engine.py
+++ b/python/packages/ai/tests/ai/prompts/test_layout_engine.py
@@ -1,0 +1,100 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+
+from teams.ai.promptsv2 import LayoutEngine, TextSection
+from teams.ai.tokenizers import GPTTokenizer
+
+
+class TestLayoutEngine(IsolatedAsyncioTestCase):
+    async def test_render_as_text_empty_sections(self):
+        layout_engine = LayoutEngine([], 1, False, "\n")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 1)
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.length, 0)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_fixed_sections(self):
+        section1 = TextSection("Hello World!", "user")
+        section2 = TextSection("Teams-AI", "user")
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 100)
+        self.assertEqual(result.output, "Hello World! Teams-AI")
+        self.assertEqual(result.length, 6)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_fixed_sections_too_long(self):
+        section1 = TextSection("Hello World!", "user")
+        section2 = TextSection("Teams-AI", "user")
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 5)
+        self.assertEqual(result.output, "Hello World! Teams-AI")
+        self.assertEqual(result.length, 6)
+        self.assertTrue(result.too_long)
+
+    async def test_render_as_text_fixed_sections_drop_optional(self):
+        section1 = TextSection("Hello World!", "user")
+        section2 = TextSection("Teams-AI", "user", required=False)
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 5)
+        self.assertEqual(result.output, "Hello World!")
+        self.assertEqual(result.length, 3)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_fixed_sections_too_long_after_drop(self):
+        section1 = TextSection("Hello World!", "user")
+        section2 = TextSection("Teams-AI", "user", required=False)
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 2)
+        self.assertEqual(result.output, "Hello World!")
+        self.assertEqual(result.length, 3)
+        self.assertTrue(result.too_long)
+
+    async def test_render_as_text_proportional_sections(self):
+        section1 = TextSection("Hello World!", "user", tokens=0.5)
+        section2 = TextSection("Teams-AI", "user", tokens=0.5)
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 5)
+        self.assertEqual(result.output, "Hello World! Teams-AI")
+        self.assertEqual(result.length, 6)
+        self.assertTrue(result.too_long)
+
+    async def test_render_as_text_proportional_sections_drop_optional(self):
+        section2 = TextSection("Teams-AI!", "user", tokens=0.5, required=False)
+        section1 = TextSection("Hello World!", "user", tokens=0.5, required=False)
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 6)
+        self.assertEqual(
+            result.output, "Hello World!"
+        )  # Teams-AI! should be dropped as Hello World! gets enough token capacity
+        self.assertEqual(result.length, 3)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_proportional_sections_too_long_after_drop(self):
+        section1 = TextSection("Hello World!", "user", tokens=0.5)
+        section2 = TextSection("Teams-AI!", "user", tokens=0.5, required=False)
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_text(None, None, None, GPTTokenizer(), 2)
+        self.assertEqual(result.output, "Hello World!")
+        self.assertEqual(result.length, 3)
+        self.assertTrue(result.too_long)
+
+    async def test_render_as_messages_empty_sections(self):
+        layout_engine = LayoutEngine([], 1, False, "\n")
+        result = await layout_engine.render_as_messages(None, None, None, GPTTokenizer(), 1)
+        self.assertEqual(result.output, [])
+        self.assertEqual(result.length, 0)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_messages(self):
+        section1 = TextSection("Hello World!", "user")
+        section2 = TextSection("Teams-AI", "user")
+        layout_engine = LayoutEngine([section1, section2], 1, False, " ")
+        result = await layout_engine.render_as_messages(None, None, None, GPTTokenizer(), 100)
+        self.assertEqual(result.output[0].content, "Hello World!")
+        self.assertEqual(result.output[1].content, "Teams-AI")
+        self.assertEqual(result.length, 6)
+        self.assertFalse(result.too_long)

--- a/python/packages/ai/tests/ai/prompts/test_prompt_section_base.py
+++ b/python/packages/ai/tests/ai/prompts/test_prompt_section_base.py
@@ -1,0 +1,182 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
+from teams.ai.promptsv2 import (
+    FunctionCall,
+    ImageContentPart,
+    Message,
+    PromptSectionBase,
+    RenderedPromptSection,
+    TextContentPart,
+)
+from teams.ai.tokenizers import GPTTokenizer
+
+
+class TestablePromptSectionBase(PromptSectionBase):
+    def __init__(
+        self,
+        tokens: float = -1,
+        required: bool = True,
+        separator: str = "\n",
+        text_prefix: str = "",
+    ):
+        super().__init__(tokens, required, separator, text_prefix)
+
+    # pylint: disable=too-many-arguments
+    async def render_as_messages(self, context, memory, functions, tokenizer, max_tokens):
+        return RenderedPromptSection([], 0, False)
+    # pylint: enable=too-many-arguments
+
+class TestPromptSectionBase(IsolatedAsyncioTestCase):
+    async def test_render_as_text_empty_message(self):
+        section = TestablePromptSectionBase()
+        section.render_as_messages = AsyncMock(return_value=RenderedPromptSection([], 0, False))
+        result = await section.render_as_text(None, None, None, GPTTokenizer(), 5)
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.length, 0)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_multiple_messages(self):
+        section = TestablePromptSectionBase()
+        messages = [Message("User", "Hello World!"), Message("User", "Teams-AI")]
+        section.render_as_messages = AsyncMock(
+            return_value=RenderedPromptSection(messages, 6, False)
+        )
+        result = await section.render_as_text(None, None, None, GPTTokenizer(), 100)
+        self.assertEqual(result.output, "Hello World!\nTeams-AI")
+        self.assertEqual(result.length, 7)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_multiple_messages_too_long(self):
+        section = TestablePromptSectionBase()
+        messages = [Message("User", "Hello World!"), Message("User", "Teams-AI")]
+        section.render_as_messages = AsyncMock(
+            return_value=RenderedPromptSection(messages, 6, False)
+        )
+        result = await section.render_as_text(None, None, None, GPTTokenizer(), 5)
+        self.assertEqual(result.output, "Hello World!\nTeams-AI")
+        self.assertEqual(result.length, 7)
+        self.assertTrue(result.too_long)
+
+    async def test_render_as_text_multiple_truncate_fixed_length(self):
+        section = TestablePromptSectionBase(tokens=5)
+        messages = [Message("User", "Hello World!"), Message("User", "Teams-AI")]
+        section.render_as_messages = AsyncMock(
+            return_value=RenderedPromptSection(messages, 6, False)
+        )
+        result = await section.render_as_text(None, None, None, GPTTokenizer(), 5)
+        self.assertEqual(result.output, "Hello World!\nTeams-A")
+        self.assertEqual(result.length, 5)
+        self.assertFalse(result.too_long)
+
+    async def test_get_token_buge_fixed_token(self):
+        section = TestablePromptSectionBase(tokens=5)
+        result = section._get_token_budget(10)
+        self.assertEqual(result, 5)
+        result = section._get_token_budget(3)
+        self.assertEqual(result, 3)
+
+    async def test_get_token_buge_proportional_token(self):
+        section = TestablePromptSectionBase(tokens=0.5)
+        result = section._get_token_budget(10)
+        self.assertEqual(result, 10)
+
+    async def test_return_messages_fixed_sections(self):
+        section = TestablePromptSectionBase()
+        messages = [Message("User", "Hello World!"), Message("User", "Teams-AI")]
+        result = section._return_messages(messages, 6, GPTTokenizer(), 100)
+        self.assertEqual(result.output, messages)
+        self.assertEqual(result.length, 6)
+        self.assertFalse(result.too_long)
+
+    async def test_return_messages_fixed_sections_too_long(self):
+        section = TestablePromptSectionBase(tokens=5)
+        messages = [Message("User", "Hello World!"), Message("User", "Teams-AI")]
+        result = section._return_messages(messages, 6, GPTTokenizer(), 4)
+        self.assertEqual(result.output[0].content, "Hello World!")
+        self.assertEqual(result.output[1].content, "Teams-A")
+        self.assertEqual(result.length, 5)
+        self.assertTrue(result.too_long)
+
+    async def test_return_messages_proportional_sections(self):
+        section = TestablePromptSectionBase(tokens=0.5)
+        messages = [Message("User", "Hello World!"), Message("User", "Teams-AI")]
+        result = section._return_messages(messages, 6, GPTTokenizer(), 4)
+        self.assertEqual(result.output[0].content, "Hello World!")
+        self.assertEqual(result.output[1].content, "Teams-AI")
+        self.assertEqual(result.length, 6)
+        self.assertTrue(result.too_long)
+
+    async def test_get_message_text(self):
+        result = PromptSectionBase.get_message_text(Message("User", "Hello World!"))
+        self.assertEqual(result, "Hello World!")
+
+    async def test_get_message_text_with_name(self):
+        result = PromptSectionBase.get_message_text(
+            Message("User", "Hello World!", name="TestCase")
+        )
+        self.assertEqual(result, "TestCase returned Hello World!")
+
+    async def test_get_message_text_content_part_list(self):
+        result = PromptSectionBase.get_message_text(
+            Message(
+                "User",
+                [
+                    TextContentPart("text", "Hello"),
+                    TextContentPart("text", "World!"),
+                    ImageContentPart("image", "https://www.microsoft.com"),
+                ],
+            )
+        )
+        self.assertEqual(result, "Hello World!")
+
+    async def test_get_message_text_function_call(self):
+        result = PromptSectionBase.get_message_text(
+            Message("User", function_call=FunctionCall("function name", "arguments"))
+        )
+        self.assertEqual(result, '{"name": "function name", "arguments": "arguments"}')
+
+    def test_required_property(self):
+        prompt_section_base = TestablePromptSectionBase(
+            tokens=0.5, required=True, separator=";", text_prefix="prefix"
+        )
+        self.assertEqual(prompt_section_base.required, True)
+
+    def test_tokens_property(self):
+        prompt_section_base = TestablePromptSectionBase(
+            tokens=0.5, required=True, separator=";", text_prefix="prefix"
+        )
+        self.assertEqual(prompt_section_base.tokens, 0.5)
+
+    def test_separator_property(self):
+        prompt_section_base = TestablePromptSectionBase(
+            tokens=0.5, required=True, separator=";", text_prefix="prefix"
+        )
+        self.assertEqual(prompt_section_base.separator, ";")
+
+    def test_text_prefix_property(self):
+        prompt_section_base = TestablePromptSectionBase(
+            tokens=0.5, required=True, separator=";", text_prefix="prefix"
+        )
+        self.assertEqual(prompt_section_base.text_prefix, "prefix")
+
+    def test_required_property_default(self):
+        prompt_section_base = TestablePromptSectionBase()
+        self.assertEqual(prompt_section_base.required, True)
+
+    def test_tokens_property_default(self):
+        prompt_section_base = TestablePromptSectionBase()
+        self.assertEqual(prompt_section_base.tokens, -1)
+
+    def test_separator_property_default(self):
+        prompt_section_base = TestablePromptSectionBase()
+        self.assertEqual(prompt_section_base.separator, "\n")
+
+    def test_text_prefix_property_default(self):
+        prompt_section_base = TestablePromptSectionBase()
+        self.assertEqual(prompt_section_base.text_prefix, "")

--- a/python/packages/ai/tests/ai/prompts/test_prompt_section_base.py
+++ b/python/packages/ai/tests/ai/prompts/test_prompt_section_base.py
@@ -30,7 +30,9 @@ class TestablePromptSectionBase(PromptSectionBase):
     # pylint: disable=too-many-arguments
     async def render_as_messages(self, context, memory, functions, tokenizer, max_tokens):
         return RenderedPromptSection([], 0, False)
+
     # pylint: enable=too-many-arguments
+
 
 class TestPromptSectionBase(IsolatedAsyncioTestCase):
     async def test_render_as_text_empty_message(self):

--- a/python/packages/ai/tests/ai/prompts/test_text_section.py
+++ b/python/packages/ai/tests/ai/prompts/test_text_section.py
@@ -1,0 +1,48 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+
+from teams.ai.promptsv2 import TextSection
+from teams.ai.tokenizers import GPTTokenizer
+
+
+class TestTextSection(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.text_section = TextSection(
+            text="test text!",
+            role="test role",
+            tokens=10,
+            required=True,
+            separator="\n",
+            text_prefix="prefix",
+        )
+
+    async def test_init(self):
+        self.assertEqual(self.text_section.text, "test text!")
+        self.assertEqual(self.text_section.role, "test role")
+        self.assertTrue(self.text_section.required)
+        self.assertEqual(self.text_section.separator, "\n")
+        self.assertEqual(self.text_section.text_prefix, "prefix")
+        self.assertEqual(self.text_section.tokens, 10)
+        self.assertEqual(self.text_section._length, -1)
+
+    async def test_render_as_messages(self):
+        result = await self.text_section.render_as_messages(None, None, None, GPTTokenizer(), 10)
+        self.assertEqual(self.text_section._length, 3)
+        self.assertEqual(len(result.output), 1)
+        self.assertEqual(result.output[0].role, "test role")
+        self.assertEqual(result.output[0].content, "test text!")
+        self.assertFalse(result.too_long)
+        self.assertEqual(result.length, 3)
+
+    async def test_render_as_messages_truncate(self):
+        self.text_section._tokens = 2
+        result = await self.text_section.render_as_messages(None, None, None, GPTTokenizer(), 1)
+        self.assertEqual(len(result.output), 1)
+        self.assertEqual(result.output[0].role, "test role")
+        self.assertEqual(result.output[0].content, "test text")
+        self.assertTrue(result.too_long)
+        self.assertEqual(result.length, 2)


### PR DESCRIPTION
## Linked issues

closes: #1065 

## Details

1. Implement prompt layout engine, text section as well as adding necessary data models for them
2. Add unit tests and docstring
3. Difference comparing with JS SDK: The default `text_prefix` value of `TextSection` class is changed from undefine to empty string to align with the `PromptSectionBase` class.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

