### PR TITLE
[PY] feat: Activity Handlers - Meetings and RemoveRecipientMention

### DIFF
--- a/python/packages/ai/teams/__init__.py
+++ b/python/packages/ai/teams/__init__.py
@@ -9,6 +9,7 @@ from .app import Application
 from .app_error import ApplicationError
 from .app_options import ApplicationOptions
 from .input_file import InputFile
+from .meetings import Meetings
 from .message_extensions import MessagePreviewAction
 from .message_reaction_types import MessageReactionTypes
 from .query import Query

--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -23,6 +23,7 @@ from botbuilder.schema import Activity, ActivityTypes
 
 from teams.adaptive_cards.adaptive_cards import AdaptiveCards
 from teams.ai import AI, TurnState
+from teams.meetings import Meetings
 from teams.task_modules import TaskModules
 
 from .activity_type import (
@@ -40,6 +41,7 @@ from .typing import Typing
 StateT = TypeVar("StateT", bound=TurnState)
 
 
+# pylint: disable=too-many-instance-attributes
 class Application(Bot, Generic[StateT]):
     """
     Application class for routing and processing incoming requests.
@@ -66,6 +68,7 @@ class Application(Bot, Generic[StateT]):
     _turn_state_factory: Optional[Callable[[Activity], Awaitable[StateT]]] = None
     _message_extensions: MessageExtensions[StateT]
     _task_modules: TaskModules[StateT]
+    _meetings: Meetings[StateT]
 
     def __init__(self, options=ApplicationOptions()) -> None:
         """
@@ -82,6 +85,7 @@ class Application(Bot, Generic[StateT]):
         self._task_modules = TaskModules[StateT](
             self._routes, options.task_modules.task_data_filter
         )
+        self._meetings = Meetings[StateT](self._routes)
 
         if options.long_running_messages and (not options.auth or not options.bot_app_id):
             raise ApplicationError(
@@ -137,6 +141,13 @@ class Application(Bot, Generic[StateT]):
         Access the application's task modules functionalities.
         """
         return self._task_modules
+
+    @property
+    def meetings(self) -> Meetings[StateT]:
+        """
+        Access the application's meetings functionalities.
+        """
+        return self._meetings
 
     def activity(
         self, type: ActivityType
@@ -466,6 +477,11 @@ class Application(Bot, Generic[StateT]):
         try:
             if self._options.start_typing_timer:
                 await self.typing.start(context)
+
+            # remove @mentions
+            if self.options.remove_recipient_mention:
+                if context.activity.type == ActivityTypes.message:
+                    context.activity.text = context.remove_recipient_mention(context.activity)
 
             state: TurnState
 

--- a/python/packages/ai/teams/meetings.py
+++ b/python/packages/ai/teams/meetings.py
@@ -1,0 +1,107 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Awaitable, Callable, Generic, List, TypeVar
+
+from botbuilder.core import TurnContext
+from botbuilder.schema import ActivityTypes
+from botbuilder.schema.teams import MeetingEndEventDetails, MeetingStartEventDetails, MeetingEndEventDetails
+
+from teams.ai import TurnState
+
+from .route import Route
+
+StateT = TypeVar("StateT", bound=TurnState)
+
+
+class Meetings(Generic[StateT]):
+    _routes: List[Route[StateT]] = []
+
+    def __init__(self, routes: List[Route[StateT]]) -> None:
+        self._routes = routes
+
+    def start(
+        self,
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, MeetingStartEventDetails], Awaitable[None]]],
+        Callable[[TurnContext, StateT, MeetingStartEventDetails], Awaitable[None]],
+    ]:
+        """
+        Registers a handler for meeting start events for Microsoft Teams.
+
+         ```python
+        # Use this method as a decorator
+        @app.meetings.start()
+        async def on_start(
+            context: TurnContext, state: TurnState, meeting: MeetingStartEventDetails
+        ):
+            print(meeting)
+
+        # Pass a function to this method
+        app.meetings.start()(on_start)
+        ```
+        """
+
+        def __selector__(context: TurnContext) -> bool:
+            return (
+                context.activity.type == ActivityTypes.event
+                and context.activity.channel_id == "msteams"
+                and context.activity.name == "application/vnd.microsoft.meetingStart"
+            )
+
+        def __call__(
+            func: Callable[[TurnContext, StateT, MeetingStartEventDetails], Awaitable[None]]
+        ) -> Callable[[TurnContext, StateT, MeetingStartEventDetails], Awaitable[None]]:
+            async def __handler__(context: TurnContext, state: StateT):
+                if not context.activity.value:
+                    return False
+                await func(context, state, context.activity.value)
+                return True
+
+            self._routes.append(Route[StateT](__selector__, __handler__))
+            return func
+
+        return __call__
+
+    def end(
+        self,
+    ) -> Callable[
+        [Callable[[TurnContext, StateT, MeetingEndEventDetails], Awaitable[None]]],
+        Callable[[TurnContext, StateT, MeetingEndEventDetails], Awaitable[None]],
+    ]:
+        """
+        Registers a handler for meeting end events for Microsoft Teams.
+
+         ```python
+        # Use this method as a decorator
+        @app.meetings.end()
+        async def on_end(context: TurnContext, state: TurnState, meeting: MeetingEndEventDetails):
+            print(meeting)
+
+        # Pass a function to this method
+        app.meetings.end()(on_end)
+        ```
+        """
+
+        def __selector__(context: TurnContext) -> bool:
+            return (
+                context.activity.type == ActivityTypes.event
+                and context.activity.channel_id == "msteams"
+                and context.activity.name == "application/vnd.microsoft.meetingEnd"
+            )
+
+        def __call__(
+            func: Callable[[TurnContext, StateT, MeetingEndEventDetails], Awaitable[None]]
+        ) -> Callable[[TurnContext, StateT, MeetingEndEventDetails], Awaitable[None]]:
+            async def __handler__(context: TurnContext, state: StateT):
+                if not context.activity.value:
+                    return False
+                await func(context, state, context.activity.value)
+                return True
+
+            self._routes.append(Route[StateT](__selector__, __handler__))
+            return func
+
+        return __call__

--- a/python/packages/ai/teams/meetings.py
+++ b/python/packages/ai/teams/meetings.py
@@ -7,7 +7,7 @@ from typing import Awaitable, Callable, Generic, List, TypeVar
 
 from botbuilder.core import TurnContext
 from botbuilder.schema import ActivityTypes
-from botbuilder.schema.teams import MeetingEndEventDetails, MeetingStartEventDetails, MeetingEndEventDetails
+from botbuilder.schema.teams import MeetingEndEventDetails, MeetingStartEventDetails
 
 from teams.ai import TurnState
 

--- a/python/packages/ai/tests/test_meetings.py
+++ b/python/packages/ai/tests/test_meetings.py
@@ -1,0 +1,324 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+# pylint:disable=duplicate-code
+
+from unittest import IsolatedAsyncioTestCase, mock
+
+import pytest
+from botbuilder.core import TurnContext
+from botbuilder.schema import Activity, ChannelAccount, ConversationAccount
+
+from teams import Application
+from tests.utils import SimpleAdapter
+
+
+class TestMeetings(IsolatedAsyncioTestCase):
+    app: Application
+
+    @pytest.fixture(autouse=True)
+    def before_each(self):
+        self.app = Application()
+        yield
+
+    @pytest.mark.asyncio
+    async def test_start(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.start()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meetingStart",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_with_invalid_name(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.start()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meeting",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_with_missing_value(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.start()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meetingStart",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                ),
+            )
+        )
+
+        handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_with_wrong_type(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.start()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="invoke",
+                    text="test",
+                    name="application/vnd.microsoft.meetingStart",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_with_wrong_channel(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.start()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meetingStart",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="team",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_end(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.end()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meetingEnd",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_end_with_missing_value(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.end()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meetingEnd",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                ),
+            )
+        )
+
+        handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_end_with_invalid_name(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.end()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meeting",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_end_with_wrong_type(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.end()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="invoke",
+                    text="test",
+                    name="application/vnd.microsoft.meetingEnd",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="msteams",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_end_with_wrong_channel(self):
+        handler = mock.AsyncMock()
+        self.app.meetings.end()(handler)
+        self.assertEqual(len(self.app._routes), 1)
+
+        await self.app.on_turn(
+            TurnContext(
+                SimpleAdapter(),
+                Activity(
+                    id="1234",
+                    type="event",
+                    text="test",
+                    name="application/vnd.microsoft.meetingEnd",
+                    from_property=ChannelAccount(id="user", name="User Name"),
+                    recipient=ChannelAccount(id="bot", name="Bot Name"),
+                    conversation=ConversationAccount(id="convo", name="Convo Name"),
+                    channel_id="team",
+                    locale="en-uS",
+                    service_url="https://example.org",
+                    value={
+                        "meetingType": "scheduled",
+                        "startTime": "2020-10-01T00:00:00.000Z",
+                        "endTime": "2020-10-01T00:30:00.000Z",
+                    },
+                ),
+            )
+        )
+
+        handler.assert_not_called()


### PR DESCRIPTION
## Linked issues

closes: #1296

## Details

- implemented logic and tests for handling `meetingStart`, `meetingEnd` events
- implemented logic for `removeRecipientMention`
- unable to currently implement `readReceipt`, `meetingParticipantJoin`, `meetingParticipantLeave` due to missing schemas for `ReadReceiptInfo`, and `MeetingParticipantsEventDetails `classes on [botbuilder](https://learn.microsoft.com/en-us/python/api/botbuilder-schema/botbuilder.schema.teams?view=botbuilder-py-latest) 
 
 Tracking through #1300 