### PR TITLE
[C#] fix: template syntax whitespace bug

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TemplateSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TemplateSectionTests.cs
@@ -31,6 +31,26 @@ namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
         }
 
         [Fact]
+        public async void Test_RenderAsTextAsync_ShouldRenderWithFunction_WithWhiteSpace()
+        {
+            TemplateSection section = new("this is a test message: {{ getMessage }}", ChatRole.User);
+            Mock<ITurnContext> context = new();
+            MemoryFork memory = new();
+            GPTTokenizer tokenizer = new();
+            PromptManager manager = new();
+
+            manager.AddFunction("getMessage", async (context, memory, functions, tokenizer, args) =>
+            {
+                return await Task.FromResult("Hello World!");
+            });
+
+            RenderedPromptSection<string> rendered = await section.RenderAsTextAsync(context.Object, memory, manager, tokenizer, 10);
+
+            Assert.Equal("this is a test message: Hello World!", rendered.Output);
+            Assert.Equal(9, rendered.Length);
+        }
+
+        [Fact]
         public async void Test_RenderAsTextAsync_ShouldRenderWithFunctionArgs()
         {
             TemplateSection section = new("this is a test message: {{getMessage 'my param'}}", ChatRole.User);
@@ -54,6 +74,23 @@ namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
         public async void Test_RenderAsTextAsync_ShouldRenderWithVariable()
         {
             TemplateSection section = new("this is a test message: {{$message}}", ChatRole.User);
+            Mock<ITurnContext> context = new();
+            MemoryFork memory = new();
+            GPTTokenizer tokenizer = new();
+            PromptManager manager = new();
+
+            memory.SetValue("message", "Hello World!");
+
+            RenderedPromptSection<string> rendered = await section.RenderAsTextAsync(context.Object, memory, manager, tokenizer, 15);
+
+            Assert.Equal("this is a test message: \"Hello World!\"", rendered.Output);
+            Assert.Equal(10, rendered.Length);
+        }
+
+        [Fact]
+        public async void Test_RenderAsTextAsync_ShouldRenderWithVariable_WithWhitespace()
+        {
+            TemplateSection section = new("this is a test message: {{ $message }}", ChatRole.User);
             Mock<ITurnContext> context = new();
             MemoryFork memory = new();
             GPTTokenizer tokenizer = new();

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/TemplateSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/TemplateSection.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Teams.AI.AI.Prompts.Sections
                         {
                             if (chunk.Length > 0)
                             {
+                                chunk = chunk.Trim();
                                 if (chunk[0] == '$')
                                 {
                                     renderers.Add(this.CreateVariableRenderer(chunk.Substring(1)));


### PR DESCRIPTION
## Linked issues

closes: #1087 (issue number)

## Details
- With this fix, starting and trailing whitespace between the "{{ }}" tags of the template syntax will be ignored, thus fixing the bug.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
