### PR TITLE
[C#] feat: Add Application unit test

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationTests.cs
@@ -59,6 +59,11 @@ namespace Microsoft.Teams.AI.Tests.Application
             {
                 Moderator = new TestModerator()
             };
+            AuthenticationOptions<TurnState> authenticationOptions = new()
+            {
+                AutoSignIn = (context, cancellationToken) => Task.FromResult(false)
+            };
+            authenticationOptions.AddAuthentication("graph", new OAuthSettings());
             ApplicationOptions<TurnState> applicationOptions = new()
             {
                 RemoveRecipientMention = removeRecipientMention,
@@ -72,10 +77,7 @@ namespace Microsoft.Teams.AI.Tests.Application
                 AdaptiveCards = adaptiveCardOptions,
                 TaskModules = taskModuleOptions,
                 AI = aiOptions,
-                Authentication = new()
-                {
-                    AutoSignIn = (context, cancellationToken) => Task.FromResult(false)
-                }
+                Authentication = authenticationOptions
             };
 
             // Act


### PR DESCRIPTION
## Linked issues

closes: #1120

## Details

Add unit tests for `Application.cs`
<img width="824" alt="image" src="https://github.com/microsoft/teams-ai/assets/7642967/8b7487ec-5b01-4fab-a915-184277a3a0f3">

#### Change details

- Cover more branches for constructor
- Cover more branches for conversation event handler
- Add auth related tests

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
