### PR TITLE
[JS] fix: Uninformative message when max repair attempts in Action Planner 

### DIFF
--- a/js/packages/teams-ai/src/planners/LLMClient.ts
+++ b/js/packages/teams-ai/src/planners/LLMClient.ts
@@ -479,7 +479,9 @@ export class LLMClient<TContent = any> {
             return {
                 status: 'invalid_response',
                 input: undefined,
-                error: new Error(`Reached max model response repair attempts. Last feedback given to model: "${feedback}"`)
+                error: new Error(
+                    `Reached max model response repair attempts. Last feedback given to model: "${feedback}"`
+                )
             };
         }
 

--- a/js/packages/teams-ai/src/planners/LLMClient.ts
+++ b/js/packages/teams-ai/src/planners/LLMClient.ts
@@ -479,7 +479,7 @@ export class LLMClient<TContent = any> {
             return {
                 status: 'invalid_response',
                 input: undefined,
-                error: new Error(`Reached max model response repair attempts. Last feedback given to model: ${feedback}`)
+                error: new Error(`Reached max model response repair attempts. Last feedback given to model: "${feedback}"`)
             };
         }
 

--- a/js/packages/teams-ai/src/planners/LLMClient.ts
+++ b/js/packages/teams-ai/src/planners/LLMClient.ts
@@ -479,7 +479,7 @@ export class LLMClient<TContent = any> {
             return {
                 status: 'invalid_response',
                 input: undefined,
-                error: new Error(validation.feedback ?? 'The response was invalid. Try another strategy.')
+                error: new Error(`Reached max model response repair attempts. Last feedback given to model: ${feedback}`)
             };
         }
 


### PR DESCRIPTION
## Linked issues

closes: #1036 (issue number)

## Details

- Fixed uninformative error message.
- Validated E2E through the light bot by mocking the model's response to return an invalid json object.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (we use [TypeDoc](https://typedoc.org/) to document our code)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
