### PR TITLE
[JS] fix:  OPENAI_KEY not found in process.env

### DIFF
--- a/js/samples/06.assistants.b.orderBot/src/index.ts
+++ b/js/samples/06.assistants.b.orderBot/src/index.ts
@@ -13,12 +13,12 @@ import { ConfigurationServiceClientCredentialFactory, TurnContext } from 'botbui
 
 import { TeamsAdapter } from '@microsoft/teams-ai';
 
-// Include the Teams AI custom component
-import * as bot from './bot';
-
 // Read botFilePath and botFileSecret from .env file.
 const ENV_FILE = path.join(__dirname, '..', '.env');
 config({ path: ENV_FILE });
+
+// Include the Teams AI custom component
+import * as bot from './bot';
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about how bots work.


### PR DESCRIPTION
## Linked issues

closes: #minor (issue number)

## Details
the environment variable was being loaded after importing * from bot.ts. Which means the process.env.OPENAI_KEY won't be loaded when accessed in bot.ts.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
