### PR TITLE
[JS] chore: set recommended node version

### DIFF
--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -12,6 +12,9 @@
         "teams",
         "ai"
     ],
+    "engines": {
+        "node": "^16 || ^18"
+    },
     "bugs": {
         "url": "https://github.com/microsoft/teams-ai/issues"
     },


### PR DESCRIPTION
## Linked issues

closes: #1196

## Details
- set node engine to 16 or 18 (recommended version on [documentation](https://github.com/microsoft/teams-ai/blob/main/getting-started/QUICKSTART.md#prerequisite))