### PR TITLE
[C#] fix: Uninformative message when max repair attempts in Action Planner 

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Teams.AI.Tests.AITests
             Assert.NotNull(response);
             Assert.Equal(PromptResponseStatus.InvalidResponse, response.Status);
             Assert.NotNull(response.Error);
-            Assert.Equal("The response was invalid. Try another strategy.", response.Error.Message);
+            Assert.Equal("Reached max model response repair attempts. Last feedback given to model: The response was invalid. Try another strategy.", response.Error.Message);
             Assert.Equal(1, memory.Values.Count);
             Assert.Equal("hello", memory.Values[options.InputVariable]);
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Teams.AI.Tests.AITests
             Assert.NotNull(response);
             Assert.Equal(PromptResponseStatus.InvalidResponse, response.Status);
             Assert.NotNull(response.Error);
-            Assert.Equal("Reached max model response repair attempts. Last feedback given to model: The response was invalid. Try another strategy.", response.Error.Message);
+            Assert.Equal("Reached max model response repair attempts. Last feedback given to model: \"The response was invalid. Try another strategy.\"", response.Error.Message);
             Assert.Equal(1, memory.Values.Count);
             Assert.Equal("hello", memory.Values[options.InputVariable]);
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Teams.AI.AI.Clients
                 return new()
                 {
                     Status = PromptResponseStatus.InvalidResponse,
-                    Error = new(feedback ?? "The response was invalid. Try another strategy.")
+                    Error = new($"Reached max model response repair attempts. Last feedback given to model: {feedback}")
                 };
             }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Teams.AI.AI.Clients
                 return new()
                 {
                     Status = PromptResponseStatus.InvalidResponse,
-                    Error = new($"Reached max model response repair attempts. Last feedback given to model: {feedback}")
+                    Error = new($"Reached max model response repair attempts. Last feedback given to model: \"{feedback}\"")
                 };
             }
 


### PR DESCRIPTION
## Linked issues

closes: #1036 

## Details

- Fixed uninformative error message.
- Validated E2E through the light bot by mocking the model's response to return an invalid json object. 

![image](https://github.com/microsoft/teams-ai/assets/115390646/4cbd206d-a9d8-45bc-b33a-b508552344da)



## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
