### PR TITLE
[PY] feat: add remaining sections and messages

### DIFF
--- a/python/packages/ai/teams/ai/promptsv2/__init__.py
+++ b/python/packages/ai/teams/ai/promptsv2/__init__.py
@@ -4,10 +4,12 @@ Licensed under the MIT License.
 """
 
 from .assistant_message import AssistantMessage
+from .conversation_history import ConversationHistory
 from .data_source_section import DataSourceSection
 from .function_call import FunctionCall
 from .function_call_message import FunctionCallMessage
 from .function_response_message import FunctionResponseMessage
+from .group_section import GroupSection
 from .layout_engine import LayoutEngine
 from .message import ImageContentPart, Message, TextContentPart
 from .prompt_section import PromptFunctions, PromptSection

--- a/python/packages/ai/teams/ai/promptsv2/__init__.py
+++ b/python/packages/ai/teams/ai/promptsv2/__init__.py
@@ -3,11 +3,17 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from .assistant_message import AssistantMessage
+from .data_source_section import DataSourceSection
 from .function_call import FunctionCall
+from .function_call_message import FunctionCallMessage
+from .function_response_message import FunctionResponseMessage
 from .layout_engine import LayoutEngine
 from .message import ImageContentPart, Message, TextContentPart
 from .prompt_section import PromptFunctions, PromptSection
 from .prompt_section_base import PromptSectionBase
 from .rendered_prompt_section import RenderedPromptSection
+from .system_message import SystemMessage
 from .template_section import TemplateSection
 from .text_section import TextSection
+from .user_message import UserMessage

--- a/python/packages/ai/teams/ai/promptsv2/assistant_message.py
+++ b/python/packages/ai/teams/ai/promptsv2/assistant_message.py
@@ -1,0 +1,24 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from .template_section import TemplateSection
+
+
+class AssistantMessage(TemplateSection):
+    """
+    A message sent by the assistant.
+    """
+
+    def __init__(self, template: str, tokens: float = -1, text_prefix: str = "assistant: "):
+        """
+        Creates a new 'AssistantMessage' instance.
+
+        Args:
+            template (str): Template to use for this section.
+            tokens (int, optional): Sizing strategy for this section. Defaults to `auto`.
+            text_prefix (str, optional): Prefix to use for assistant messages when
+              rendering as text. Defaults to `assistant: `.
+        """
+        super().__init__(template, "assistant", tokens, True, "\n", text_prefix)

--- a/python/packages/ai/teams/ai/promptsv2/conversation_history.py
+++ b/python/packages/ai/teams/ai/promptsv2/conversation_history.py
@@ -1,0 +1,188 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+from copy import deepcopy
+from typing import List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from ..utilities import to_string
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class ConversationHistory(PromptSectionBase):
+    """
+    A section that renders the conversation history.
+    """
+
+    _variable: str
+    _user_prefix: str
+    _assistant_prefix: str
+
+    def __init__(
+        self,
+        variable: str,
+        tokens: float = 1.0,
+        required: bool = False,
+        user_prefix: str = "user: ",
+        assistant_prefix: str = "assistant: ",
+        separator: str = "\n",
+    ):
+        """
+        Creates a new `ConversationHistory` instance.
+
+        Args:
+            variable (str): Name of memory variable used to store the histories.
+            tokens (float, optional): izing strategy for this section. Defaults to `proportional`
+              with a value of `1.0`.
+            required (bool, optional): Indicates if this section is required. Defaults to `false`.
+            user_prefix (str, optional): Prefix to use for user messages when rendering as text.
+              Defaults to `user: `.
+            assistant_prefix (str, optional): Prefix to use for assistant messages when rendering
+              as text. Defaults to `assistant: `.
+            separator (str, optional): Separator to use between sections when rendering as text.
+              Defaults to `\n`.
+        """
+        super().__init__(tokens, required, separator)
+        self._variable = variable
+        self._user_prefix = user_prefix
+        self._assistant_prefix = assistant_prefix
+
+    @property
+    def variable(self):
+        """
+        Gets the variable name used to store the conversation history.
+        """
+        return self._variable
+
+    @property
+    def user_prefix(self):
+        """
+        Gets the prefix used for user messages when rendering as text.
+        """
+        return self._user_prefix
+
+    @property
+    def assistant_prefix(self):
+        """
+        Gets the prefix used for assistant messages when rendering as text.
+        """
+        return self._assistant_prefix
+
+    async def render_as_text(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[str]:
+        """
+        Renders the section as a string of text.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[str]: The rendered prompt section as a string.
+        """
+
+        # Get messages from memory
+        history: List[Message] = memory.get_value(self.variable) or []
+        history = deepcopy(history)
+
+        # Populate history and stay under the token budget
+        tokens = 0
+        budget = min(self.tokens, max_tokens) if self.tokens > 1.0 else max_tokens
+        separator_length = len(tokenizer.encode(self.separator))
+        lines: List[str] = []
+        for msg in reversed(history):
+            msg = Message(role=msg.role, content=to_string(tokenizer, msg.content))
+            prefix = self.user_prefix if msg.role == "user" else self.assistant_prefix
+            line = prefix + msg.content
+            length = len(tokenizer.encode(line)) + (separator_length if len(lines) > 0 else 0)
+
+            # Add initial line if required
+            if len(lines) == 0 and self.required:
+                tokens += length
+                lines.insert(0, line)
+                continue
+
+            # Stop if we're over the token budget
+            if tokens + length > budget:
+                break
+
+            # Add line
+            tokens += length
+            lines.insert(0, line)
+
+        return RenderedPromptSection[str](self.separator.join(lines), tokens, tokens > max_tokens)
+
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[List[Message]]:
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
+
+        # Get messages from memory
+        history: List[Message] = memory.get_value(self.variable) or []
+        history = deepcopy(history)
+
+        # Populate messages and stay under the token budget
+        tokens = 0
+        budget = self._get_token_budget(max_tokens)
+        messages: List[Message] = []
+        for msg in reversed(history):
+            # Clone message
+            message = deepcopy(msg)
+            if message.content is not None:
+                message.content = to_string(tokenizer, message.content)
+
+            # Get text message length
+            length = len(tokenizer.encode(self.get_message_text(message)))
+
+            # Add length of any image parts
+            if isinstance(message.content, list):
+                length += sum(1 for part in message.content if part.type == "image") * 85
+
+            # Add initial message if required
+            if len(messages) == 0 and self.required:
+                tokens += length
+                messages.insert(0, message)
+                continue
+
+            # Stop if we're over the token budget
+            if tokens + length > budget:
+                break
+
+            # Add message
+            tokens += length
+            messages.insert(0, message)
+
+        return RenderedPromptSection(messages, tokens, tokens > max_tokens)

--- a/python/packages/ai/teams/ai/promptsv2/data_source_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/data_source_section.py
@@ -1,0 +1,69 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..data_sources import DataSource
+from ..tokenizers import Tokenizer
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class DataSourceSection(PromptSectionBase):
+    """
+    A section that renders a data source to a prompt.
+    """
+
+    _data_source: DataSource
+
+    def __init__(self, dataSource: DataSource, tokens: float):
+        """
+        Creates a new `DataSourceSection` instance.
+
+        Args:
+            dataSource (DataSource): The data source to render.
+            tokens (int): Sizing strategy for this section.
+        """
+        super().__init__(tokens, True, "\n\n")
+        self._data_source = dataSource
+
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[List[Message[str]]]:
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
+        # Render data source
+        budget = self._get_token_budget(max_tokens)
+        rendered = await self._data_source.render_data(context, memory, tokenizer, budget)
+
+        # Return as a 'system' message
+        # - The role will typically end up being ignored because as this section is usually added
+        #   to a `GroupSection` which will override the role.
+        return RenderedPromptSection(
+            output=[Message[str]("system", rendered.output)],
+            length=rendered.length,
+            too_long=rendered.too_long,
+        )

--- a/python/packages/ai/teams/ai/promptsv2/function_call_message.py
+++ b/python/packages/ai/teams/ai/promptsv2/function_call_message.py
@@ -1,0 +1,86 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import json
+from dataclasses import asdict
+from typing import List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from .function_call import FunctionCall
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class FunctionCallMessage(PromptSectionBase):
+    """
+    An `assistant` message containing a function to call.
+
+    The function call information is returned by the model so we use an "assistant" message to
+    represent it in conversation history.
+    """
+
+    _length: int
+    _function_call: FunctionCall
+
+    def __init__(
+        self, function_call: FunctionCall, tokens: float = -1, assistant_prefix: str = "assistant: "
+    ):
+        """
+        Creates a new `FunctionCallMessage` instance.
+
+        Args:
+            function_call (FunctionCall): Name and arguments of the function to call.
+            tokens (int, optional): Sizing strategy for this section. Defaults to `auto`.
+            assistant_prefix (str, optional): Prefix to use for assistant messages when
+              rendering as text. Defaults to `assistant: `.
+        """
+        super().__init__(tokens, True, "\n", assistant_prefix)
+        self._length: int = -1
+        self._function_call: FunctionCall = function_call
+
+    @property
+    def function_call(self) -> FunctionCall:
+        """
+        Name and arguments of the function to call.
+        """
+        return self._function_call
+
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: "Memory",
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[List[Message]]:
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
+        # Calculate and cache response text and length
+        if self._length < 0:
+            self._length = len(tokenizer.encode(json.dumps(asdict(self.function_call))))
+
+        # Return output
+        return self._return_messages(
+            [Message("assistant", function_call=self.function_call)],
+            self._length,
+            tokenizer,
+            max_tokens,
+        )

--- a/python/packages/ai/teams/ai/promptsv2/function_response_message.py
+++ b/python/packages/ai/teams/ai/promptsv2/function_response_message.py
@@ -1,0 +1,96 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Any, List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from ..utilities import to_string
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class FunctionResponseMessage(PromptSectionBase):
+    """
+    Message containing the response to a function call.
+    """
+
+    _text: str
+    _length: int
+    _name: str
+    _response: Any
+
+    def __init__(
+        self, name: str, response: Any, tokens: float = -1, function_prefix: str = "user: "
+    ):
+        """
+        Creates a new `FunctionResponseMessage` instance.
+
+        Args:
+            name (str): Name of the function that was called.
+            response (Any): The response returned by the called function.
+            tokens (int, optional): Sizing strategy for this section. Defaults to `auto`.
+            function_prefix (str, optional): Prefix to use for function messages when
+              rendering as text. Defaults to `user: `  to simulate the response
+              coming from the user..
+
+        """
+        super().__init__(tokens, True, "\n", function_prefix)
+        self._text = ""
+        self._length = -1
+        self._name = name
+        self._response = response
+
+    @property
+    def name(self) -> str:
+        """
+        Name of the function that was called.
+        """
+        return self._name
+
+    @property
+    def response(self) -> Any:
+        """
+        The response returned by the called function.
+        """
+        return self._response
+
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[List[Message]]:
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
+        # Calculate and cache response text and length
+        if self._length < 0:
+            self._text = to_string(tokenizer, self.response)
+            self._length = len(tokenizer.encode(self.name)) + len(tokenizer.encode(self._text))
+
+        # Return output
+        return self._return_messages(
+            [Message("function", name=self.name, content=self._text)],
+            self._length,
+            tokenizer,
+            max_tokens,
+        )

--- a/python/packages/ai/teams/ai/promptsv2/group_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/group_section.py
@@ -1,0 +1,98 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import List
+
+from botbuilder.core import TurnContext
+
+from ...state import Memory
+from ..tokenizers import Tokenizer
+from .layout_engine import LayoutEngine
+from .message import Message
+from .prompt_functions import PromptFunctions
+from .prompt_section import PromptSection
+from .prompt_section_base import PromptSectionBase
+from .rendered_prompt_section import RenderedPromptSection
+
+
+class GroupSection(PromptSectionBase):
+    """
+    A group of sections that will rendered as a single message.
+    """
+
+    _layout_engine: LayoutEngine
+    _sections: List[PromptSection]
+    _role: str
+
+    def __init__(
+        self,
+        sections: List[PromptSection],
+        role: str = "system",
+        tokens: float = -1,
+        required: bool = True,
+        separator: str = "\n\n",
+        text_prefix: str = "",
+    ):
+        """
+        Initializes the GroupSection object.
+
+        Args:
+            sections (List[PromptSection]): List of sections to group together.
+            role (str, optional): Message role to use for this section. Defaults to `system`.
+            tokens (float, optional): Sizing strategy for this section. Defaults to `auto`.
+            required (bool, optional): Indicates if this section is required. Defaults to `true`.
+            separator (str, optional): Separator to use between sections when rendering as text.
+              Defaults to `\n\n`.
+            text_prefix (str, optional): Prefix to use for text output. Defaults to ``.
+        """
+        super().__init__(tokens, required, separator, text_prefix)
+        self._layout_engine = LayoutEngine(sections, tokens, required, separator)
+        self._sections = sections
+        self._role = role
+
+    @property
+    def sections(self):
+        """
+        Gets the sections in this group.
+        """
+        return self._sections
+
+    @property
+    def role(self):
+        """
+        Gets the role for this group.
+        """
+        return self._role
+
+    async def render_as_messages(
+        self,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        max_tokens: int,
+    ) -> RenderedPromptSection[List[Message]]:
+        """
+        Renders the section as a list of messages.
+
+        Args:
+            context (TurnContext): Context for the current turn of conversation with the user.
+            memory (Memory): An interface for accessing state values.
+            functions (PromptFunctions): Registry of functions that can be used by the section.
+            tokenizer (Tokenizer): Tokenizer to use when rendering the section.
+            max_tokens (int): Maximum number of tokens allowed to be rendered.
+
+        Returns:
+            RenderedPromptSection[List[Message]]: The rendered prompt section as a list of messages.
+        """
+        # Render sections to text
+        result = await self._layout_engine.render_as_text(
+            context, memory, functions, tokenizer, max_tokens
+        )
+
+        # Return output as a single message
+        return self._return_messages(
+            [Message(self.role, result.output)], result.length, tokenizer, max_tokens
+        )

--- a/python/packages/ai/teams/ai/promptsv2/system_message.py
+++ b/python/packages/ai/teams/ai/promptsv2/system_message.py
@@ -1,0 +1,22 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from .template_section import TemplateSection
+
+
+class SystemMessage(TemplateSection):
+    """
+    A system message
+    """
+
+    def __init__(self, template: str, tokens: float = -1):
+        """
+        Creates a new 'SystemMessage' instance.
+
+        Args:
+            template (str): Template to use for this section.
+            tokens (int, optional): Sizing strategy for this section. Defaults to `auto`.
+        """
+        super().__init__(template, "system", tokens, True, "\n", "")

--- a/python/packages/ai/teams/ai/promptsv2/template_section.py
+++ b/python/packages/ai/teams/ai/promptsv2/template_section.py
@@ -56,7 +56,7 @@ class TemplateSection(PromptSectionBase):
         self,
         template: str,
         role: str,
-        tokens: int = -1,
+        tokens: float = -1,
         required: bool = True,
         separator: str = "\n",
         text_prefix: str = "",

--- a/python/packages/ai/teams/ai/promptsv2/user_message.py
+++ b/python/packages/ai/teams/ai/promptsv2/user_message.py
@@ -1,0 +1,24 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from .template_section import TemplateSection
+
+
+class UserMessage(TemplateSection):
+    """
+    A user message
+    """
+
+    def __init__(self, template: str, tokens: float = -1, user_prefix: str = "user: "):
+        """
+        Creates a new 'UserMessage' instance.
+
+        Args:
+            template (str): Template to use for this section.
+            tokens (int, optional): Sizing strategy for this section. Defaults to `auto`.
+            user_prefix (str, optional): Prefix to use for user messages when
+                rendering as text. Defaults to `user: `.
+        """
+        super().__init__(template, "user", tokens, True, "\n", user_prefix)

--- a/python/packages/ai/tests/ai/prompts/test_assistant_message.py
+++ b/python/packages/ai/tests/ai/prompts/test_assistant_message.py
@@ -1,0 +1,28 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import TestCase
+
+from teams.ai.promptsv2 import AssistantMessage
+
+
+class TestAssistantMessage(TestCase):
+    def test_init_default_values(self):
+        assistant_message = AssistantMessage("template")
+        self.assertEqual(assistant_message.template, "template")
+        self.assertEqual(assistant_message.tokens, -1)
+        self.assertEqual(assistant_message.text_prefix, "assistant: ")
+        self.assertEqual(assistant_message.role, "assistant")
+        self.assertTrue(assistant_message.required)
+        self.assertEqual(assistant_message.separator, "\n")
+
+    def test_init_with_optional_params(self):
+        assistant_message = AssistantMessage("template", 1, "text_prefix")
+        self.assertEqual(assistant_message.template, "template")
+        self.assertEqual(assistant_message.tokens, 1)
+        self.assertEqual(assistant_message.text_prefix, "text_prefix")
+        self.assertEqual(assistant_message.role, "assistant")
+        self.assertTrue(assistant_message.required)
+        self.assertEqual(assistant_message.separator, "\n")

--- a/python/packages/ai/tests/ai/prompts/test_conversation_history.py
+++ b/python/packages/ai/tests/ai/prompts/test_conversation_history.py
@@ -1,0 +1,154 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+from botbuilder.core import TurnContext
+
+from teams.ai.promptsv2 import ConversationHistory, Message, PromptFunctions
+from teams.ai.tokenizers import GPTTokenizer
+from teams.state import TurnState
+
+
+class TestConversationHistory(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.memory = TurnState()
+        self.prompt_functions = MagicMock(spec=PromptFunctions)
+        self.turn_context = MagicMock(spec=TurnContext)
+        await self.memory.load(self.turn_context)
+        self.memory.conversation.get_dict()["history"] = [
+            Message("user", "Hello"),
+            Message("assistant", "Hi! How can I help you?"),
+            Message("user", "I'd like to book a flight"),
+            Message("assistant", "Sure, where would you like to go?"),
+        ]
+
+    def test_init(self):
+        conversation_history = ConversationHistory("conversation.history")
+        self.assertEqual(conversation_history.tokens, 1.0)
+        self.assertFalse(conversation_history.required)
+        self.assertEqual(conversation_history.separator, "\n")
+        self.assertEqual(conversation_history.user_prefix, "user: ")
+        self.assertEqual(conversation_history.assistant_prefix, "assistant: ")
+
+    def test_init_with_optional_params(self):
+        conversation_history = ConversationHistory(
+            "conversation.history",
+            tokens=0.5,
+            required=True,
+            user_prefix="user: ",
+            assistant_prefix="assistant: ",
+            separator="\n",
+        )
+        self.assertEqual(conversation_history.tokens, 0.5)
+        self.assertTrue(conversation_history.required)
+        self.assertEqual(conversation_history.separator, "\n")
+        self.assertEqual(conversation_history.user_prefix, "user: ")
+        self.assertEqual(conversation_history.assistant_prefix, "assistant: ")
+
+    async def test_render_as_text(self):
+        conversation_history = ConversationHistory("conversation.history")
+        result = await conversation_history.render_as_text(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 100
+        )
+        self.assertEqual(
+            result.output,
+            "user: Hello\n"
+            "assistant: Hi! How can I help you?\n"
+            "user: I'd like to book a flight\n"
+            "assistant: Sure, where would you like to go?",
+        )
+        self.assertEqual(result.length, 36)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_include_initial_line_when_required(self):
+        conversation_history = ConversationHistory("conversation.history", required=True)
+        result = await conversation_history.render_as_text(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 1
+        )
+        self.assertEqual(result.output, "assistant: Sure, where would you like to go?")
+        self.assertEqual(result.length, 11)
+        self.assertTrue(result.too_long)
+
+    async def test_render_as_text_truncate_history(self):
+        conversation_history = ConversationHistory("conversation.history")
+        result = await conversation_history.render_as_text(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 12
+        )
+        self.assertEqual(result.output, "assistant: Sure, where would you like to go?")
+        self.assertEqual(result.length, 11)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_empty_history(self):
+        conversation_history = ConversationHistory("conversation.no_history")
+        result = await conversation_history.render_as_text(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 100
+        )
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.length, 0)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_text_long_last_message(self):
+        conversation_history = ConversationHistory("conversation.history")
+        result = await conversation_history.render_as_text(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 1
+        )
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.length, 0)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_messages(self):
+        conversation_history = ConversationHistory("conversation.history")
+        result = await conversation_history.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 100
+        )
+        self.assertEqual(
+            result.output,
+            [
+                Message("user", "Hello"),
+                Message("assistant", "Hi! How can I help you?"),
+                Message("user", "I'd like to book a flight"),
+                Message("assistant", "Sure, where would you like to go?"),
+            ],
+        )
+        self.assertEqual(result.length, 25)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_messages_include_initial_line_when_required(self):
+        conversation_history = ConversationHistory("conversation.history", required=True)
+        result = await conversation_history.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 1
+        )
+        self.assertEqual(result.output, [Message("assistant", "Sure, where would you like to go?")])
+        self.assertEqual(result.length, 9)
+        self.assertTrue(result.too_long)
+
+    async def test_render_as_messages_truncate_history(self):
+        conversation_history = ConversationHistory("conversation.history")
+        result = await conversation_history.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 12
+        )
+        self.assertEqual(result.output, [Message("assistant", "Sure, where would you like to go?")])
+        self.assertEqual(result.length, 9)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_messages_empty_history(self):
+        conversation_history = ConversationHistory("conversation.no_history")
+        result = await conversation_history.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 100
+        )
+        self.assertEqual(result.output, [])
+        self.assertEqual(result.length, 0)
+        self.assertFalse(result.too_long)
+
+    async def test_render_as_messages_long_last_message(self):
+        conversation_history = ConversationHistory("conversation.history")
+        result = await conversation_history.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 1
+        )
+        self.assertEqual(result.output, [])
+        self.assertEqual(result.length, 0)
+        self.assertFalse(result.too_long)

--- a/python/packages/ai/tests/ai/prompts/test_data_source_section.py
+++ b/python/packages/ai/tests/ai/prompts/test_data_source_section.py
@@ -1,0 +1,39 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+from botbuilder.core import TurnContext
+
+from teams.ai.data_sources import TextDataSource
+from teams.ai.promptsv2 import DataSourceSection, PromptFunctions
+from teams.ai.tokenizers import GPTTokenizer
+from teams.state import Memory
+
+
+class TestDataSourceSection(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.data_source = TextDataSource("test_name", "Hello World!")
+        self.memory = MagicMock(spec=Memory)
+        self.prompt_functions = MagicMock(spec=PromptFunctions)
+        self.turn_context = MagicMock(spec=TurnContext)
+
+    def test_init(self):
+        data_source_section = DataSourceSection(self.data_source, -1)
+        self.assertEqual(data_source_section.tokens, -1)
+        self.assertTrue(data_source_section.required)
+        self.assertEqual(data_source_section.separator, "\n\n")
+        self.assertEqual(data_source_section.text_prefix, "")
+
+    async def test_render_as_messages(self):
+        data_source_section = DataSourceSection(self.data_source, -1)
+        rendered = await data_source_section.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 10
+        )
+        self.assertEqual(rendered.output[0].role, "system")
+        self.assertEqual(rendered.output[0].content, "Hello World!")
+        self.assertEqual(rendered.length, 3)
+        self.assertFalse(rendered.too_long)

--- a/python/packages/ai/tests/ai/prompts/test_function_call_message.py
+++ b/python/packages/ai/tests/ai/prompts/test_function_call_message.py
@@ -1,0 +1,48 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+from botbuilder.core import TurnContext
+
+from teams.ai.promptsv2 import FunctionCall, FunctionCallMessage, PromptFunctions
+from teams.ai.tokenizers import GPTTokenizer
+from teams.state import Memory
+
+
+class TestFunctionCallMessage(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.function_call = FunctionCall("test", '{"foo":"bar"}')
+        self.memory = MagicMock(spec=Memory)
+        self.prompt_functions = MagicMock(spec=PromptFunctions)
+        self.turn_context = MagicMock(spec=TurnContext)
+
+    def test_init(self):
+        function_call_message = FunctionCallMessage(self.function_call)
+        self.assertEqual(function_call_message.function_call, self.function_call)
+        self.assertEqual(function_call_message.tokens, -1)
+        self.assertTrue(function_call_message.required)
+        self.assertEqual(function_call_message.separator, "\n")
+        self.assertEqual(function_call_message.text_prefix, "assistant: ")
+
+    def test_init_with_optional_params(self):
+        function_call_message = FunctionCallMessage(self.function_call, 100, "text_prefix")
+        self.assertEqual(function_call_message.function_call, self.function_call)
+        self.assertEqual(function_call_message.tokens, 100)
+        self.assertTrue(function_call_message.required)
+        self.assertEqual(function_call_message.separator, "\n")
+        self.assertEqual(function_call_message.text_prefix, "text_prefix")
+
+    async def test_render_as_messages(self):
+        function_call_message = FunctionCallMessage(self.function_call)
+        rendered = await function_call_message.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 100
+        )
+        self.assertEqual(rendered.output[0].role, "assistant")
+        self.assertIsNone(rendered.output[0].content)
+        self.assertEqual(rendered.output[0].function_call, self.function_call)
+        self.assertEqual(rendered.length, 16)
+        self.assertFalse(rendered.too_long)

--- a/python/packages/ai/tests/ai/prompts/test_function_response_message.py
+++ b/python/packages/ai/tests/ai/prompts/test_function_response_message.py
@@ -1,0 +1,49 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+from botbuilder.core import TurnContext
+
+from teams.ai.promptsv2 import FunctionResponseMessage, PromptFunctions
+from teams.ai.tokenizers import GPTTokenizer
+from teams.state import Memory
+
+
+class TestFunctionResponseMessage(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.memory = MagicMock(spec=Memory)
+        self.prompt_functions = MagicMock(spec=PromptFunctions)
+        self.turn_context = MagicMock(spec=TurnContext)
+
+    def test_init(self):
+        function_response_message = FunctionResponseMessage("foo", "bar")
+        self.assertEqual(function_response_message.name, "foo")
+        self.assertEqual(function_response_message.response, "bar")
+        self.assertEqual(function_response_message.tokens, -1)
+        self.assertTrue(function_response_message.required)
+        self.assertEqual(function_response_message.separator, "\n")
+        self.assertEqual(function_response_message.text_prefix, "user: ")
+
+    def test_init_with_optional_params(self):
+        function_response_message = FunctionResponseMessage("foo", "bar", 100, "text_prefix")
+        self.assertEqual(function_response_message.name, "foo")
+        self.assertEqual(function_response_message.response, "bar")
+        self.assertEqual(function_response_message.tokens, 100)
+        self.assertTrue(function_response_message.required)
+        self.assertEqual(function_response_message.separator, "\n")
+        self.assertEqual(function_response_message.text_prefix, "text_prefix")
+
+    async def test_render_as_messages(self):
+        function_response_message = FunctionResponseMessage("foo", "bar")
+        rendered = await function_response_message.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 100
+        )
+        self.assertEqual(rendered.output[0].role, "function")
+        self.assertEqual(rendered.output[0].content, "bar")
+        self.assertEqual(rendered.output[0].name, "foo")
+        self.assertEqual(rendered.length, 2)
+        self.assertFalse(rendered.too_long)

--- a/python/packages/ai/tests/ai/prompts/test_group_section.py
+++ b/python/packages/ai/tests/ai/prompts/test_group_section.py
@@ -1,0 +1,67 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+from botbuilder.core import TurnContext
+
+from teams.ai.promptsv2 import GroupSection, PromptFunctions, TextSection
+from teams.ai.tokenizers import GPTTokenizer
+from teams.state import Memory
+
+
+class TestGroupSection(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.memory = MagicMock(spec=Memory)
+        self.prompt_functions = MagicMock(spec=PromptFunctions)
+        self.turn_context = MagicMock(spec=TurnContext)
+
+    def test_init(self):
+        group_section = GroupSection([TextSection("foo", "user"), TextSection("bar", "user")])
+        self.assertEqual(len(group_section.sections), 2)
+        self.assertEqual(group_section.role, "system")
+        self.assertEqual(group_section.tokens, -1)
+        self.assertTrue(group_section.required)
+        self.assertEqual(group_section.separator, "\n\n")
+        self.assertEqual(group_section.text_prefix, "")
+
+    def test_init_with_optional_params(self):
+        group_section = GroupSection(
+            [TextSection("foo", "user"), TextSection("bar", "user")],
+            "role",
+            100,
+            False,
+            "separator",
+            "text_prefix",
+        )
+        self.assertEqual(len(group_section.sections), 2)
+        self.assertEqual(group_section.role, "role")
+        self.assertEqual(group_section.tokens, 100)
+        self.assertFalse(group_section.required)
+        self.assertEqual(group_section.separator, "separator")
+        self.assertEqual(group_section.text_prefix, "text_prefix")
+
+    async def test_render_as_messages(self):
+        group_section = GroupSection([TextSection("foo", "user"), TextSection("bar", "user")])
+        rendered = await group_section.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 100
+        )
+        self.assertEqual(len(rendered.output), 1)
+        self.assertEqual(rendered.output[0].role, "system")
+        self.assertEqual(rendered.output[0].content, "foo\n\nbar")
+        self.assertEqual(rendered.length, 3)
+        self.assertFalse(rendered.too_long)
+
+    async def test_render_as_messages_too_long(self):
+        group_section = GroupSection([TextSection("foo", "user"), TextSection("bar", "user")])
+        rendered = await group_section.render_as_messages(
+            self.turn_context, self.memory, self.prompt_functions, GPTTokenizer(), 1
+        )
+        self.assertEqual(len(rendered.output), 1)
+        self.assertEqual(rendered.output[0].role, "system")
+        self.assertEqual(rendered.output[0].content, "foo\n\nbar")
+        self.assertEqual(rendered.length, 3)
+        self.assertTrue(rendered.too_long)

--- a/python/packages/ai/tests/ai/prompts/test_system_message.py
+++ b/python/packages/ai/tests/ai/prompts/test_system_message.py
@@ -1,0 +1,28 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import TestCase
+
+from teams.ai.promptsv2 import SystemMessage
+
+
+class TestSystemMessage(TestCase):
+    def test_init(self):
+        system_message = SystemMessage("template")
+        self.assertEqual(system_message.template, "template")
+        self.assertEqual(system_message.tokens, -1)
+        self.assertEqual(system_message.text_prefix, "")
+        self.assertEqual(system_message.role, "system")
+        self.assertTrue(system_message.required)
+        self.assertEqual(system_message.separator, "\n")
+
+    def test_init_with_optional_params(self):
+        system_message = SystemMessage("template", 100)
+        self.assertEqual(system_message.template, "template")
+        self.assertEqual(system_message.tokens, 100)
+        self.assertEqual(system_message.text_prefix, "")
+        self.assertEqual(system_message.role, "system")
+        self.assertTrue(system_message.required)
+        self.assertEqual(system_message.separator, "\n")

--- a/python/packages/ai/tests/ai/prompts/test_user_message.py
+++ b/python/packages/ai/tests/ai/prompts/test_user_message.py
@@ -1,0 +1,28 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from unittest import TestCase
+
+from teams.ai.promptsv2 import UserMessage
+
+
+class TestUserMessage(TestCase):
+    def test_init(self):
+        user_message = UserMessage("template")
+        self.assertEqual(user_message.template, "template")
+        self.assertEqual(user_message.tokens, -1)
+        self.assertEqual(user_message.text_prefix, "user: ")
+        self.assertEqual(user_message.role, "user")
+        self.assertTrue(user_message.required)
+        self.assertEqual(user_message.separator, "\n")
+
+    def test_init_with_optional_params(self):
+        user_message = UserMessage("template", 100, "text_prefix")
+        self.assertEqual(user_message.template, "template")
+        self.assertEqual(user_message.tokens, 100)
+        self.assertEqual(user_message.text_prefix, "text_prefix")
+        self.assertEqual(user_message.role, "user")
+        self.assertTrue(user_message.required)
+        self.assertEqual(user_message.separator, "\n")


### PR DESCRIPTION
## Linked issues

closes: #1065

## Details

1. Add remaining sections and messages besides `UserInputMessage`.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
