### PR TITLE
[PY] feat: template section

### DIFF
--- a/python/packages/ai/poetry.lock
+++ b/python/packages/ai/poetry.lock
@@ -2106,6 +2106,17 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.12"
+description = "Typing stubs for PyYAML"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-PyYAML-6.0.12.12.tar.gz", hash = "sha256:334373d392fde0fdf95af5c3f1661885fa10c52167b14593eb856289e1855062"},
+    {file = "types_PyYAML-6.0.12.12-py3-none-any.whl", hash = "sha256:c05bc6c158facb0676674b7f11fe3960db4f389718e19e62bd2b84d6205cfd24"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -2338,4 +2349,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "d171a4507d2619e783fdd0710491d3bde57607a1e026e7eaf99b50703d5d332d"
+content-hash = "e70f313fd2042fd0b510ef384207ec545acb8a4c69d367f4d9ed4f118440e0eb"

--- a/python/packages/ai/pyproject.toml
+++ b/python/packages/ai/pyproject.toml
@@ -15,6 +15,7 @@ botbuilder-core = "^4.14.4"
 semantic-kernel = "^0.3.7.dev0"
 tiktoken = "^0.4.0"
 aiohttp = "^3.8.5"
+types-pyyaml = "^6.0.12.12"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"

--- a/python/packages/ai/teams/ai/data_sources/data_source.py
+++ b/python/packages/ai/teams/ai/data_sources/data_source.py
@@ -38,6 +38,6 @@ class DataSource(ABC):
             max_tokens (int): Maximum number of tokens allowed to be rendered.
 
         Returns:
-            RenderedPromptSection: The text to inject into the prompt as a 
+            RenderedPromptSection: The text to inject into the prompt as a
             `RenderedPromptSection` object.
         """

--- a/python/packages/ai/teams/ai/data_sources/text_data_source.py
+++ b/python/packages/ai/teams/ai/data_sources/text_data_source.py
@@ -61,18 +61,18 @@ class TextDataSource(DataSource):
             max_tokens (int): Maximum number of tokens allowed to be rendered.
 
         Returns:
-            RenderedPromptSection: The text to inject into the prompt as a 
+            RenderedPromptSection: The text to inject into the prompt as a
             `RenderedPromptSection` object.
         """
 
-        if not self._tokens: # Tokenize text on first use
+        if not self._tokens:  # Tokenize text on first use
             self._tokens = tokenizer.encode(self._text)
 
-        if len(self._tokens) > max_tokens: # Check for max tokens
+        if len(self._tokens) > max_tokens:  # Check for max tokens
             trimmed = self._tokens[0:max_tokens]
             return RenderedPromptSection[str](
                 output=tokenizer.decode(trimmed), length=len(trimmed), too_long=True
             )
         return RenderedPromptSection[str](
-                output=self._text, length=len(self._tokens), too_long=False
+            output=self._text, length=len(self._tokens), too_long=False
         )

--- a/python/packages/ai/teams/ai/promptsv2/__init__.py
+++ b/python/packages/ai/teams/ai/promptsv2/__init__.py
@@ -6,7 +6,9 @@ Licensed under the MIT License.
 from .function_call import FunctionCall
 from .layout_engine import LayoutEngine
 from .message import ImageContentPart, Message, TextContentPart
+from .prompt_functions import PromptFunctions
 from .prompt_section import PromptSection
 from .prompt_section_base import PromptSectionBase
 from .rendered_prompt_section import RenderedPromptSection
+from .template_section import TemplateSection
 from .text_section import TextSection

--- a/python/packages/ai/teams/ai/promptsv2/prompt_functions.py
+++ b/python/packages/ai/teams/ai/promptsv2/prompt_functions.py
@@ -62,7 +62,7 @@ class PromptFunctions(ABC):
 
     # pylint: disable=too-many-arguments # No argument can be removed based on the design
     @abstractmethod
-    def invoke_function(
+    async def invoke_function(
         self, name: str, context: TurnContext, memory: Memory, tokenizer: Tokenizer, args: List[str]
     ):
         """

--- a/python/packages/ai/teams/ai/promptsv2/template_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/template_section.py
@@ -1,0 +1,264 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from enum import Enum
+from typing import Awaitable, Callable, List
+
+from botbuilder.core import TurnContext
+
+from ...app_error import ApplicationError
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from ..utilities import to_string
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
+
+
+# private
+class _ParseState(Enum):
+    IN_TEXT = 1
+    IN_PARAMETER = 2
+    IN_STRING = 3
+
+
+# private
+_PartRenderer = Callable[[TurnContext, Memory, PromptFunctions, Tokenizer, int], Awaitable[str]]
+
+
+class TemplateSection(PromptSectionBase):
+    """
+    A template section that will be rendered as a message.
+
+    This section type is used to render a template as a message. The template can contain
+    parameters that will be replaced with values from memory or call functions to generate
+    dynamic content.
+
+    Template syntax:
+    - `{{$memoryKey}}` - Renders the value of the specified memory key.
+    - `{{functionName}}` - Calls the specified function and renders the result.
+    - `{{functionName arg1 arg2 ...}}` - Calls the specified function with the
+      provided list of arguments.
+
+    Function arguments are optional and separated by spaces.
+    They can be quoted using ', ", or ` delimiters.
+    """
+
+    _template: str
+    _role: str
+    _parts: List[_PartRenderer]
+
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
+    def __init__(
+        self,
+        template: str,
+        role: str,
+        tokens: int = -1,
+        required: bool = True,
+        separator: str = "\n",
+        text_prefix: str = "",
+    ):
+        """
+        Creates a new 'TemplateSection' instance.
+
+        Args:
+            template (str): Template to use for this section.
+            role (str): Message role to use for this section.
+            tokens (int, optional): Sizing strategy for this section. Defaults to `auto`.
+            required (bool, optional): Indicates if this section is required. Defaults to `True`.
+            separator (str, optional): Separator to use between sections when rendering as text.
+              Defaults to `\n`.
+            text_prefix (str, optional): The text prefix. Prefix to use for text output.
+              Defaults to ''.
+
+        """
+        super().__init__(tokens, required, separator, text_prefix)
+        self._template = template
+        self._role = role
+        self._parts: List[_PartRenderer] = []
+        self._parse_template()
+
+    # pylint: enable=too-many-arguments
+
+    @property
+    def template(self) -> str:
+        """str: The template string."""
+        return self._template
+
+    @property
+    def role(self) -> str:
+        """str: The role of the template."""
+        return self._role
+
+    # pylint: disable=too-many-arguments # No argument can be removed based on the design
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[List[Message]]:
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
+
+        rendered_parts = [
+            await part(context, memory, functions, tokenizer, max_tokens) for part in self._parts
+        ]
+
+        # Join all parts
+        text = "".join(rendered_parts)
+        length = len(tokenizer.encode(text))
+
+        # Return output
+        messages = [Message(self.role, text)] if length > 0 else []
+        return self._return_messages(messages, length, tokenizer, max_tokens)
+
+    # pylint: enable=too-many-arguments
+
+    def _parse_template(self):
+        # Parse template
+        part = ""
+        state = _ParseState.IN_TEXT
+        string_delim = ""
+        i = 0
+        while i < len(self.template):
+            char = self.template[i]
+            if state == _ParseState.IN_TEXT:
+                if char == "{" and i + 1 < len(self.template) and self.template[i + 1] == "{":
+                    if len(part) > 0:
+                        self._parts.append(self._create_text_renderer(part))
+                        part = ""
+                    state = _ParseState.IN_PARAMETER
+                    i += 1
+                else:
+                    part += char
+            elif state == _ParseState.IN_PARAMETER:
+                if char == "}" and i + 1 < len(self.template) and self.template[i + 1] == "}":
+                    if len(part) > 0:
+                        part = part.strip()
+                        if part[0] == "$":
+                            self._parts.append(self._create_variable_renderer(part[1:]))
+                        else:
+                            self._parts.append(self._create_function_renderer(part))
+                        part = ""
+
+                    state = _ParseState.IN_TEXT
+                    i += 1
+                elif char in ["'", '"', "`"]:
+                    string_delim = char
+                    state = _ParseState.IN_STRING
+                    part += char
+                else:
+                    part += char
+            elif state == _ParseState.IN_STRING:
+                part += char
+                if char == string_delim:
+                    state = _ParseState.IN_PARAMETER
+
+            i += 1
+
+        # Ensure we ended in the correct state
+        if state != _ParseState.IN_TEXT:
+            raise ApplicationError(f"Invalid template: {self.template}")
+
+        # Add final part
+        if len(part) > 0:
+            self._parts.append(self._create_text_renderer(part))
+
+    def _create_text_renderer(self, text: str) -> _PartRenderer:
+        async def renderer(
+            _context: TurnContext,
+            _memory: Memory,
+            _functions: PromptFunctions,
+            _tokenizer: Tokenizer,
+            _max_tokens: int,
+        ) -> str:
+            return text
+
+        return renderer
+
+    def _create_variable_renderer(self, name: str) -> _PartRenderer:
+        async def renderer(
+            _context: TurnContext,
+            memory: Memory,
+            _functions: PromptFunctions,
+            tokenizer: Tokenizer,
+            _max_tokens: int,
+        ) -> str:
+            return to_string(tokenizer, memory.get_value(name))
+
+        return renderer
+
+    def _create_function_renderer(self, param: str) -> _PartRenderer:
+        name = ""
+        args: List[str] = []
+
+        # Parse function name and args
+        part = ""
+        state = _ParseState.IN_TEXT
+        string_delim = ""
+        for _, char in enumerate(param):
+            if state == _ParseState.IN_TEXT:
+                if char in ["'", '"', "`"]:
+                    if len(part) > 0:
+                        if not name:
+                            name = part
+                        else:
+                            args.append(part)
+                        part = ""
+                    string_delim = char
+                    state = _ParseState.IN_STRING
+                elif char == " ":
+                    if len(part) > 0:
+                        if not name:
+                            name = part
+                        else:
+                            args.append(part)
+                        part = ""
+                else:
+                    part += char
+            elif state == _ParseState.IN_STRING:
+                if char == string_delim:
+                    if len(part) > 0:
+                        if not name:
+                            name = part
+                        else:
+                            args.append(part)
+                        part = ""
+                    state = _ParseState.IN_TEXT
+                else:
+                    part += char
+
+        # Add final part
+        if len(part) > 0:
+            if not name:
+                name = part
+            else:
+                args.append(part)
+
+        async def renderer(
+            context: TurnContext,
+            memory: Memory,
+            functions: PromptFunctions,
+            tokenizer: Tokenizer,
+            _max_tokens: int,
+        ) -> str:
+            value = await functions.invoke_function(name, context, memory, tokenizer, args)
+            return to_string(tokenizer, value)
+
+        return renderer

--- a/python/packages/ai/teams/ai/utilities.py
+++ b/python/packages/ai/teams/ai/utilities.py
@@ -1,0 +1,46 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import json
+from typing import Any
+
+import yaml
+
+from .tokenizers import Tokenizer
+
+
+def to_string(tokenizer: Tokenizer, value: Any, as_json: bool = False) -> str:
+    """
+    Converts a value to a string representation.
+    Dates are converted to ISO strings and Objects are converted to JSON or YAML,
+    whichever is shorter.
+
+    Args:
+        tokenizer (Tokenizer): The tokenizer object used for encoding.
+        value (Any): The value to be converted.
+        as_json (bool, optional): Flag indicating whether to return the value as JSON string.
+          Defaults to False.
+
+    Returns:
+        str: The string representation of the value.
+    """
+    if value is None:
+        return ""
+
+    if isinstance(value, str):
+        return value
+    if hasattr(value, "isoformat") and callable(value.isoformat):
+        # Used when the value is a datetime object
+        return value.isoformat()
+    if as_json:
+        return json.dumps(value)
+
+    # Return shorter version of object
+    yaml_str = yaml.dump(value)
+    json_str = json.dumps(value)
+    if len(tokenizer.encode(yaml_str)) < len(tokenizer.encode(json_str)):
+        return yaml_str
+
+    return json_str

--- a/python/packages/ai/tests/ai/data_sources/test_text_data_source.py
+++ b/python/packages/ai/tests/ai/data_sources/test_text_data_source.py
@@ -8,7 +8,7 @@ from unittest import IsolatedAsyncioTestCase
 import pytest
 
 from teams.ai.data_sources import TextDataSource
-from teams.ai.tokenizers import Tokenizer, GPTTokenizer
+from teams.ai.tokenizers import GPTTokenizer, Tokenizer
 
 
 class TestTextDataSource(IsolatedAsyncioTestCase):

--- a/python/packages/ai/tests/ai/prompts/test_template_section.py
+++ b/python/packages/ai/tests/ai/prompts/test_template_section.py
@@ -1,0 +1,199 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from botbuilder.core import MemoryStorage, TurnContext
+
+from teams.ai.promptsv2 import PromptFunctions, TemplateSection
+from teams.ai.tokenizers import GPTTokenizer
+from teams.app_error import ApplicationError
+from teams.state import TurnState
+
+
+class TestTemplateSection(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.context = MagicMock(spec=TurnContext)
+        self.context.activity.channel_id = "channel_id"
+        self.context.activity.recipient.id = "bot_id"
+        self.context.activity.conversation.id = "conversation_id"
+        self.context.activity.from_property.id = "user_id"
+
+        memory_storage = MemoryStorage()
+        self.memory = TurnState()
+        await self.memory.load(self.context, memory_storage)
+        self.memory.conversation.get_dict()["test_property"] = "conversation_test_value"
+        self.memory.user.get_dict()["test_property"] = "user_test_value"
+        self.memory.temp.input = "temp_input"
+
+        self.functions = MagicMock(spec=PromptFunctions)
+        mock_invoke_function = AsyncMock()
+        mock_invoke_function.return_value = "test_func"
+        self.functions.invoke_function = mock_invoke_function
+        self.tokenizer = GPTTokenizer()
+
+    async def test_init(self):
+        template_section = TemplateSection("template", "user")
+        self.assertEqual(template_section.template, "template")
+        self.assertEqual(template_section.role, "user")
+        self.assertEqual(template_section.tokens, -1)
+        self.assertTrue(template_section.required)
+        self.assertEqual(template_section.separator, "\n")
+        self.assertEqual(template_section.text_prefix, "")
+
+    async def test_init_with_optional_params(self):
+        template_section = TemplateSection("template", "user", 10, False, " ", "text_prefix")
+        self.assertEqual(template_section.template, "template")
+        self.assertEqual(template_section.role, "user")
+        self.assertEqual(template_section.tokens, 10)
+        self.assertFalse(template_section.required)
+        self.assertEqual(template_section.separator, " ")
+        self.assertEqual(template_section.text_prefix, "text_prefix")
+
+    async def test_init_with_missing_brace(self):
+        with self.assertRaises(ApplicationError) as context:
+            TemplateSection("Hello {{test_func}", "user")  # missing closing brace
+        self.assertEqual(str(context.exception), "Invalid template: Hello {{test_func}")
+
+    async def test_init_with_with_unclosed_function_arg(self):
+        with self.assertRaises(ApplicationError) as context:
+            TemplateSection("Hello {{test_func 'arg1}}", "role")
+        self.assertEqual(str(context.exception), "Invalid template: Hello {{test_func 'arg1}}")
+
+    async def test_render_as_messages(self):
+        template_section = TemplateSection("Hello World", "role")
+        result = await template_section.render_as_messages(
+            self.context, self.memory, self.functions, self.tokenizer, 10
+        )
+        self.assertEqual(result.output[0].role, "role")
+        self.assertEqual(result.output[0].content, "Hello World")
+        self.assertFalse(result.too_long)
+        self.assertEqual(result.length, 2)
+
+    async def test_render_as_messages_too_long(self):
+        template_section = TemplateSection("Hello World", "role")
+        result = await template_section.render_as_messages(
+            self.context, self.memory, self.functions, self.tokenizer, 1
+        )
+        self.assertEqual(result.output[0].role, "role")
+        self.assertEqual(result.output[0].content, "Hello World")
+        self.assertTrue(result.too_long)
+        self.assertEqual(result.length, 2)
+
+    async def test_render_as_text(self):
+        template_section = TemplateSection("Hello World", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 10
+        )
+        self.assertEqual(result.output, "Hello World")
+        self.assertFalse(result.too_long)
+        self.assertEqual(result.length, 2)
+
+    async def test_render_as_text_too_long(self):
+        template_section = TemplateSection("Hello World", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 1
+        )
+        self.assertEqual(result.output, "Hello World")
+        self.assertTrue(result.too_long)
+        self.assertEqual(result.length, 2)
+
+    async def test_render_variable(self):
+        template_section = TemplateSection(
+            "Hello {{$user.test_property}} {{$conversation.test_property}} {{$temp.input}}", "role"
+        )
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        self.assertEqual(result.output, "Hello user_test_value conversation_test_value temp_input")
+        self.assertEqual(result.length, 9)
+        self.assertFalse(result.too_long)
+
+    async def test_render_variable_with_whitespace(self):
+        template_section = TemplateSection(
+            "Hello {{ $user.test_property }} {{ $conversation.test_property }} {{ $temp.input }}",
+            "role",
+        )
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        self.assertEqual(result.output, "Hello user_test_value conversation_test_value temp_input")
+        self.assertEqual(result.length, 9)
+        self.assertFalse(result.too_long)
+
+    async def test_render_non_exist_variable(self):
+        template_section = TemplateSection("Hello {{$user.non_exist}}", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        self.assertEqual(result.output, "Hello ")
+        self.assertEqual(result.length, 2)
+        self.assertFalse(result.too_long)
+
+    async def test_render_function(self):
+        template_section = TemplateSection("Hello {{test_func}}", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        args, _kwargs = self.functions.invoke_function.call_args
+        name_param_value = args[0]
+        args_parama_value = args[4]
+        self.assertEqual(result.output, "Hello test_func")
+        self.assertEqual(name_param_value, "test_func")
+        self.assertEqual(args_parama_value, [])
+        self.assertEqual(result.length, 3)
+        self.assertFalse(result.too_long)
+
+    async def test_render_function_with_args(self):
+        template_section = TemplateSection("Hello {{test_func arg1 arg2}}", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        args, _kwargs = self.functions.invoke_function.call_args
+        name_param_value = args[0]
+        args_parama_value = args[4]
+        self.assertEqual(result.output, "Hello test_func")
+        self.assertEqual(name_param_value, "test_func")
+        self.assertEqual(args_parama_value, ["arg1", "arg2"])
+        self.assertEqual(result.length, 3)
+        self.assertFalse(result.too_long)
+
+    async def test_render_function_with_args_and_whitespaces(self):
+        template_section = TemplateSection("Hello {{ test_func arg1 arg2 }}", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        args, _kwargs = self.functions.invoke_function.call_args
+        name_param_value = args[0]
+        args_parama_value = args[4]
+        self.assertEqual(result.output, "Hello test_func")
+        self.assertEqual(name_param_value, "test_func")
+        self.assertEqual(args_parama_value, ["arg1", "arg2"])
+        self.assertEqual(result.length, 3)
+        self.assertFalse(result.too_long)
+
+    async def test_render_function_with_quoted_args(self):
+        template_section = TemplateSection("Hello {{ test_func 'arg1' \"arg2\" `arg3` }}", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        args, _kwargs = self.functions.invoke_function.call_args
+        name_param_value = args[0]
+        args_parama_value = args[4]
+        self.assertEqual(result.output, "Hello test_func")
+        self.assertEqual(name_param_value, "test_func")
+        self.assertEqual(args_parama_value, ["arg1", "arg2", "arg3"])
+        self.assertEqual(result.length, 3)
+        self.assertFalse(result.too_long)
+
+    async def test_render_empty_block(self):
+        template_section = TemplateSection("Hello {{}}", "role")
+        result = await template_section.render_as_text(
+            self.context, self.memory, self.functions, self.tokenizer, 100
+        )
+        self.assertEqual(result.output, "Hello ")
+        self.assertEqual(result.length, 2)
+        self.assertFalse(result.too_long)

--- a/python/packages/ai/tests/ai/test_utilities.py
+++ b/python/packages/ai/tests/ai/test_utilities.py
@@ -1,0 +1,46 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import datetime
+import json
+from unittest import TestCase
+
+import yaml
+
+from teams.ai.tokenizers.gpt_tokenizer import GPTTokenizer
+from teams.ai.utilities import to_string
+
+
+class TestUtilities(TestCase):
+    def setUp(self):
+        self.tokenizer = GPTTokenizer()
+
+    def test_to_string_with_none(self):
+        self.assertEqual(to_string(self.tokenizer, None), "")
+
+    def test_to_string_with_string(self):
+        self.assertEqual(to_string(self.tokenizer, "test"), "test")
+
+    def test_to_string_with_number(self):
+        self.assertEqual(to_string(self.tokenizer, 123), "123")
+
+    def test_to_string_with_datetime(self):
+        current_time = datetime.datetime.now()
+        self.assertEqual(to_string(self.tokenizer, current_time), current_time.isoformat())
+
+    def test_to_string_with_object(self):
+        obj = {"key": "value", "key2": [1, 2, 3]}
+        yaml_str = yaml.dump(obj)
+        json_str = json.dumps(obj)
+        expected = (
+            yaml_str
+            if len(self.tokenizer.encode(yaml_str)) < len(self.tokenizer.encode(json_str))
+            else json_str
+        )
+        self.assertEqual(to_string(self.tokenizer, obj), expected)
+
+    def test_to_string_with_object_as_json(self):
+        obj = {"key": "value", "key2": [1, 2, 3]}
+        self.assertEqual(to_string(self.tokenizer, obj, as_json=True), json.dumps(obj))


### PR DESCRIPTION
## Linked issues

closes: #1065

## Details

1. Implement `TemplateSection` as well as related classes
2. Mark `invoke_function` from `PromptFunctions` as async

Note: due to language differences, the implementation of `to_string` function in `utilities` is different than js and might cause different output in corner cases. Currently the implementation has been tweaked to have same output as JS in all the test cases.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

