### PR TITLE
[JS] fix: template syntax whitespace bug

### DIFF
--- a/js/packages/teams-ai/src/prompts/TemplateSection.spec.ts
+++ b/js/packages/teams-ai/src/prompts/TemplateSection.spec.ts
@@ -96,6 +96,17 @@ describe('TemplateSection', () => {
             });
         });
 
+        it('should render a template with a {{ $variable }} - even with white space inbetween the parameter', async () => {
+            await adapter.sendTextToBot('test', async (context) => {
+                const state = await TestTurnState.create(context, { conversation });
+                const section = new TemplateSection('Hello {{ $conversation.foo }}', 'user');
+                const rendered = await section.renderAsText(context, state, functions, tokenizer, 100);
+                assert.equal(rendered.output, 'Hello bar');
+                assert.equal(rendered.length, 2);
+                assert.equal(rendered.tooLong, false);
+            });
+        });
+
         it('should render a template with a {{$variable}} and a {{function}}', async () => {
             await adapter.sendTextToBot('test', async (context) => {
                 const state = await TestTurnState.create(context, { conversation });
@@ -111,6 +122,17 @@ describe('TemplateSection', () => {
             await adapter.sendTextToBot('test', async (context) => {
                 const state = await TestTurnState.create(context);
                 const section = new TemplateSection('Hello {{test2 World}}', 'user');
+                const rendered = await section.renderAsText(context, state, functions, tokenizer, 100);
+                assert.equal(rendered.output, 'Hello World');
+                assert.equal(rendered.length, 2);
+                assert.equal(rendered.tooLong, false);
+            });
+        });
+
+        it('should render a template with a {{ function }} and arguments - even with white space inbetween the parameter', async () => {
+            await adapter.sendTextToBot('test', async (context) => {
+                const state = await TestTurnState.create(context);
+                const section = new TemplateSection('Hello {{ test2 World }}', 'user');
                 const rendered = await section.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'Hello World');
                 assert.equal(rendered.length, 2);

--- a/js/packages/teams-ai/src/prompts/TemplateSection.ts
+++ b/js/packages/teams-ai/src/prompts/TemplateSection.ts
@@ -114,6 +114,7 @@ export class TemplateSection extends PromptSectionBase {
                 case ParseState.inParameter:
                     if (char === '}' && this.template[i + 1] === '}') {
                         if (part.length > 0) {
+                            part = part.trim();
                             if (part[0] === '$') {
                                 this._parts.push(this.createVariableRenderer(part.substring(1)));
                             } else {


### PR DESCRIPTION
## Linked issues

closes: #1087  (issue number)

## Details

With this fix, starting and trailing whitespace between the "{{ }}" tags of the template syntax will be ignored, thus fixing the bug.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
