### PR TITLE
[PY] feat: Activity Handlers - Message Reactions and Message Update

### DIFF
--- a/python/packages/ai/teams/__init__.py
+++ b/python/packages/ai/teams/__init__.py
@@ -10,4 +10,5 @@ from .app_error import ApplicationError
 from .app_options import ApplicationOptions
 from .input_file import InputFile
 from .message_extensions import MessagePreviewAction
+from .message_reaction_types import MessageReactionTypes
 from .query import Query

--- a/python/packages/ai/teams/activity_type.py
+++ b/python/packages/ai/teams/activity_type.py
@@ -39,3 +39,7 @@ ConversationUpdateType = Literal[
     "teamUnarchived",
     "teamRestored",
 ]
+
+MessageReactionType = Literal["reactionsAdded", "reactionsRemoved"]
+
+MessageUpdateType = Literal["editMessage", "softDeleteMessage", "undeleteMessage"]

--- a/python/packages/ai/teams/message_reaction_types.py
+++ b/python/packages/ai/teams/message_reaction_types.py
@@ -1,0 +1,11 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from enum import Enum
+
+
+class MessageReactionTypes(str, Enum):
+    LIKE = "like"
+    PLUS_ONE = "plusOne"

--- a/python/packages/ai/tests/test_app.py
+++ b/python/packages/ai/tests/test_app.py
@@ -12,6 +12,7 @@ from botbuilder.core import TurnContext
 from botbuilder.schema import Activity, ChannelAccount, ConversationAccount
 
 from teams import Application
+from teams.message_reaction_types import MessageReactionTypes
 from tests.utils import SimpleAdapter
 
 
@@ -149,3 +150,118 @@ class TestApp(IsolatedAsyncioTestCase):
         )
 
         on_member_added.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_message_reaction(self):
+        on_reactions_added = mock.AsyncMock()
+        on_reactions_removed = mock.AsyncMock()
+        self.app.message_reaction("reactionsAdded")(on_reactions_added)
+        self.app.message_reaction("reactionsRemoved")(on_reactions_removed)
+        self.assertEqual(len(self.app._routes), 2)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="messageReaction",
+                    text="test",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="UnitTest",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    reactions_added=[{type: MessageReactionTypes.LIKE}],
+                ),
+            )
+        )
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="messageReaction",
+                    text="test",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="UnitTest",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    reactions_removed=[{type: MessageReactionTypes.PLUS_ONE}],
+                ),
+            )
+        )
+
+        on_reactions_added.assert_called_once()
+        on_reactions_removed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_message_update(self):
+        on_edit_message = mock.AsyncMock()
+        on_soft_delete_message = mock.AsyncMock()
+        on_undelete_message = mock.AsyncMock()
+        self.app.message_update("editMessage")(on_edit_message)
+        self.app.message_update("softDeleteMessage")(on_soft_delete_message)
+        self.app.message_update("undeleteMessage")(on_undelete_message)
+        self.assertEqual(len(self.app._routes), 3)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="messageUpdate",
+                    text="test",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="UnitTest",
+                    channel_data={"event_type": "editMessage"},
+                    locale="en-uS",
+                    service_url="https://example.org",
+                ),
+            )
+        )
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="messageDelete",
+                    text="test",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="UnitTest",
+                    channel_data={"event_type": "softDeleteMessage"},
+                    locale="en-uS",
+                    service_url="https://example.org",
+                ),
+            )
+        )
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="messageUpdate",
+                    text="test",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="UnitTest",
+                    channel_data={"event_type": "undeleteMessage"},
+                    locale="en-uS",
+                    service_url="https://example.org",
+                ),
+            )
+        )
+
+        on_edit_message.assert_called_once()
+        on_soft_delete_message.assert_called_once()
+        on_undelete_message.assert_called_once()


### PR DESCRIPTION
## Linked issues

closes: #1292 and #1293 

## Details
- Implemented logic and tests for handling message reactions and message update events 
- Message reactions include `reactionsAdded` and `reactionsRemoved`
- Message updates include `editMessage`, `softDeleteMessage`, `undeleteMessage`

