### PR TITLE
[JS] fix: Change default encoder for Tokenizer

### DIFF
--- a/js/.eslintrc
+++ b/js/.eslintrc
@@ -47,6 +47,7 @@
         "no-async-promise-executor": "off",
         "no-constant-condition": "off",
         "no-extra-boolean-cast": "off",
+        "no-prototype-builtins": "off",
         "no-undef": "off", // Disabled due to conflicts with @typescript/eslint
         "no-unused-vars": "off", // Disabled due to conflicts with @typescript/eslint
         "prettier/prettier": "error"

--- a/js/packages/api/teams-ai.api.json
+++ b/js/packages/api/teams-ai.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.40.1",
+    "toolVersion": "7.41.0",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -280,7 +280,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@microsoft/teams-ai!ActionAugmentationSection#actions:member",
-              "docComment": "/**\n * Map of action names to actions.\n */\n",
+              "docComment": "/**\n * @returns {Map<string, ChatCompletionAction>} Map of action names to actions.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -324,7 +324,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!ActionAugmentationSection#renderAsMessages:member(1)",
-              "docComment": "/**\n * Renders the prompt section as a list of `Message` objects.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - Interface for accessing state variables.\n *\n * @param functions - Functions for rendering prompts.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns The rendered prompt section.\n */\n",
+              "docComment": "/**\n * Renders the prompt section as a list of `Message` objects.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - Interface for accessing state variables.\n *\n * @param functions - Functions for rendering prompts.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns {Promise<RenderedPromptSection<Message<string>[]>>} The rendered prompt section.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -11298,7 +11298,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!DefaultAugmentation#createPlanFromResponse:member(1)",
-              "docComment": "/**\n * Creates a plan given validated response value.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - An interface for accessing state variables.\n *\n * @param response - The validated and transformed response for the prompt.\n *\n * @returns The created plan.\n */\n",
+              "docComment": "/**\n * Creates a plan given validated response value.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - An interface for accessing state variables.\n *\n * @param response - The validated and transformed response for the prompt.\n *\n * @returns {Promise<Plan>} The created plan.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -11399,7 +11399,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!DefaultAugmentation#createPromptSection:member(1)",
-              "docComment": "/**\n * Creates an optional prompt section for the augmentation.\n */\n",
+              "docComment": "/**\n * @returns {PromptSection|undefined} Returns an optional prompt section for the augmentation.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -11435,7 +11435,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!DefaultAugmentation#validateResponse:member(1)",
-              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns A `Validation` object.\n */\n",
+              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns {Validation} A `Validation` object.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18313,7 +18313,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!MonologueAugmentation#createPlanFromResponse:member(1)",
-              "docComment": "/**\n * Creates a plan given validated response value.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - An interface for accessing state variables.\n *\n * @param response - The validated and transformed response for the prompt.\n *\n * @returns The created plan.\n */\n",
+              "docComment": "/**\n * Creates a plan given validated response value.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - An interface for accessing state variables.\n *\n * @param response - The validated and transformed response for the prompt.\n *\n * @returns {Plan} The created plan.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18423,7 +18423,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!MonologueAugmentation#createPromptSection:member(1)",
-              "docComment": "/**\n * Creates an optional prompt section for the augmentation.\n */\n",
+              "docComment": "/**\n * @returns {PromptSection|undefined} Returns an optional prompt section for the augmentation.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18459,7 +18459,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!MonologueAugmentation#validateResponse:member(1)",
-              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns A `Validation` object.\n */\n",
+              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns {Validation} A `Validation` object.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -19220,7 +19220,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!OpenAIModel#completePrompt:member(1)",
-              "docComment": "/**\n * Completes a prompt using OpenAI or Azure OpenAI.\n *\n * @param context - Current turn context.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param functions - Functions to use when rendering the prompt.\n *\n * @param tokenizer - Tokenizer to use when rendering the prompt.\n *\n * @param template - Prompt template to complete.\n *\n * @returns A `PromptResponse` with the status and message.\n */\n",
+              "docComment": "/**\n * Completes a prompt using OpenAI or Azure OpenAI.\n *\n * @param context - Current turn context.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param functions - Functions to use when rendering the prompt.\n *\n * @param tokenizer - Tokenizer to use when rendering the prompt.\n *\n * @param template - Prompt template to complete.\n *\n * @returns {Promise<PromptResponse<string>>} A `PromptResponse` with the status and message.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -19351,7 +19351,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!OpenAIModel#copyOptionsToRequest:member(1)",
-              "docComment": "/**\n * @param target - \n *\n * @param src - \n *\n * @param fields -  @private\n */\n",
+              "docComment": "/**\n * @private  @template TRequest\n *\n * @param target - The target TRequest.\n *\n * @param src - The source object.\n *\n * @param fields - List of fields to copy.\n *\n * @returns {TRequest} The TRequest\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -19449,7 +19449,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!OpenAIModel#createChatCompletion:member(1)",
-              "docComment": "/**\n * @param request - \n *\n * @param model -  @private\n */\n",
+              "docComment": "/**\n * @private\n *\n * @param request - The request for Chat Completion\n *\n * @param model - The string name of the model.\n *\n * @returns {Promise<AxiosResponse<CreateChatCompletionResponse>>} A Promise containing the CreateChatCompletionResponse response.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -19577,7 +19577,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!OpenAIModel#post:member(1)",
-              "docComment": "/**\n * @param url - \n *\n * @param body - \n *\n * @param retryCount -  @private\n */\n",
+              "docComment": "/**\n * @private  @template TData\n *\n * @param url - Url to post to.\n *\n * @param body - POST body.\n *\n * @param retryCount - Number of allowed retries.\n *\n * @returns {Promise<AxiosResponse<TData>>} Promise containing the POST response.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -21242,7 +21242,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#beginTask:member(1)",
-                  "docComment": "/**\n * Starts a new task.\n *\n * @remarks\n *\n * This method is called when the AI system is ready to start a new task. The planner should generate a plan that the AI system will execute. Returning an empty plan signals that there is no work to be performed.\n *\n * The planner should take the users input from `state.temp.input`.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n *\n * @param ai - The AI system that is generating the plan.\n *\n * @returns The plan that was generated.\n */\n",
+                  "docComment": "/**\n * Starts a new task.\n *\n * @remarks\n *\n * This method is called when the AI system is ready to start a new task. The planner should generate a plan that the AI system will execute. Returning an empty plan signals that there is no work to be performed.\n *\n * The planner should take the users input from `state.temp.input`.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n *\n * @param ai - The AI system that is generating the plan.\n *\n * @returns {Promise<Plan>} The plan that was generated.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21342,7 +21342,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#continueTask:member(1)",
-                  "docComment": "/**\n * Continues the current task.\n *\n * @remarks\n *\n * This method is called when the AI system has finished executing the previous plan and is ready to continue the current task. The planner should generate a plan that the AI system will execute. Returning an empty plan signals that the task is completed and there is no work to be performed.\n *\n * The output from the last plan step that was executed is passed to the planner via `state.temp.input`.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n *\n * @param ai - The AI system that is generating the plan.\n *\n * @returns The plan that was generated.\n */\n",
+                  "docComment": "/**\n * Continues the current task.\n *\n * @remarks\n *\n * This method is called when the AI system has finished executing the previous plan and is ready to continue the current task. The planner should generate a plan that the AI system will execute. Returning an empty plan signals that the task is completed and there is no work to be performed.\n *\n * The output from the last plan step that was executed is passed to the planner via `state.temp.input`.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n *\n * @param ai - The AI system that is generating the plan.\n *\n * @returns {Promise<Plan>} The plan that was generated.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21442,7 +21442,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner.createAssistant:member(1)",
-                  "docComment": "/**\n * Static helper method for programmatically creating an assistant.\n *\n * @param apiKey - OpenAI API key.\n *\n * @param request - Definition of the assistant to create.\n *\n * @returns The created assistant.\n */\n",
+                  "docComment": "/**\n * Static helper method for programmatically creating an assistant.\n *\n * @param apiKey - OpenAI API key.\n *\n * @param request - Definition of the assistant to create.\n *\n * @returns {Promise<OpenAI.Beta.Assistants.Assistant>} The created assistant.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21521,7 +21521,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#createMessage:member(1)",
-                  "docComment": "/**\n * @param thread_id - \n *\n * @param body -  @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @param thread_id - The thread id\n *\n * @param body - Message body.\n *\n * @returns {Promise<OpenAI.Beta.Threads.Messages.ThreadMessage>} The thread message.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21600,7 +21600,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#createRun:member(1)",
-                  "docComment": "/**\n * @param thread_id -  @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @param thread_id - The thread id to create Run.\n *\n * @returns {Promise<OpenAI.Beta.Threads.Runs.Run>} The created run.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21662,7 +21662,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#createThread:member(1)",
-                  "docComment": "/**\n * @param request -  @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @param request - The Threads request.\n *\n * @returns {Promise<OpenAI.Beta.Threads.Thread>} The Thread.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21725,7 +21725,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#listMessages:member(1)",
-                  "docComment": "/**\n * @param thread_id -  @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @param thread_id - The current thread id\n *\n * @returns {Promise<OpenAI.Beta.Threads.Messages.ThreadMessagesPage>} The list of messages.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21787,7 +21787,7 @@
                 {
                   "kind": "Property",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#openai:member",
-                  "docComment": "/**\n * Gets the OpenAI SDK instance being used.\n */\n",
+                  "docComment": "/**\n * Gets the OpenAI SDK instance being used.\n *\n * @returns {OpenAI} The OpenAI instance\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21818,7 +21818,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#retrieveAssistant:member(1)",
-                  "docComment": "/**\n * @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @returns {Promise<OpenAI.Beta.Assistants.Assistant>} - The assistant.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21863,7 +21863,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#retrieveLastRun:member(1)",
-                  "docComment": "/**\n * @param thread_id -  @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @param thread_id - The thread id to retrieve the run.\n *\n * @returns {Promise<OpenAI.Beta.Threads.Runs.Run>} The retrieved run.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -21925,7 +21925,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#retrieveRun:member(1)",
-                  "docComment": "/**\n * @param thread_id - \n *\n * @param run_id -  @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @param thread_id - The thread id to retrieve the run.\n *\n * @param run_id - The run id to retrieve.\n *\n * @returns {OpenAI.Beta.Threads.Runs.Run} The retrieved run.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -22003,7 +22003,7 @@
                 {
                   "kind": "Method",
                   "canonicalReference": "@microsoft/teams-ai!preview.AssistantsPlanner#submitToolOutputs:member(1)",
-                  "docComment": "/**\n * @param thread_id - \n *\n * @param run_id - \n *\n * @param tool_outputs -  @private Exposed for unit testing.\n */\n",
+                  "docComment": "/**\n * @private Exposed for unit testing.\n *\n * @param thread_id - The current thread id.\n *\n * @param run_id - The current run id.\n *\n * @param tool_outputs - The run's tool output parameters.\n *\n * @returns {Promise<OpenAI.Beta.Threads.Run.Run>} The tool outputs.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",
@@ -25833,7 +25833,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!SequenceAugmentation#createPlanFromResponse:member(1)",
-              "docComment": "/**\n * Creates a plan given validated response value.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - An interface for accessing state variables.\n *\n * @param response - The validated and transformed response for the prompt.\n *\n * @returns The created plan.\n */\n",
+              "docComment": "/**\n * Creates a plan given validated response value.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - An interface for accessing state variables.\n *\n * @param response - The validated and transformed response for the prompt.\n *\n * @returns {Promise<Plan>} The created plan.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -25943,7 +25943,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!SequenceAugmentation#createPromptSection:member(1)",
-              "docComment": "/**\n * Creates an optional prompt section for the augmentation.\n */\n",
+              "docComment": "/**\n * Creates an optional prompt section for the augmentation.\n *\n * @returns {PromptSection | undefined} The new PromptSection or undefined.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -25979,7 +25979,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!SequenceAugmentation#validateResponse:member(1)",
-              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns A `Validation` object.\n */\n",
+              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns {Validation} A `Validation` object.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -28297,7 +28297,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@microsoft/teams-ai!TextDataSource#name:member",
-              "docComment": "/**\n * Name of the data source.\n */\n",
+              "docComment": "/**\n * @returns {string} Name of the data source.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -28327,7 +28327,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!TextDataSource#renderData:member(1)",
-              "docComment": "/**\n * Renders the data source as a string of text.\n *\n * @param context - Turn context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use when rendering the data source.\n *\n * @param maxTokens - Maximum number of tokens allowed to be rendered.\n *\n * @returns The text to inject into the prompt as a `RenderedPromptSection` object.\n */\n",
+              "docComment": "/**\n * Renders the data source as a string of text.\n *\n * @param context - Turn context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use when rendering the data source.\n *\n * @param maxTokens - Maximum number of tokens allowed to be rendered.\n *\n * @returns {Promise<RenderedPromptSection<string>>} The text to inject into the prompt as a `RenderedPromptSection` object.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/js/packages/api/teams-ai.api.json
+++ b/js/packages/api/teams-ai.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.39.1",
+    "toolVersion": "7.40.1",
     "schemaVersion": 1011,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {
@@ -641,7 +641,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!ActionPlanner#beginTask:member(1)",
-              "docComment": "/**\n * Starts a new task.\n *\n * @remarks\n *\n * This method is called when the AI system is ready to start a new task. The planner should generate a plan that the AI system will execute. Returning an empty plan signals that there is no work to be performed.\n *\n * The planner should take the users input from `state.temp.input`.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n *\n * @param ai - The AI system that is generating the plan.\n *\n * @returns The plan that was generated.\n */\n",
+              "docComment": "/**\n * Starts a new task.\n *\n * @remarks\n *\n * This method is called when the AI system is ready to start a new task. The planner should generate a plan that the AI system will execute. Returning an empty plan signals that there is no work to be performed.\n *\n * The planner should take the users input from `state.temp.input`.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n *\n * @param ai - The AI system that is generating the plan.\n *\n * @returns {Promise<Plan>} The plan that was generated.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -1276,7 +1276,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!ActionPlannerOptions#tokenizer:member",
-              "docComment": "/**\n * Optional tokenizer to use.\n *\n * @remarks\n *\n * If not specified, a new `GPT3Tokenizer` instance will be created.\n */\n",
+              "docComment": "/**\n * Optional tokenizer to use.\n *\n * @remarks\n *\n * If not specified, a new `GPTTokenizer` instance will be created.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2606,7 +2606,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!AI#action:member(1)",
-              "docComment": "/**\n * Registers a handler for a named action.\n *\n * @remarks\n *\n * The AI systems planner returns plans that are made up of a series of commands or actions that should be performed. Registering a handler lets you provide code that should be run in response to one of the predicted actions.\n *\n * Plans support a DO command which specifies the name of an action to call and an optional set of entities that should be passed to the action. The internal plan executor will call the registered handler for the action passing in the current context, state, and entities.\n *\n * Additionally, the AI system itself uses actions to handle things like unknown actions, flagged input, and flagged output. You can override these actions by registering your own handler for them. The names of the built-in actions are available as static properties on the AI class.  @template TParameters Optional. The type of parameters that the action handler expects.\n *\n * @param name - Unique name of the action.  @callback handler\n *\n * @param handler - The code to execute when the _ is triggered.\n *\n * @param  - {TurnContext} handler.context The current turn context for the handler callback.\n *\n * @param  - {TState} handler.state The current turn state for the handler callback.\n *\n * @param  - {TParameters} handler.parameters Optional. Entities to pass to the action.\n *\n * @returns {this} The AI system instance for chaining purposes.\n */\n",
+              "docComment": "/**\n * Registers a handler for a named action.\n *\n * @remarks\n *\n * The AI systems planner returns plans that are made up of a series of commands or actions that should be performed. Registering a handler lets you provide code that should be run in response to one of the predicted actions.\n *\n * Plans support a DO command which specifies the name of an action to call and an optional set of entities that should be passed to the action. The internal plan executor will call the registered handler for the action passing in the current context, state, and entities.\n *\n * Additionally, the AI system itself uses actions to handle things like unknown actions, flagged input, and flagged output. You can override these actions by registering your own handler for them. The names of the built-in actions are available as static properties on the AI class.  @template TParameters Optional. The type of parameters that the action handler expects.\n *\n * @param name - Unique name of the action.  @callback handler\n *\n * @param handler - The code to execute when the action's name is triggered.\n *\n * @param  - {TurnContext} handler.context The current turn context for the handler callback.\n *\n * @param  - {TState} handler.state The current turn state for the handler callback.\n *\n * @param  - {TParameters} handler.parameters Optional. Entities to pass to the action.\n *\n * @returns {this} The AI system instance for chaining purposes.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2714,7 +2714,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!AI#defaultAction:member(1)",
-              "docComment": "/**\n * Registers the default handler for a named action.\n *\n * @remarks\n *\n * Default handlers can be replaced by calling the action() method with the same name.  @template TParameters Optional. The type of parameters that the action handler expects.\n *\n * @param name - Unique name of the action.  @callback handler\n *\n * @param handler - The code to execute when the _ is triggered.\n *\n * @param  - {TurnContext} handler.context The current turn context for the handler callback.\n *\n * @param  - {TState} handler.state The current turn state for the handler callback.\n *\n * @returns {this} The AI system instance for chaining purposes.\n */\n",
+              "docComment": "/**\n * Registers the default handler for a named action.\n *\n * @remarks\n *\n * Default handlers can be replaced by calling the action() method with the same name.  @template TParameters Optional. The type of parameters that the action handler expects.\n *\n * @param name - Unique name of the action.  @callback handler\n *\n * @param handler - The code to execute when the action's name is triggered.\n *\n * @param  - {TurnContext} handler.context The current turn context for the handler callback.\n *\n * @param  - {TState} handler.state The current turn state for the handler callback.\n *\n * @returns {this} The AI system instance for chaining purposes.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -4179,6 +4179,81 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@microsoft/teams-ai!Application#error:member(1)",
+              "docComment": "/**\n * Sets the bot's error handler\n *\n * @param handler - Function to call when an error is encountered.\n *\n * @returns {this} The application instance for chaining purposes.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "error(handler: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(context: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TurnContext",
+                  "canonicalReference": "botbuilder-core!TurnContext:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", error: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Error",
+                  "canonicalReference": "!Error:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "this"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 9,
+                "endIndex": 10
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "handler",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 8
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "error"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!Application#fileConsentAccept:member(1)",
               "docComment": "/**\n * Registers a handler to process when a file consent card is accepted by the user.\n *\n * @param handler - Function to call when the route is triggered.\n *\n * @returns {this} The application instance for chaining purposes.\n */\n",
               "excerptTokens": [
@@ -4934,7 +5009,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!Application#sendProactiveActivity:member(1)",
-              "docComment": "/**\n * Sends a proactive activity to an existing conversation the bot is a member of.\n *\n * @remarks\n *\n * This method provides a simple way to send a proactive message to a conversation the bot is a member of.\n *\n * Use of the method requires you configure the Application with the `adapter` and `botAppId` options. An exception will be thrown if either is missing.\n *\n * @param context - Context of the conversation to proactively message. This can be derived from either a TurnContext, ConversationReference, or Activity.\n *\n * @param activityOrText - Activity or message to send to the conversation.\n *\n * @param speak - Optional. Text to speak for channels that support voice.\n *\n * @param inputHint - Optional. Input hint for channels that support voice.\n *\n * @returns A Resource response containing the ID of the activity that was sent.\n */\n",
+              "docComment": "/**\n * Sends a proactive activity to an existing conversation the bot is a member of.\n *\n * @remarks\n *\n * This method provides a simple way to send a proactive message to a conversation the bot is a member of.\n *\n * Use of the method requires you configure the Application with the `adapter.appId` options. An exception will be thrown if either is missing.\n *\n * @param context - Context of the conversation to proactively message. This can be derived from either a TurnContext, ConversationReference, or Activity.\n *\n * @param activityOrText - Activity or message to send to the conversation.\n *\n * @param speak - Optional. Text to speak for channels that support voice.\n *\n * @param inputHint - Optional. Input hint for channels that support voice.\n *\n * @returns A Resource response containing the ID of the activity that was sent.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -5661,7 +5736,7 @@
               "text": "> "
             }
           ],
-          "fileUrlPath": "src/Application.ts",
+          "fileUrlPath": "src/ApplicationBuilder.ts",
           "releaseTag": "Public",
           "typeParameters": [
             {
@@ -5925,8 +6000,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "BotAdapter",
-                  "canonicalReference": "botbuilder-core!BotAdapter:class"
+                  "text": "TeamsAdapter",
+                  "canonicalReference": "@microsoft/teams-ai!TeamsAdapter:class"
                 },
                 {
                   "kind": "Content",
@@ -5991,8 +6066,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "BotAdapter",
-                  "canonicalReference": "botbuilder-core!BotAdapter:class"
+                  "text": "TeamsAdapter",
+                  "canonicalReference": "@microsoft/teams-ai!TeamsAdapter:class"
                 },
                 {
                   "kind": "Content",
@@ -6234,7 +6309,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!ApplicationOptions#adapter:member",
-              "docComment": "/**\n * Optional. Bot adapter being used.\n *\n * @remarks\n *\n * If using the `longRunningMessages` option or calling the continueConversationAsync() method, this property is required.\n */\n",
+              "docComment": "/**\n * Optional. Options used to initialize your `BotAdapter`\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -6242,8 +6317,8 @@
                 },
                 {
                   "kind": "Reference",
-                  "text": "BotAdapter",
-                  "canonicalReference": "botbuilder-core!BotAdapter:class"
+                  "text": "TeamsAdapter",
+                  "canonicalReference": "@microsoft/teams-ai!TeamsAdapter:class"
                 },
                 {
                   "kind": "Content",
@@ -7989,6 +8064,79 @@
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 6
+              }
+            }
+          ],
+          "extendsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "@microsoft/teams-ai!AuthenticatorResult:interface",
+          "docComment": "",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface AuthenticatorResult "
+            }
+          ],
+          "fileUrlPath": "src/TeamsAttachmentDownloader.ts",
+          "releaseTag": "Public",
+          "name": "AuthenticatorResult",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@microsoft/teams-ai!AuthenticatorResult#accessToken:member",
+              "docComment": "/**\n * The value of the access token resulting from an authentication process.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "accessToken: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "accessToken",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "@microsoft/teams-ai!AuthenticatorResult#expiresOn:member",
+              "docComment": "/**\n * The date and time of expiration relative to Coordinated Universal Time (UTC).\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "expiresOn: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Date",
+                  "canonicalReference": "!Date:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "expiresOn",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
               }
             }
           ],
@@ -10079,7 +10227,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!ConfiguredPromptManagerOptions#max_conversation_history_tokens:member",
-              "docComment": "/**\n * Maximum number of tokens to of conversation history to include in prompts.\n */\n",
+              "docComment": "/**\n * Maximum number of tokens of conversation history to include in prompts.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -10133,7 +10281,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!ConfiguredPromptManagerOptions#max_input_tokens:member",
-              "docComment": "/**\n * Maximum number of tokens user input to include in prompts.\n */\n",
+              "docComment": "/**\n * Maximum number of tokens of user input to include in prompts.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -11739,7 +11887,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!DefaultResponseValidator#validateResponse:member(1)",
-              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns {PromptResponseValidator<TValue>} A `Validation` object.\n */\n",
+              "docComment": "/**\n * Validates a response to a prompt.\n *\n * @param context - Context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use for encoding and decoding text.\n *\n * @param response - Response to validate.\n *\n * @param remaining_attempts - Number of remaining attempts to validate the response.\n *\n * @returns {Promise<Validation<TValue>>} A `Validation` object.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -13085,6 +13233,135 @@
         },
         {
           "kind": "Class",
+          "canonicalReference": "@microsoft/teams-ai!GPTTokenizer:class",
+          "docComment": "/**\n * Tokenizer that uses GPT's cl100k_base encoding. To use GPT-3 encoding, pass in an instance of GPT3Tokenizer.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare class GPTTokenizer implements "
+            },
+            {
+              "kind": "Reference",
+              "text": "Tokenizer",
+              "canonicalReference": "@microsoft/teams-ai!Tokenizer:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "src/tokenizers/GPTTokenizer.ts",
+          "releaseTag": "Public",
+          "isAbstract": false,
+          "name": "GPTTokenizer",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "Method",
+              "canonicalReference": "@microsoft/teams-ai!GPTTokenizer#decode:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "decode(tokens: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "tokens",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "decode"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@microsoft/teams-ai!GPTTokenizer#encode:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "encode(text: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "text",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "encode"
+            }
+          ],
+          "implementsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 2
+            }
+          ]
+        },
+        {
+          "kind": "Class",
           "canonicalReference": "@microsoft/teams-ai!GroupSection:class",
           "docComment": "/**\n * A group of sections that will rendered as a single message.\n */\n",
           "excerptTokens": [
@@ -13990,36 +14267,6 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "@microsoft/teams-ai!JSONResponseValidator#instanceName:member",
-              "docComment": "/**\n * Optional. Substitution for the word \"instance\" to use in feedback messages.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "instanceName?: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": true,
-              "releaseTag": "Public",
-              "name": "instanceName",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              },
-              "isStatic": false,
-              "isProtected": false,
-              "isAbstract": false
-            },
-            {
-              "kind": "Property",
               "canonicalReference": "@microsoft/teams-ai!JSONResponseValidator#missingJsonFeedback:member",
               "docComment": "/**\n * Feedback given when no JSON is returned.\n */\n",
               "excerptTokens": [
@@ -14736,7 +14983,7 @@
         {
           "kind": "Class",
           "canonicalReference": "@microsoft/teams-ai!LLMClient:class",
-          "docComment": "/**\n * LLMClient class that's used to complete prompts.\n *\n * @remarks\n *\n * Each wave, at a minimum needs to be configured with a `client`, `prompt`, and `prompt_options`.\n *\n * Configuring the wave to use a `validator` is optional but recommended. The primary benefit to using LLMClient is it's response validation and automatic response repair features. The validator acts as guard and guarantees that you never get an malformed response back from the model. At least not without it being flagged as an `invalid_response`.\n *\n * Using the `JSONResponseValidator`, for example, guarantees that you only ever get a valid object back from `completePrompt()`. In fact, you'll get back a fully parsed object and any additional response text from the model will be dropped. If you give the `JSONResponseValidator` a JSON Schema, you will get back a strongly typed and validated instance of an object in the returned `response.message.content`.\n *\n * When a validator detects a bad response from the model, it gives the model \"feedback\" as to the problem it detected with its response and more importantly an instruction that tells the model how it should repair the problem. This puts the wave into a special repair mode where it first forks the memory for the conversation and then has a side conversation with the model in an effort to get it to repair its response. By forking the conversation, this isolates the bad response and prevents it from contaminating the main conversation history. If the response can be repaired, the wave will un-fork the memory and use the repaired response in place of the original bad response. To the model it's as if it never made a mistake which is important for future turns with the model. If the response can't be repaired, a response status of `invalid_response` will be returned.\n *\n * When using a well designed validator, like the `JSONResponseValidator`, the wave can typically repair a bad response in a single additional model call. Sometimes it takes a couple of calls to effect a repair and occasionally it won't be able to repair it at all. If your prompt is well designed and you only occasionally see failed repair attempts, I'd recommend just calling the wave a second time. Given the stochastic nature of these models, there's a decent chance it won't make the same mistake on the second call. A well designed prompt coupled with a well designed validator should get the reliability of calling these models somewhere close to 99% reliable.\n *\n * This \"feedback\" technique works with all the GPT-3 generation of models and I've tested it with `text-davinci-003`, `gpt-3.5-turbo`, and `gpt-4`. There's a good chance it will work with other open source models like `LLaMA` and Googles `Bard` but I have yet to test it with those models.\n *\n * LLMClient supports OpenAI's functions feature and can validate the models response against the schema for the supported functions. When an LLMClient is configured with both a `OpenAIModel` and a `FunctionResponseValidator`, the model will be cloned and configured to send the validators configured list of functions with the request. There's no need to separately configure the models `functions` list, but if you do, the models functions list will be sent instead.  @template TContent Optional. Type of message content returned for a 'success' response. The `response.message.content` field will be of type TContent. Defaults to `any`.\n */\n",
+          "docComment": "/**\n * Represents an LLM (Language Learning Model) client. This class provides methods for configuring and interacting with the LLM model.  @template TContent The type of message content returned for a 'success' response.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -14891,7 +15138,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!LLMClient#completePrompt:member(1)",
-              "docComment": "/**\n * Completes a prompt.\n *\n * @remarks\n *\n * The `input` parameter is optional but if passed in, will be assigned to memory using the configured `input_variable`. If it's not passed in an attempt will be made to read it from memory so passing it in or assigning to memory works. In either case, the `input` variable is only used when constructing a user message that, will be added to the conversation history and formatted like `{ role: 'user', content: input }`.\n *\n * It's important to note that if you want the users input sent to the model as part of the prompt, you will need to add a `UserMessage` section to your prompt. The wave does not do anything to modify your prompt, except when performing repairs and those changes are temporary.\n *\n * When the model successfully returns a valid (or repaired) response, a 'user' message (if input was detected) and 'assistant' message will be automatically added to the conversation history. You can disable that behavior by setting `max_history_messages` to `0`.\n *\n * The response returned by `completePrompt()` will be strongly typed by the validator you're using. The `DefaultResponseValidator` returns a `string` and the `JSONResponseValidator` will return either an `object` or if a JSON Schema is provided, an instance of `TContent`. When using a custom validator, the validator is return any type of content it likes.\n *\n * A successful response is indicated by `response.status == 'success'` and the content can be accessed via `response.message.content`. If a response is invalid it will have a `response.status == 'invalid_response'` and the `response.message` will be a string containing the validator feedback message. There are other status codes for various errors and in all cases except `success` the `response.message` will be of type `string`.  @template TContent Optional. Type of message content returned for a 'success' response. The `response.message.content` field will be of type TContent. Defaults to `any`.\n *\n * @param context - Current turn context.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param functions - Functions to use when rendering the prompt.\n *\n * @returns A `PromptResponse` with the status and message.\n */\n",
+              "docComment": "/**\n * Completes a prompt.\n *\n * @remarks\n *\n * The `input` parameter is optional but if passed in, will be assigned to memory using the configured `input_variable`. If it's not passed in an attempt will be made to read it from memory so passing it in or assigning to memory works. In either case, the `input` variable is only used when constructing a user message that, will be added to the conversation history and formatted like `{ role: 'user', content: input }`.\n *\n * It's important to note that if you want the users input sent to the model as part of the prompt, you will need to add a `UserMessage` section to your prompt. The wave does not do anything to modify your prompt, except when performing repairs and those changes are temporary.\n *\n * When the model successfully returns a valid (or repaired) response, a 'user' message (if input was detected) and 'assistant' message will be automatically added to the conversation history. You can disable that behavior by setting `max_history_messages` to `0`.\n *\n * The response returned by `completePrompt()` will be strongly typed by the validator you're using. The `DefaultResponseValidator` returns a `string` and the `JSONResponseValidator` will return either an `object` or if a JSON Schema is provided, an instance of `TContent`. When using a custom validator, the validator is return any type of content it likes.\n *\n * A successful response is indicated by `response.status == 'success'` and the content can be accessed via `response.message.content`. If a response is invalid it will have a `response.status == 'invalid_response'` and the `response.message` will be a string containing the validator feedback message. There are other status codes for various errors and in all cases except `success` the `response.message` will be of type `string`.  @template TContent Optional. Type of message content returned for a 'success' response. The `response.message.content` field will be of type TContent. Defaults to `any`.\n *\n * @param context - Current turn context.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param functions - Functions to use when rendering the prompt.\n *\n * @returns {Promise<PromptResponse<TContent>>} A `PromptResponse` with the status and message.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -15253,7 +15500,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!LLMClientOptions#tokenizer:member",
-              "docComment": "/**\n * Optional. Tokenizer to use when rendering the prompt or counting tokens.\n *\n * @remarks\n *\n * If not specified a new instance of `GPT3Tokenizer` will be created.\n */\n",
+              "docComment": "/**\n * Optional. Tokenizer to use when rendering the prompt or counting tokens.\n *\n * @remarks\n *\n * If not specified, a new instance of `GPTTokenizer` will be created. GPT3Tokenizer can be passed in for gpt-3 models.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -15376,7 +15623,7 @@
             {
               "kind": "MethodSignature",
               "canonicalReference": "@microsoft/teams-ai!Memory#getValue:member(1)",
-              "docComment": "/**\n * Retrieves a value from the memory.\n *\n * @param path - Path to the value to retrieve in the form of `[scope].property`. If scope is omitted, the value is retrieved from the temporary scope.\n *\n * @returns The value or undefined if not found.\n */\n",
+              "docComment": "/**\n * Retrieves a value from the memory.  @template TValue Type of the value to retrieve.\n *\n * @param path - Path to the value to retrieve in the form of `[scope].property`. If scope is omitted, the value is retrieved from the temporary scope.\n *\n * @returns The value or undefined if not found.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -15657,7 +15904,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!MemoryFork#getValue:member(1)",
-              "docComment": "/**\n * Retrieves a value from the memory.\n *\n * @remarks\n *\n * The forked memory is checked first, then the original memory.\n *\n * @param path - Path to the value to retrieve in the form of `[scope].property`. If scope is omitted, the value is retrieved from the temporary scope.\n *\n * @returns {unknown | undefined} The value or undefined if not found.\n */\n",
+              "docComment": "/**\n * Retrieves a value from the memory.  @template TValue Type of the value to retrieve.\n *\n * @remarks\n *\n * The forked memory is checked first, then the original memory.\n *\n * @param path - Path to the value to retrieve in the form of `[scope].property`. If scope is omitted, the value is retrieved from the temporary scope.\n *\n * @returns {TValue | undefined} The value or undefined if not found.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -18376,7 +18623,7 @@
             },
             {
               "kind": "Content",
-              "text": " & {\n    tokenExchangeUri?: string;\n}"
+              "text": " & {\n    tokenExchangeUri?: string;\n    enableSso?: boolean;\n}"
             },
             {
               "kind": "Content",
@@ -22012,7 +22259,7 @@
             {
               "kind": "Constructor",
               "canonicalReference": "@microsoft/teams-ai!Prompt:constructor(1)",
-              "docComment": "/**\n * Creates a new 'Prompt' instance.\n *\n * @param sections - Sections to render.\n *\n * @param tokens - Optional. Sizing strategy for this section. Defaults to `auto`.\n *\n * @param required - Optional. Indicates if this section is required. Defaults to `true`.\n *\n * @param separator - Optional. Separator to use between sections when rendering as text. Defaults to `\\n\\n`.\n */\n",
+              "docComment": "/**\n * Creates a new 'Prompt' instance.\n *\n * @param sections - Sections to render.\n *\n * @param tokens - Optional. Sizing strategy for this section. Defaults to -1, 'auto'.\n *\n * @param required - Optional. Indicates if this section is required. Defaults to `true`.\n *\n * @param separator - Optional. Separator to use between sections when rendering as text. Defaults to `\\n\\n`.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22572,7 +22819,7 @@
             {
               "kind": "Constructor",
               "canonicalReference": "@microsoft/teams-ai!PromptManager:constructor(1)",
-              "docComment": "/**\n * Creates a new 'PromptManager' instance.\n *\n * @param options - Options used to configure the prompt manager.\n */\n",
+              "docComment": "/**\n * Creates a new 'PromptManager' instance.\n *\n * @param options - Options used to configure the prompt manager.\n *\n * @returns {PromptManager} A new prompt manager instance.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22605,7 +22852,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#addDataSource:member(1)",
-              "docComment": "/**\n * Registers a new data source with the prompt manager.\n *\n * @param dataSource - Data source to add.\n *\n * @returns The prompt manager for chaining.\n */\n",
+              "docComment": "/**\n * Registers a new data source with the prompt manager.\n *\n * @param dataSource - Data source to add.\n *\n * @returns {this} The prompt manager for chaining.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22654,7 +22901,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#addFunction:member(1)",
-              "docComment": "/**\n * Registers a new prompt template function with the prompt manager.\n *\n * @param name - Name of the function to add.\n *\n * @param fn - Function to add.\n *\n * @returns The prompt manager for chaining.\n */\n",
+              "docComment": "/**\n * Registers a new prompt template function with the prompt manager.\n *\n * @param name - Name of the function to add.\n *\n * @param fn - Function to add.\n *\n * @returns {this} - The prompt manager for chaining.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22719,7 +22966,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#addPrompt:member(1)",
-              "docComment": "/**\n * Registers a new prompt template with the prompt manager.\n *\n * @param prompt - Prompt template to add.\n *\n * @returns The prompt manager for chaining.\n */\n",
+              "docComment": "/**\n * Registers a new prompt template with the prompt manager.\n *\n * @param prompt - Prompt template to add.\n *\n * @returns {this} The prompt manager for chaining.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22768,7 +23015,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#getDataSource:member(1)",
-              "docComment": "/**\n * Looks up a data source by name.\n *\n * @param name - Name of the data source to lookup.\n *\n * @returns The data source.\n */\n",
+              "docComment": "/**\n * Looks up a data source by name.\n *\n * @param name - Name of the data source to lookup.\n *\n * @returns {DataSource} The data source.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22817,7 +23064,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#getFunction:member(1)",
-              "docComment": "/**\n * Looks up a prompt template function by name.\n *\n * @param name - Name of the function to lookup.\n *\n * @returns The function.\n */\n",
+              "docComment": "/**\n * Looks up a prompt template function by name.\n *\n * @param name - Name of the function to lookup.\n *\n * @returns {PromptFunction} The function.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22866,7 +23113,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#getPrompt:member(1)",
-              "docComment": "/**\n * Loads a named prompt template from the filesystem.\n *\n * @remarks\n *\n * The template will be pre-parsed and cached for use when the template is rendered by name.\n *\n * Any augmentations will also be added to the template.\n *\n * @param name - Name of the prompt to load.\n *\n * @returns The loaded and parsed prompt template.\n */\n",
+              "docComment": "/**\n * Loads a named prompt template from the filesystem.\n *\n * @remarks\n *\n * The template will be pre-parsed and cached for use when the template is rendered by name.\n *\n * Any augmentations will also be added to the template.\n *\n * @param name - Name of the prompt to load.\n *\n * @returns {Promise<PromptTemplate>} The loaded and parsed prompt template.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22928,7 +23175,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#hasDataSource:member(1)",
-              "docComment": "/**\n * Checks for the existence of a named data source.\n *\n * @param name - Name of the data source to lookup.\n *\n * @returns True if the data source exists.\n */\n",
+              "docComment": "/**\n * Checks for the existence of a named data source.\n *\n * @param name - Name of the data source to lookup.\n *\n * @returns {boolean} True if the data source exists.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -22976,7 +23223,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#hasFunction:member(1)",
-              "docComment": "/**\n * Checks for the existence of a named prompt template function.\n *\n * @param name - Name of the function to lookup.\n *\n * @returns True if the function exists.\n */\n",
+              "docComment": "/**\n * Checks for the existence of a named prompt template function.\n *\n * @param name - Name of the function to lookup.\n *\n * @returns {boolean} True if the function exists.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23024,7 +23271,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#hasPrompt:member(1)",
-              "docComment": "/**\n * Checks for the existence of a named prompt.\n *\n * @param name - Name of the prompt to load.\n *\n * @returns True if the prompt exists.\n */\n",
+              "docComment": "/**\n * Checks for the existence of a named prompt.\n *\n * @param name - Name of the prompt to load.\n *\n * @returns {boolean} True if the prompt exists.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23077,7 +23324,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#invokeFunction:member(1)",
-              "docComment": "/**\n * Invokes a prompt template function by name.\n *\n * @param name - Name of the function to invoke.\n *\n * @param context - Turn context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use when rendering the prompt.\n *\n * @param args - Arguments to pass to the function.\n *\n * @returns Value returned by the function.\n */\n",
+              "docComment": "/**\n * Invokes a prompt template function by name.\n *\n * @param name - Name of the function to invoke.\n *\n * @param context - Turn context for the current turn of conversation with the user.\n *\n * @param memory - An interface for accessing state values.\n *\n * @param tokenizer - Tokenizer to use when rendering the prompt.\n *\n * @param args - Arguments to pass to the function.\n *\n * @returns {Promise<any>} Value returned by the function.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23197,7 +23444,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@microsoft/teams-ai!PromptManager#options:member",
-              "docComment": "/**\n * Gets the configured prompt manager options.\n */\n",
+              "docComment": "/**\n * Gets the configured prompt manager options.\n *\n * @returns {ConfiguredPromptManagerOptions} The configured prompt manager options.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23251,7 +23498,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!PromptManagerOptions#max_conversation_history_tokens:member",
-              "docComment": "/**\n * Optional. Maximum number of tokens to of conversation history to include in prompts.\n *\n * @remarks\n *\n * The default is to let conversation history consume the remainder of the prompts `max_input_tokens` budget. Setting this a value greater then 1 will override that and all prompts will use a fixed token budget.\n */\n",
+              "docComment": "/**\n * Optional. Maximum number of tokens of conversation history to include in prompts.\n *\n * @remarks\n *\n * The default is to let conversation history consume the remainder of the prompts `max_input_tokens` budget. Setting this to a value greater than 1 will override that and all prompts will use a fixed token budget.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23305,7 +23552,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!PromptManagerOptions#max_input_tokens:member",
-              "docComment": "/**\n * Optional. Maximum number of tokens user input to include in prompts.\n *\n * @remarks\n *\n * This defaults to unlimited but can set to a value greater then `1` to limit the length of user input included in prompts. For example, if set to `100` then the any user input over 100 tokens in length will be truncated.\n */\n",
+              "docComment": "/**\n * Optional. Maximum number of tokens user input to include in prompts.\n *\n * @remarks\n *\n * This defaults to unlimited but can be set to a value greater than `1` to limit the length of user input included in prompts. For example, if set to `100` then the any user input over 100 tokens in length will be truncated.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -23332,7 +23579,7 @@
             {
               "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!PromptManagerOptions#promptsFolder:member",
-              "docComment": "/**\n * Path to the filesystem folder containing all the applications prompts.\n */\n",
+              "docComment": "/**\n * Path to the filesystem folder containing all the application's prompts.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -24104,7 +24351,7 @@
             {
               "kind": "Constructor",
               "canonicalReference": "@microsoft/teams-ai!PromptSectionBase:constructor(1)",
-              "docComment": "/**\n * Creates a new 'PromptSectionBase' instance.\n *\n * @param tokens - Optional. Sizing strategy for this section. Defaults to `auto`.\n *\n * @param required - Optional. Indicates if this section is required. Defaults to `true`.\n *\n * @param separator - Optional. Separator to use between sections when rendering as text. Defaults to `\\n`.\n *\n * @param textPrefix - Optional. Prefix to use for text output. Defaults to `undefined`.\n */\n",
+              "docComment": "/**\n * Creates a new 'PromptSectionBase' instance.\n *\n * @param tokens - Optional. Sizing strategy for this section. Defaults to -1, 'auto'.\n *\n * @param required - Optional. Indicates if this section is required. Defaults to `true`.\n *\n * @param separator - Optional. Separator to use between sections when rendering as text. Defaults to `\\n`.\n *\n * @param textPrefix - Optional. Prefix to use for text output. Defaults to an empty string.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -24184,7 +24431,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptSectionBase.getMessageText:member(1)",
-              "docComment": "/**\n * Returns the content of a message as a string.\n *\n * @param message - Message to get the text of.\n *\n * @returns The message content as a string.\n */\n",
+              "docComment": "/**\n * Returns the content of a message as a string.\n *\n * @param message - Message to get the text of.\n *\n * @returns {string} The message content as a string.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -24233,7 +24480,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptSectionBase#getTokenBudget:member(1)",
-              "docComment": "/**\n * Calculates the token budget for the prompt section.\n *\n * @remarks\n *\n * If the section has a fixed length, the budget will be the minimum of the section's length and the maximum number of tokens. Otherwise, the budget will be the maximum number of tokens.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns The token budget for the prompt section.\n */\n",
+              "docComment": "/**\n * Calculates the token budget for the prompt section.\n *\n * @remarks\n *\n * If the section has a fixed length, the budget will be the minimum of the section's length and the maximum number of tokens. Otherwise, the budget will be the maximum number of tokens.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns {number} The token budget for the prompt section.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -24281,7 +24528,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptSectionBase#renderAsMessages:member(1)",
-              "docComment": "/**\n * Renders the prompt section as a list of `Message` objects.\n *\n * @remarks\n *\n * MUST be implemented by derived classes.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - Interface for accessing state variables.\n *\n * @param functions - Functions for rendering prompts.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns The rendered prompt section.\n */\n",
+              "docComment": "/**\n * Renders the prompt section as a list of `Message` objects.\n *\n * @remarks\n *\n * MUST be implemented by derived classes.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - Interface for accessing state variables.\n *\n * @param functions - Functions for rendering prompts.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns {Promise<RenderedPromptSection<Message<any>[]>>} The rendered prompt section.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -24420,7 +24667,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptSectionBase#renderAsText:member(1)",
-              "docComment": "/**\n * Renders the prompt section as a string of text.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - Interface for accessing state variables.\n *\n * @param functions - Functions for rendering prompts.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns The rendered prompt section.\n */\n",
+              "docComment": "/**\n * Renders the prompt section as a string of text.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param memory - Interface for accessing state variables.\n *\n * @param functions - Functions for rendering prompts.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns {Promise<RenderedPromptSection<string>>} The rendered prompt section.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -24580,7 +24827,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!PromptSectionBase#returnMessages:member(1)",
-              "docComment": "/**\n * Helper method for returning a list of messages from `renderAsMessages()`.\n *\n * @remarks\n *\n * If the section has a fixed length, the function will truncate the list of messages to fit within the token budget.\n *\n * @param output - List of messages to return.\n *\n * @param length - Total number of tokens consumed by the list of messages.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns The rendered prompt section.\n */\n",
+              "docComment": "/**\n * Helper method for returning a list of messages from `renderAsMessages()`.\n *\n * @remarks\n *\n * If the section has a fixed length, the function will truncate the list of messages to fit within the token budget.\n *\n * @param output - List of messages to return.\n *\n * @param length - Total number of tokens consumed by the list of messages.\n *\n * @param tokenizer - Tokenizer to use for encoding/decoding text.\n *\n * @param maxTokens - Maximum number of tokens allowed for the rendered prompt.\n *\n * @returns {RenderedPromptSection<Message[]>} The rendered prompt section.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -26849,6 +27096,439 @@
         },
         {
           "kind": "Class",
+          "canonicalReference": "@microsoft/teams-ai!TeamsAdapter:class",
+          "docComment": "/**\n * An adapter that implements the Bot Framework Protocol and can be hosted in different cloud environments both public and private.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare class TeamsAdapter extends "
+            },
+            {
+              "kind": "Reference",
+              "text": "CloudAdapter",
+              "canonicalReference": "botbuilder!CloudAdapter:class"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "fileUrlPath": "src/TeamsAdapter.ts",
+          "releaseTag": "Public",
+          "isAbstract": false,
+          "name": "TeamsAdapter",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "Constructor",
+              "canonicalReference": "@microsoft/teams-ai!TeamsAdapter:constructor(1)",
+              "docComment": "/**\n * Constructs a new instance of the `TeamsAdapter` class\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "constructor(botFrameworkAuthConfig?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        MicrosoftAppId?: string | undefined;\n        MicrosoftAppTenantId?: string | undefined;\n        OAuthApiEndpoint?: string | undefined;\n        BotOpenIdMetadata?: string | undefined;\n        ChannelService?: string | undefined;\n        ValidateAuthority?: string | boolean | undefined;\n        ToChannelFromBotLoginUrl?: string | undefined;\n        ToChannelFromBotOAuthScope?: string | undefined;\n        ToBotFromChannelTokenIssuer?: string | undefined;\n        OAuthUrl?: string | undefined;\n        ToBotFromChannelOpenIdMetadataUrl?: string | undefined;\n        ToBotFromEmulatorOpenIdMetadataUrl?: string | undefined;\n        CallerId?: string | undefined;\n        CertificateThumbprint?: string | undefined;\n        CertificatePrivateKey?: string | undefined;\n    } | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", credentialsFactory?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ServiceClientCredentialsFactory",
+                  "canonicalReference": "botframework-connector!ServiceClientCredentialsFactory:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", authConfiguration?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "AuthenticationConfiguration",
+                  "canonicalReference": "botframework-connector!AuthenticationConfiguration:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", connectorClientOptions?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ConnectorClientOptions",
+                  "canonicalReference": "botframework-connector!ConnectorClientOptions:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ");"
+                }
+              ],
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "botFrameworkAuthConfig",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": true
+                },
+                {
+                  "parameterName": "credentialsFactory",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": true
+                },
+                {
+                  "parameterName": "authConfiguration",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  },
+                  "isOptional": true
+                },
+                {
+                  "parameterName": "connectorClientOptions",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
+                  },
+                  "isOptional": true
+                }
+              ]
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@microsoft/teams-ai!TeamsAdapter#botFrameworkAuthConfig:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly botFrameworkAuthConfig?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        MicrosoftAppId?: string | undefined;\n        MicrosoftAppTenantId?: string | undefined;\n        OAuthApiEndpoint?: string | undefined;\n        BotOpenIdMetadata?: string | undefined;\n        ChannelService?: string | undefined;\n        ValidateAuthority?: string | boolean | undefined;\n        ToChannelFromBotLoginUrl?: string | undefined;\n        ToChannelFromBotOAuthScope?: string | undefined;\n        ToBotFromChannelTokenIssuer?: string | undefined;\n        OAuthUrl?: string | undefined;\n        ToBotFromChannelOpenIdMetadataUrl?: string | undefined;\n        ToBotFromEmulatorOpenIdMetadataUrl?: string | undefined;\n        CallerId?: string | undefined;\n        CertificateThumbprint?: string | undefined;\n        CertificatePrivateKey?: string | undefined;\n    } | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": true,
+              "releaseTag": "Public",
+              "name": "botFrameworkAuthConfig",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@microsoft/teams-ai!TeamsAdapter#credentialsFactory:member",
+              "docComment": "/**\n * The credentials factory used by the bot adapter to create a [ServiceClientCredentials](xref:botframework-connector.ServiceClientCredentials) object.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "readonly credentialsFactory: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "ServiceClientCredentialsFactory",
+                  "canonicalReference": "botframework-connector!ServiceClientCredentialsFactory:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "credentialsFactory",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@microsoft/teams-ai!TeamsAdapter#process:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "process(req: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Request",
+                  "canonicalReference": "botbuilder!Request:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", res: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Response",
+                  "canonicalReference": "botbuilder!Response:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", logic: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(context: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TurnContext",
+                  "canonicalReference": "botbuilder-core!TurnContext:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 11,
+                "endIndex": 13
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "req",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "res",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "logic",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 10
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "process"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@microsoft/teams-ai!TeamsAdapter#process:member(2)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "process(req: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Request",
+                  "canonicalReference": "botbuilder!Request:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", socket: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "INodeSocket",
+                  "canonicalReference": "botframework-streaming!INodeSocket:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", head: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "INodeBuffer",
+                  "canonicalReference": "botframework-streaming!INodeBuffer:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", logic: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(context: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TurnContext",
+                  "canonicalReference": "botbuilder-core!TurnContext:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ") => "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Promise",
+                  "canonicalReference": "!Promise:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": "<void>"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 13,
+                "endIndex": 15
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 2,
+              "parameters": [
+                {
+                  "parameterName": "req",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "socket",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "head",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "logic",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 12
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "process"
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@microsoft/teams-ai!TeamsAdapter#userAgent:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "get userAgent(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": true,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "userAgent",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            }
+          ],
+          "extendsTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          },
+          "implementsTokenRanges": []
+        },
+        {
+          "kind": "Class",
           "canonicalReference": "@microsoft/teams-ai!TeamsAttachmentDownloader:class",
           "docComment": "/**\n * Downloads attachments from Teams using the bots access token.\n */\n",
           "excerptTokens": [
@@ -26943,7 +27623,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!TeamsAttachmentDownloader#downloadFiles:member(1)",
-              "docComment": "/**\n * Download any files relative to the current user's input.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n */\n",
+              "docComment": "/**\n * Download any files relative to the current user's input.  @template TState - Type of the state object passed to the `TurnContext.turnState` method.\n *\n * @param context - Context for the current turn of conversation.\n *\n * @param state - Application state for the current turn of conversation.\n *\n * @returns {Promise<InputFile[]>} Promise that resolves to an array of downloaded input files.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -27044,6 +27724,34 @@
           "members": [
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@microsoft/teams-ai!TeamsAttachmentDownloaderOptions#adapter:member",
+              "docComment": "/**\n * ServiceClientCredentialsFactory\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "adapter: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TeamsAdapter",
+                  "canonicalReference": "@microsoft/teams-ai!TeamsAdapter:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "adapter",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@microsoft/teams-ai!TeamsAttachmentDownloaderOptions#botAppId:member",
               "docComment": "/**\n * The Microsoft App ID of the bot.\n */\n",
               "excerptTokens": [
@@ -27064,33 +27772,6 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "botAppId",
-              "propertyTypeTokenRange": {
-                "startIndex": 1,
-                "endIndex": 2
-              }
-            },
-            {
-              "kind": "PropertySignature",
-              "canonicalReference": "@microsoft/teams-ai!TeamsAttachmentDownloaderOptions#botAppPassword:member",
-              "docComment": "/**\n * The Microsoft App Password of the bot.\n */\n",
-              "excerptTokens": [
-                {
-                  "kind": "Content",
-                  "text": "botAppPassword: "
-                },
-                {
-                  "kind": "Content",
-                  "text": "string"
-                },
-                {
-                  "kind": "Content",
-                  "text": ";"
-                }
-              ],
-              "isReadonly": false,
-              "isOptional": false,
-              "releaseTag": "Public",
-              "name": "botAppPassword",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -28457,7 +29138,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@microsoft/teams-ai!TurnState#conversation:member",
-              "docComment": "/**\n * Gets the conversation state from the turn state.  @template TConversationState\n *\n * @returns {TConversationState} The conversation state.\n *\n * @throws\n *\n * Error if TurnState hasn't been loaded. Call loadState() first.\n */\n",
+              "docComment": "/**\n * Gets the conversation state from the turn state.  @template TConversationState\n *\n * @returns {TConversationState} The conversation state.\n *\n * @throws\n *\n * Error if TurnState hasn't been loaded. Call load() first.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -29097,7 +29778,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@microsoft/teams-ai!TurnState#temp:member",
-              "docComment": "/**\n * Accessor for the temp state.\n *\n * @returns {TTempState} The temp TurnState.\n *\n * @throws\n *\n * Error if TurnState hasn't been loaded. Call loadState() first.\n */\n",
+              "docComment": "/**\n * Accessor for the temp state.\n *\n * @returns {TTempState} The temp TurnState.\n *\n * @throws\n *\n * Error if TurnState hasn't been loaded. Call load() first.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -29793,7 +30474,7 @@
             {
               "kind": "Method",
               "canonicalReference": "@microsoft/teams-ai!Utilities.toString:member(1)",
-              "docComment": "/**\n * Converts a value to a string.\n *\n * @remarks\n *\n * Dates are converted to ISO strings and Objects are converted to JSON or YAML, whichever is shorter.\n *\n * @param tokenizer - Tokenizer to use for encoding.\n *\n * @param value - Value to convert.\n *\n * @param asJSON - Optional. If true objects will always be converted to JSON instead of YAML. Defaults to false.\n *\n * @returns Converted value.\n */\n",
+              "docComment": "/**\n * Converts a value to a string.\n *\n * @remarks\n *\n * Dates are converted to ISO strings and Objects are converted to JSON or YAML, whichever is shorter.\n *\n * @param tokenizer - Tokenizer to use for encoding.\n *\n * @param value - Value to convert.\n *\n * @param asJSON - Optional. If true objects will always be converted to JSON instead of YAML. Defaults to false.\n *\n * @returns {string} Converted value.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",

--- a/js/packages/api/teams-ai.api.md
+++ b/js/packages/api/teams-ai.api.md
@@ -48,6 +48,7 @@ export const ACTION_INVOKE_NAME = "adaptiveCard/action";
 // @public
 export class ActionAugmentationSection extends PromptSectionBase {
     constructor(actions: ChatCompletionAction[], callToAction: string);
+    // (undocumented)
     get actions(): Map<string, ChatCompletionAction>;
     renderAsMessages(context: TurnContext, memory: Memory, functions: PromptFunctions, tokenizer: Tokenizer, maxTokens: number): Promise<RenderedPromptSection<Message<string>[]>>;
 }
@@ -226,21 +227,14 @@ class AssistantsPlanner<TState extends TurnState = TurnState> implements Planner
     beginTask(context: TurnContext, state: TState, ai: AI<TState>): Promise<Plan>;
     continueTask(context: TurnContext, state: TState, ai: AI<TState>): Promise<Plan>;
     static createAssistant(apiKey: string, request: OpenAI.Beta.Assistants.AssistantCreateParams): Promise<OpenAI.Beta.Assistants.Assistant>;
-    // (undocumented)
     protected createMessage(thread_id: string, body: OpenAI.Beta.Threads.Messages.MessageCreateParams): Promise<OpenAI.Beta.Threads.Messages.ThreadMessage>;
-    // (undocumented)
     protected createRun(thread_id: string): Promise<OpenAI.Beta.Threads.Runs.Run>;
-    // (undocumented)
     protected createThread(request: OpenAI.Beta.Threads.ThreadCreateParams): Promise<OpenAI.Beta.Threads.Thread>;
-    // (undocumented)
     protected listMessages(thread_id: string): Promise<OpenAI.Beta.Threads.Messages.ThreadMessagesPage>;
     get openai(): OpenAI;
     protected retrieveAssistant(): Promise<OpenAI.Beta.Assistants.Assistant>;
-    // (undocumented)
     protected retrieveLastRun(thread_id: string): Promise<OpenAI.Beta.Threads.Runs.Run | null>;
-    // (undocumented)
     protected retrieveRun(thread_id: string, run_id: string): Promise<OpenAI.Beta.Threads.Runs.Run>;
-    // (undocumented)
     protected submitToolOutputs(thread_id: string, run_id: string, tool_outputs: OpenAI.Beta.Threads.Runs.RunSubmitToolOutputsParams): Promise<OpenAI.Beta.Threads.Runs.Run>;
 }
 
@@ -455,6 +449,7 @@ export class DataSourceSection extends PromptSectionBase {
 // @public
 export class DefaultAugmentation implements Augmentation<string> {
     createPlanFromResponse(context: TurnContext_2, memory: Memory, response: PromptResponse<string>): Promise<Plan>;
+    // (undocumented)
     createPromptSection(): PromptSection | undefined;
     validateResponse(context: TurnContext_2, memory: Memory, tokenizer: Tokenizer, response: PromptResponse<string>, remaining_attempts: number): Promise<Validation<string>>;
 }
@@ -722,6 +717,7 @@ export interface Moderator<TState extends TurnState = TurnState> {
 export class MonologueAugmentation implements Augmentation<InnerMonologue | undefined> {
     constructor(actions: ChatCompletionAction[]);
     createPlanFromResponse(context: TurnContext_2, memory: Memory, response: PromptResponse<InnerMonologue | undefined>): Promise<Plan>;
+    // (undocumented)
     createPromptSection(): PromptSection | undefined;
     validateResponse(context: TurnContext_2, memory: Memory, tokenizer: Tokenizer, response: PromptResponse<string>, remaining_attempts: number): Promise<Validation<InnerMonologue | undefined>>;
 }
@@ -757,7 +753,6 @@ export interface OpenAIEmbeddingsOptions extends BaseOpenAIEmbeddingsOptions {
 export class OpenAIModel implements PromptCompletionModel {
     constructor(options: OpenAIModelOptions | AzureOpenAIModelOptions);
     completePrompt(context: TurnContext, memory: Memory, functions: PromptFunctions, tokenizer: Tokenizer, template: PromptTemplate): Promise<PromptResponse<string>>;
-    // (undocumented)
     protected copyOptionsToRequest<TRequest>(target: Partial<TRequest>, src: any, fields: string[]): TRequest;
     // Warning: (ae-forgotten-export) The symbol "CreateChatCompletionRequest" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "CreateChatCompletionResponse" needs to be exported by the entry point index.d.ts
@@ -765,7 +760,6 @@ export class OpenAIModel implements PromptCompletionModel {
     // (undocumented)
     protected createChatCompletion(request: CreateChatCompletionRequest, model: string): Promise<AxiosResponse<CreateChatCompletionResponse>>;
     readonly options: OpenAIModelOptions | AzureOpenAIModelOptions;
-    // (undocumented)
     protected post<TData>(url: string, body: object, retryCount?: number): Promise<AxiosResponse<TData>>;
 }
 
@@ -1119,6 +1113,7 @@ export interface TextContentPart {
 // @public
 export class TextDataSource implements DataSource {
     constructor(name: string, text: string);
+    // (undocumented)
     get name(): string;
     renderData(context: TurnContext, memory: Memory, tokenizer: Tokenizer, maxTokens: number): Promise<RenderedPromptSection<string>>;
 }

--- a/js/packages/teams-ai/README.md
+++ b/js/packages/teams-ai/README.md
@@ -1,15 +1,15 @@
 # Teams AI Library
 
-Welcome to the Teams AI Library JavaScript package! 
+Welcome to the Teams AI Library JavaScript package!
 
 This SDK is specifically designed to assist you in creating bots capable of interacting with Teams and Microsoft 365 applications. It is constructed using the [Bot Framework SDK](https://github.com/microsoft/botbuilder-js) as its foundation, simplifying the process of developing bots that interact with Teams' artificial intelligence capabilities. See the [Teams AI repo README.md](https://github.com/microsoft/teams-ai), for general information, and .Net support is available via the [dotnet](https://github.com/microsoft/teams-ai/tree/main/dotnet) folder.
 
 Requirements:
+
 -   node v16.x
 -   node v18.x
 
-To get started with the SDK [see](../../../getting-started/README.md). 
-
+To get started with the SDK [see](https://github.com/microsoft/teams-ai/tree/main/getting-started).
 
 ## Getting Started
 
@@ -17,4 +17,4 @@ To get started, take a look at the [getting started docs](https://github.com/mic
 
 ## Migration
 
-If you're migrating an existing project, switching to add on the Teams AI Library layer is quick and simple. See the [migration guide](https://github.com/microsoft/teams-ai/blob/main/getting-started/MIGRATION/02.JS.md).
+If you're migrating an existing project, switching to add on the Teams AI Library layer is quick and simple. See the [migration guide](https://github.com/microsoft/teams-ai/blob/main/getting-started/MIGRATION/JS.md).

--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -26,7 +26,7 @@
         "axios": "^1.6.7",
         "botbuilder": "^4.22.1",
         "botbuilder-dialogs": "^4.22.1",
-        "gpt-3-encoder": "^1.1.4",
+        "gpt-tokenizer": "^2.1.2",
         "json-colorizer": "^2.2.2",
         "jsonschema": "1.4.1",
         "openai": "^4.28.0",

--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -55,8 +55,8 @@
     },
     "scripts": {
         "build": "tsc -b",
-        "build:rollup": "yarn clean && yarn build && npx api-extractor run --verbose --local",
-        "clean": "rimraf _ts3.4 lib tsconfig.tsbuildinfo node_modules",
+        "build:rollup": "npx api-extractor run --verbose --local",
+        "clean": "npx rimraf _ts3.4 lib tsconfig.tsbuildinfo node_modules",
         "depcheck": "depcheck --config ../../.depcheckrc",
         "lint": "eslint **/src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern",
         "test": "npx mocha -r ts-node/register src/**/*.spec.ts",

--- a/js/packages/teams-ai/src/Application.ts
+++ b/js/packages/teams-ai/src/Application.ts
@@ -362,7 +362,7 @@ export class Application<TState extends TurnState = TurnState> {
 
     /**
      * Sets the bot's error handler
-     * @param handler Function to call when an error is encountered.
+     * @param {Function} handler Function to call when an error is encountered.
      * @returns {this} The application instance for chaining purposes.
      */
     public error(handler: (context: TurnContext, error: Error) => Promise<void>): this {

--- a/js/packages/teams-ai/src/Meetings.ts
+++ b/js/packages/teams-ai/src/Meetings.ts
@@ -20,7 +20,8 @@ export class Meetings<TState extends TurnState = TurnState> {
 
     /**
      * Handles meeting start events for Microsoft Teams.
-     * @param {(context: TurnContext, state: TState, meeting: MeetingStartEventDetails)} handler - Function to call when the handler is triggered.
+     * @template TState
+     * @param {Function} handler - Function to call when the handler is triggered.
      * @returns {Application<TState>} The application for chaining purposes.
      */
     public start(
@@ -46,7 +47,8 @@ export class Meetings<TState extends TurnState = TurnState> {
 
     /**
      * Handles meeting end events for Microsoft Teams.
-     * @param {(context: TurnContext, state: TState, meeting: MeetingEndEventDetails)} handler - Function to call when the handler is triggered.
+     * @template TState - The type of TurnState
+     * @param {Function} handler - Function to call when the handler is triggered.
      * @returns {Application<TState>} The application for chaining purposes.
      */
     public end(
@@ -72,7 +74,8 @@ export class Meetings<TState extends TurnState = TurnState> {
 
     /**
      * Handles meeting participant join events for Microsoft Teams.
-     * @param {(context: TurnContext, state: TState, meeting: MeetingParticipantsEventDetails)} handler - Function to call when the handler is triggered.
+     * @template TState
+     * @param {Function} handler - Function to call when the handler is triggered.
      * @returns {Application<TState>} The application for chaining purposes.
      */
     public participantsJoin(
@@ -98,7 +101,8 @@ export class Meetings<TState extends TurnState = TurnState> {
 
     /**
      * Handles meeting participant leave events for Microsoft Teams.
-     * @param {(context: TurnContext, state: TState, meeting: MeetingParticipantsEventDetails)} handler - Function to call when the handler is triggered.
+     * @template TState - The type of TurnState
+     * @param {Function} handler - Function to call when the handler is triggered.
      * @returns {Application<TState>} The application for chaining purposes.
      */
     public participantsLeave(

--- a/js/packages/teams-ai/src/Utilities.spec.ts
+++ b/js/packages/teams-ai/src/Utilities.spec.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from 'assert';
 import { Utilities } from './Utilities';
-import { GPT3Tokenizer } from './tokenizers';
+import { GPTTokenizer } from './tokenizers';
 
 describe('Utilities', () => {
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     describe('toString', () => {
         it('should convert a number to a string', () => {
             const result = Utilities.toString(tokenizer, 1);
@@ -21,8 +21,8 @@ describe('Utilities', () => {
         });
 
         it('should convert a simple object to yaml', () => {
-            const result = Utilities.toString(tokenizer, { a: 1 });
-            assert.equal(result, 'a: 1\n');
+            const result = Utilities.toString(tokenizer, { abc: 1 });
+            assert.equal(result, 'abc: 1\n');
         });
 
         it('should convert a deep object to JSON', () => {

--- a/js/packages/teams-ai/src/Utilities.spec.ts
+++ b/js/packages/teams-ai/src/Utilities.spec.ts
@@ -21,8 +21,8 @@ describe('Utilities', () => {
         });
 
         it('should convert a simple object to yaml', () => {
-            const result = Utilities.toString(tokenizer, { abc: 1 });
-            assert.equal(result, 'abc: 1\n');
+            const result = Utilities.toString(tokenizer, { a: 1 });
+            assert.equal(result, 'a: 1\n');
         });
 
         it('should convert a deep object to JSON', () => {

--- a/js/packages/teams-ai/src/Utilities.ts
+++ b/js/packages/teams-ai/src/Utilities.ts
@@ -26,7 +26,7 @@ export class Utilities {
                 // Return shorter version of object
                 const asYaml = stringify(value);
                 const asJSON = JSON.stringify(value);
-                if (tokenizer.encode(asYaml).length < tokenizer.encode(asJSON).length) {
+                if (tokenizer.encode(asYaml).length <= tokenizer.encode(asJSON).length) {
                     return asYaml;
                 } else {
                     return asJSON;

--- a/js/packages/teams-ai/src/Utilities.ts
+++ b/js/packages/teams-ai/src/Utilities.ts
@@ -9,10 +9,10 @@ export class Utilities {
      * Converts a value to a string.
      * @remarks
      * Dates are converted to ISO strings and Objects are converted to JSON or YAML, whichever is shorter.
-     * @param tokenizer Tokenizer to use for encoding.
-     * @param value Value to convert.
-     * @param asJSON Optional. If true objects will always be converted to JSON instead of YAML. Defaults to false.
-     * @returns Converted value.
+     * @param {Tokenizer} tokenizer Tokenizer to use for encoding.
+     * @param {any} value Value to convert.
+     * @param {boolean} asJSON Optional. If true objects will always be converted to JSON instead of YAML. Defaults to false.
+     * @returns {string} Converted value.
      */
     public static toString(tokenizer: Tokenizer, value: any, asJSON: boolean = false): string {
         if (value === undefined || value === null) {

--- a/js/packages/teams-ai/src/augmentations/ActionAugmentationSection.ts
+++ b/js/packages/teams-ai/src/augmentations/ActionAugmentationSection.ts
@@ -6,13 +6,14 @@
  * Licensed under the MIT License.
  */
 
-import { Message, PromptFunctions, RenderedPromptSection, PromptSectionBase } from '../prompts';
 import { TurnContext } from 'botbuilder';
-import { Tokenizer } from '../tokenizers';
-import { ChatCompletionAction } from '../models';
 import { Schema } from 'jsonschema';
 import { stringify } from 'yaml';
+
 import { Memory } from '../MemoryFork';
+import { ChatCompletionAction } from '../models';
+import { Message, PromptFunctions, RenderedPromptSection, PromptSectionBase } from '../prompts';
+import { Tokenizer } from '../tokenizers';
 
 /**
  * A prompt section that renders a list of actions to the prompt.
@@ -24,8 +25,8 @@ export class ActionAugmentationSection extends PromptSectionBase {
 
     /**
      * Creates a new `ActionAugmentationSection` instance.
-     * @param actions List of actions to render.
-     * @param callToAction Text to display after the list of actions.
+     * @param {ChatCompletionAction[]} actions List of actions to render.
+     * @param {string} callToAction Text to display after the list of actions.
      */
     public constructor(actions: ChatCompletionAction[], callToAction: string) {
         super(-1, true, '\n\n');
@@ -51,7 +52,7 @@ export class ActionAugmentationSection extends PromptSectionBase {
     }
 
     /**
-     * Map of action names to actions.
+     * @returns {Map<string, ChatCompletionAction>} Map of action names to actions.
      */
     public get actions(): Map<string, ChatCompletionAction> {
         return this._actions;
@@ -59,12 +60,12 @@ export class ActionAugmentationSection extends PromptSectionBase {
 
     /**
      * Renders the prompt section as a list of `Message` objects.
-     * @param context Context for the current turn of conversation.
-     * @param memory Interface for accessing state variables.
-     * @param functions Functions for rendering prompts.
-     * @param tokenizer Tokenizer to use for encoding/decoding text.
-     * @param maxTokens Maximum number of tokens allowed for the rendered prompt.
-     * @returns The rendered prompt section.
+     * @param {TurnContext} context - Context for the current turn of conversation.
+     * @param {Memory} memory - Interface for accessing state variables.
+     * @param {PromptFunctions} functions - Functions for rendering prompts.
+     * @param {Tokenizer} tokenizer - Tokenizer to use for encoding/decoding text.
+     * @param {number} maxTokens - Maximum number of tokens allowed for the rendered prompt.
+     * @returns {Promise<RenderedPromptSection<Message<string>[]>>} The rendered prompt section.
      */
     public renderAsMessages(
         context: TurnContext,

--- a/js/packages/teams-ai/src/augmentations/DefaultAugmentation.spec.ts
+++ b/js/packages/teams-ai/src/augmentations/DefaultAugmentation.spec.ts
@@ -3,12 +3,12 @@ import { TestAdapter } from 'botbuilder';
 
 import { TestTurnState } from '../internals/testing/TestTurnState';
 import { PromptResponse } from '../models';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { DefaultAugmentation } from './DefaultAugmentation';
 
 describe('DefaultAugmentation', () => {
     const adapter = new TestAdapter();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const valid_content = JSON.stringify({
         type: 'plan',
         commands: [

--- a/js/packages/teams-ai/src/augmentations/DefaultAugmentation.ts
+++ b/js/packages/teams-ai/src/augmentations/DefaultAugmentation.ts
@@ -23,7 +23,7 @@ import { Memory } from '../MemoryFork';
  */
 export class DefaultAugmentation implements Augmentation<string> {
     /**
-     * Creates an optional prompt section for the augmentation.
+     * @returns {PromptSection|undefined} Returns an optional prompt section for the augmentation.
      */
     public createPromptSection(): PromptSection | undefined {
         return undefined;
@@ -31,12 +31,12 @@ export class DefaultAugmentation implements Augmentation<string> {
 
     /**
      * Validates a response to a prompt.
-     * @param context Context for the current turn of conversation with the user.
-     * @param memory An interface for accessing state values.
-     * @param tokenizer Tokenizer to use for encoding and decoding text.
-     * @param response Response to validate.
-     * @param remaining_attempts Number of remaining attempts to validate the response.
-     * @returns A `Validation` object.
+     * @param {TurnContext} context - Context for the current turn of conversation with the user.
+     * @param {Memory} memory - An interface for accessing state values.
+     * @param {Tokenizer} tokenizer - Tokenizer to use for encoding and decoding text.
+     * @param {PromptResponse<string>} response - Response to validate.
+     * @param {number} remaining_attempts Number of remaining attempts to validate the response.
+     * @returns {Validation} A `Validation` object.
      */
     public validateResponse(
         context: TurnContext,
@@ -53,10 +53,10 @@ export class DefaultAugmentation implements Augmentation<string> {
 
     /**
      * Creates a plan given validated response value.
-     * @param context Context for the current turn of conversation.
-     * @param memory An interface for accessing state variables.
-     * @param response The validated and transformed response for the prompt.
-     * @returns The created plan.
+     * @param {TurnContext} context Context for the current turn of conversation.
+     * @param {Memory} memory An interface for accessing state variables.
+     * @param {PromptResponse<string>} response The validated and transformed response for the prompt.
+     * @returns {Promise<Plan>} The created plan.
      */
     public createPlanFromResponse(
         context: TurnContext,

--- a/js/packages/teams-ai/src/augmentations/MonologueAugmentation.spec.ts
+++ b/js/packages/teams-ai/src/augmentations/MonologueAugmentation.spec.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
 import { ChatCompletionAction, PromptResponse } from '../models';
@@ -10,7 +10,7 @@ import { MonologueAugmentation } from './MonologueAugmentation';
 describe('MonologueAugmentation', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const actions: ChatCompletionAction[] = [
         {
             name: 'test',

--- a/js/packages/teams-ai/src/augmentations/MonologueAugmentation.ts
+++ b/js/packages/teams-ai/src/augmentations/MonologueAugmentation.ts
@@ -20,7 +20,7 @@ import { Memory } from '../MemoryFork';
 /**
  * @private
  */
-const MISSING_ACTION_FEEDBACK = `The JSON returned had errors. Apply these fixes:\nadd the \"action\" property to \"instance\"`;
+const MISSING_ACTION_FEEDBACK = `The JSON returned had errors. Apply these fixes:\nadd the "action" property to "instance"`;
 
 /**
  * @private
@@ -110,7 +110,7 @@ export class MonologueAugmentation implements Augmentation<InnerMonologue | unde
 
     /**
      * Creates a new `MonologueAugmentation` instance.
-     * @param actions List of actions supported by the prompt.
+     * @param {ChatCompletionAction[]} actions - List of actions supported by the prompt.
      */
     public constructor(actions: ChatCompletionAction[]) {
         actions = appendSAYAction(actions);
@@ -129,7 +129,7 @@ export class MonologueAugmentation implements Augmentation<InnerMonologue | unde
     }
 
     /**
-     * Creates an optional prompt section for the augmentation.
+     * @returns {PromptSection|undefined} Returns an optional prompt section for the augmentation.
      */
     public createPromptSection(): PromptSection | undefined {
         return this._section;
@@ -137,12 +137,12 @@ export class MonologueAugmentation implements Augmentation<InnerMonologue | unde
 
     /**
      * Validates a response to a prompt.
-     * @param context Context for the current turn of conversation with the user.
-     * @param memory An interface for accessing state values.
-     * @param tokenizer Tokenizer to use for encoding and decoding text.
-     * @param response Response to validate.
-     * @param remaining_attempts Number of remaining attempts to validate the response.
-     * @returns A `Validation` object.
+     * @param {TurnContext} context - Context for the current turn of conversation with the user.
+     * @param {Memory} memory - An interface for accessing state values.
+     * @param {Tokenizer} tokenizer - Tokenizer to use for encoding and decoding text.
+     * @param {PromptResponse<string>} response - Response to validate.
+     * @param {number} remaining_attempts - Number of remaining attempts to validate the response.
+     * @returns {Validation} A `Validation` object.
      */
     public async validateResponse(
         context: TurnContext,
@@ -193,10 +193,10 @@ export class MonologueAugmentation implements Augmentation<InnerMonologue | unde
 
     /**
      * Creates a plan given validated response value.
-     * @param context Context for the current turn of conversation.
-     * @param memory An interface for accessing state variables.
-     * @param response The validated and transformed response for the prompt.
-     * @returns The created plan.
+     * @param {TurnContext} context - Context for the current turn of conversation.
+     * @param {Memory} memory - An interface for accessing state variables.
+     * @param {PromptResponse<InnerMonologue|undefined>} response - The validated and transformed response for the prompt.
+     * @returns {Plan} The created plan.
      */
     public createPlanFromResponse(
         context: TurnContext,
@@ -223,8 +223,9 @@ export class MonologueAugmentation implements Augmentation<InnerMonologue | unde
 }
 
 /**
- * @param actions
  * @private
+ * @param {ChatCompletionAction[]} actions - List of actions
+ * @returns {ChatCompletionAction[]} The modified list of actions.
  */
 function appendSAYAction(actions: ChatCompletionAction[]): ChatCompletionAction[] {
     const clone = actions.slice();

--- a/js/packages/teams-ai/src/augmentations/SequenceAugmentation.spec.ts
+++ b/js/packages/teams-ai/src/augmentations/SequenceAugmentation.spec.ts
@@ -4,13 +4,13 @@ import { TestAdapter } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
 import { ChatCompletionAction, PromptResponse } from '../models';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { SequenceAugmentation } from './SequenceAugmentation';
 
 describe('SequenceAugmentation', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const actions: ChatCompletionAction[] = [
         {
             name: 'test',

--- a/js/packages/teams-ai/src/augmentations/SequenceAugmentation.ts
+++ b/js/packages/teams-ai/src/augmentations/SequenceAugmentation.ts
@@ -80,6 +80,7 @@ export class SequenceAugmentation implements Augmentation<Plan | undefined> {
 
     /**
      * Creates an optional prompt section for the augmentation.
+     * @returns {PromptSection | undefined} The new PromptSection or undefined.
      */
     public createPromptSection(): PromptSection | undefined {
         return this._section;
@@ -87,12 +88,12 @@ export class SequenceAugmentation implements Augmentation<Plan | undefined> {
 
     /**
      * Validates a response to a prompt.
-     * @param context Context for the current turn of conversation with the user.
-     * @param memory An interface for accessing state values.
-     * @param tokenizer Tokenizer to use for encoding and decoding text.
-     * @param response Response to validate.
-     * @param remaining_attempts Number of remaining attempts to validate the response.
-     * @returns A `Validation` object.
+     * @param {TurnContext} context - Context for the current turn of conversation with the user.
+     * @param {Memory} memory - An interface for accessing state values.
+     * @param {Tokenizer} tokenizer - Tokenizer to use for encoding and decoding text.
+     * @param {PromptResponse<string>} response - Response to validate.
+     * @param {number} remaining_attempts - Number of remaining attempts to validate the response.
+     * @returns {Validation} A `Validation` object.
      */
     public async validateResponse(
         context: TurnContext,
@@ -172,10 +173,10 @@ export class SequenceAugmentation implements Augmentation<Plan | undefined> {
 
     /**
      * Creates a plan given validated response value.
-     * @param context Context for the current turn of conversation.
-     * @param memory An interface for accessing state variables.
-     * @param response The validated and transformed response for the prompt.
-     * @returns The created plan.
+     * @param {TurnContext} context - Context for the current turn of conversation.
+     * @param {Memory} memory - An interface for accessing state variables.
+     * @param {PromptResponse<Plan|undefined>} response - The validated and transformed response for the prompt.
+     * @returns {Promise<Plan>} The created plan.
      */
     public createPlanFromResponse(
         context: TurnContext,

--- a/js/packages/teams-ai/src/authentication/TeamsBotSsoPrompt.spec.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsBotSsoPrompt.spec.ts
@@ -59,7 +59,6 @@ describe('TeamsSsoPrompt', () => {
      * }
      */
     const ssoToken =
-        // eslint-disable-next-line no-secrets/no-secrets
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0X2F1ZGllbmNlIiwiaXNzIjoiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL3Rlc3RfYWFkX2lkL3YyLjAiLCJpYXQiOjE1MzcyMzEwNDgsIm5iZiI6MTUzNzIzMTA0OCwiZXhwIjoxNTM3MjM0OTQ4LCJhaW8iOiJ0ZXN0X2FpbyIsIm5hbWUiOiJNT0RTIFRvb2xraXQgU0RLIFVuaXQgVGVzdCIsIm9pZCI6IjExMTExMTExLTIyMjItMzMzMy00NDQ0LTU1NTU1NTU1NTU1NSIsInByZWZlcnJlZF91c2VybmFtZSI6InRlc3RAbWljcm9zb2Z0LmNvbSIsInJoIjoidGVzdF9yaCIsInNjcCI6ImFjY2Vzc19hc191c2VyIiwic3ViIjoidGVzdF9zdWIiLCJ0aWQiOiJ0ZXN0X3RlbmFudF9pZCIsInV0aSI6InRlc3RfdXRpIiwidmVyIjoiMi4wIn0.SshbL1xuE1aNZD5swrWOQYgTR9QCNXkZqUebautBvKM';
     const tokenExpiration = '2023-01-01T00:00:00.000Z';
     const timeoutValue = 50;

--- a/js/packages/teams-ai/src/authentication/TeamsBotSsoPrompt.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsBotSsoPrompt.ts
@@ -53,10 +53,10 @@ export class TeamsSsoPrompt extends Dialog {
 
     /**
      * Creates a new instance of TeamsSsoPrompt.
-     * @param dialogId The ID of the dialog.
-     * @param settingName The name of the setting.
-     * @param settings The settings for Teams SSO.
-     * @param msal The MSAL (Microsoft Authentication Library) object.
+     * @param {string} dialogId - The ID of the dialog.
+     * @param {string} settingName - The name of the setting.
+     * @param {TeamsSsoSettings} settings - The settings for Teams SSO.
+     * @param {ConfidentialClientApplication} msal - The MSAL (Microsoft Authentication Library) object.
      */
     constructor(
         dialogId: string,
@@ -76,10 +76,10 @@ export class TeamsSsoPrompt extends Dialog {
      * Called when a prompt dialog is pushed onto the dialog stack and is being activated.
      * @remarks
      * If the task is successful, the result indicates whether the prompt is still
-     * @param options
      * active after the turn has been processed by the prompt.
-     * @param dc The DialogContext for the current turn of the conversation.
-     * @returns A `Promise` representing the result of current turn.
+     * @param {any} dc - The DialogContext for the current turn of the conversation.
+     * @param {any} options - The options for the dialog
+     * @returns {Promise<any>} A `Promise` representing the result of current turn.
      */
     public async beginDialog(dc: any, options: any): Promise<any> {
         const default_timeout = 900000;
@@ -124,8 +124,8 @@ export class TeamsSsoPrompt extends Dialog {
      * @remarks
      * If the task is successful, the result indicates whether the dialog is still
      * active after the turn has been processed by the dialog.
-     * @param dc The DialogContext for the current turn of the conversation.
-     * @returns A `Promise` representing the result of the turn after the dialog has processed the activity.
+     * @param {any} dc The DialogContext for the current turn of the conversation.
+     * @returns {Promise<any>} A `Promise` representing the result of the turn after the dialog has processed the activity.
      */
     public async continueDialog(dc: any): Promise<any> {
         const state = dc.activeDialog?.state;
@@ -289,6 +289,6 @@ export class TeamsSsoPrompt extends Dialog {
     }
 
     private isTokenExchangeRequest(obj: any): obj is TokenExchangeInvokeRequest {
-        return obj.hasOwnProperty('token');
+        return Object.prototype.hasOwnProperty.call(obj, 'token');
     }
 }

--- a/js/packages/teams-ai/src/authentication/TeamsSsoAdaptiveCardAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoAdaptiveCardAuthentication.ts
@@ -27,8 +27,8 @@ export class TeamsSsoAdaptiveCardAuthentication extends AdaptiveCardAuthenticati
 
     /**
      * Handles the user sign-in.
-     * @param context - The turn context.
-     * @param magicCode - The magic code from user sign-in.
+     * @param {TurnContext} context - The turn context.
+     * @param {string} magicCode - The magic code from user sign-in.
      */
     public async handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined> {
         throw new Error('Not implemented');
@@ -36,7 +36,7 @@ export class TeamsSsoAdaptiveCardAuthentication extends AdaptiveCardAuthenticati
 
     /**
      * Gets the login request for Adaptive Card authentication.
-     * @param context - The turn context.
+     * @param {TurnContext} context - The turn context.
      */
     public async getLoginRequest(context: TurnContext): Promise<AdaptiveCardLoginRequest> {
         throw new Error('Not implemented');
@@ -44,8 +44,8 @@ export class TeamsSsoAdaptiveCardAuthentication extends AdaptiveCardAuthenticati
 
     /**
      * Checks if the activity is valid for Adaptive Card authentication.
-     * @param context - The turn context.
-     * @returns A boolean indicating if the activity is valid.
+     * @param {TurnContext} context - The turn context.
+     * @returns {boolean} A boolean indicating if the activity is valid.
      */
     public override isValidActivity(context: TurnContext): boolean {
         if (super.isValidActivity(context)) {

--- a/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.spec.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.spec.ts
@@ -234,8 +234,8 @@ describe('TeamsSsoBotAuthentication', () => {
 
             /**
              *
-             * @param msg
-             * @param expected
+             * @param {Partial<Activity>} msg - The message to check
+             * @param {string} expected - The expected message
              */
             function assertResponse(msg: Partial<Activity>, expected: string) {
                 const response = JSON.parse(msg.text!);

--- a/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.ts
@@ -33,11 +33,11 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
 
     /**
      * Initializes a new instance of the TeamsSsoBotAuthentication class.
-     * @param app - The application object.
-     * @param settings - The settings for Teams SSO.
-     * @param settingName - The name of the setting.
-     * @param msal - The MSAL (Microsoft Authentication Library) object.
-     * @param storage - The storage object for storing state.
+     * @param {Application<TState>} app - The application object.
+     * @param {TeamsSsoSettings} settings - The settings for Teams SSO.
+     * @param {string} settingName - The name of the setting.
+     * @param {ConfidentialClientApplication} msal - The MSAL (Microsoft Authentication Library) object.
+     * @param {Storage} storage - The storage object for storing state.
      */
     public constructor(
         app: Application<TState>,
@@ -61,10 +61,10 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
 
     /**
      * Run or continue the SSO dialog and returns the result.
-     * @param context - The turn context object.
-     * @param state - The turn state object.
-     * @param dialogStateProperty - The name of the dialog state property.
-     * @returns A promise that resolves to the dialog turn result containing the token response.
+     * @param {TurnContext} context - The turn context object.
+     * @param {TState} state - The turn state object.
+     * @param {string} dialogStateProperty - The name of the dialog state property.
+     * @returns {Promise<DialogTurnResult<TokenResponse>>} A promise that resolves to the dialog turn result containing the token response.
      */
     public async runDialog(
         context: TurnContext,
@@ -81,10 +81,10 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
 
     /**
      * Continues the SSO dialog and returns the result.
-     * @param context - The turn context object.
-     * @param state - The turn state object.
-     * @param dialogStateProperty - The name of the dialog state property.
-     * @returns A promise that resolves to the dialog turn result containing the token response.
+     * @param {TurnContext} context - The turn context object.
+     * @param {TState} state - The turn state object.
+     * @param {string} dialogStateProperty - The name of the dialog state property.
+     * @returns {Promise<DialogTurnResult<TokenResponse>>} A promise that resolves to the dialog turn result containing the token response.
      */
     public async continueDialog(
         context: TurnContext,
@@ -97,8 +97,8 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
 
     /**
      * Determines whether the token exchange activity should be processed by current authentication setting.
-     * @param context - The turn context object.
-     * @returns A promise that resolves to a boolean indicating whether the token exchange route should be processed by current class instance.
+     * @param {TurnContext} context - The turn context object.
+     * @returns {Promise<boolean>} A promise that resolves to a boolean indicating whether the token exchange route should be processed by current class instance.
      */
     protected async tokenExchangeRouteSelector(context: TurnContext): Promise<boolean> {
         return (
@@ -109,10 +109,10 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
 
     /**
      * Creates the SSO dialog context.
-     * @param context - The turn context object.
-     * @param state - The turn state object.
-     * @param dialogStateProperty - The name of the dialog state property.
-     * @returns A promise that resolves to the dialog context object.
+     * @param {TurnContext} context - The turn context object.
+     * @param {TState} state - The turn state object.
+     * @param {string} dialogStateProperty - The name of the dialog state property.
+     * @returns {Promise<DialogContext>} A promise that resolves to the dialog context object.
      */
     private async createSsoDialogContext(
         context: TurnContext,
@@ -143,8 +143,8 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
 
     /**
      * Checks if deduplication should be performed for token exchange.
-     * @param context - The turn context object.
-     * @returns A promise that resolves to a boolean indicating whether deduplication should be performed.
+     * @param {TurnContext} context - The turn context object.
+     * @returns {Promise<boolean>} A promise that resolves to a boolean indicating whether deduplication should be performed.
      */
     private async shouldDedup(context: TurnContext): Promise<boolean> {
         const storeItem = {
@@ -167,8 +167,8 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
 
     /**
      * Gets the storage key for storing the token exchange state.
-     * @param context - The turn context object.
-     * @returns The storage key.
+     * @param {TurnContext} context - The turn context object.
+     * @returns {string} The storage key.
      * @throws Error if the context is invalid or the activity is not a token exchange invoke.
      */
     private getStorageKey(context: TurnContext): string {

--- a/js/packages/teams-ai/src/authentication/TeamsSsoMessageExtensionAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoMessageExtensionAuthentication.ts
@@ -16,8 +16,8 @@ import { MessageExtensionsInvokeNames } from '../MessageExtensions';
 export class TeamsSsoMessageExtensionAuthentication extends MessageExtensionAuthenticationBase {
     /**
      * Creates a new instance of TeamsSsoMessageExtensionAuthentication.
-     * @param settings The Teams SSO settings.
-     * @param msal The MSAL (Microsoft Authentication Library) instance.
+     * @param {TeamsSsoSettings} settings The Teams SSO settings.
+     * @param {ConfidentialClientApplication} msal The MSAL (Microsoft Authentication Library) instance.
      */
     public constructor(
         private readonly settings: TeamsSsoSettings,
@@ -28,8 +28,8 @@ export class TeamsSsoMessageExtensionAuthentication extends MessageExtensionAuth
 
     /**
      * Checks if the activity is a valid Message Extension activity that supports SSO
-     * @param context The turn context.
-     * @returns A boolean indicating if the activity is valid.
+     * @param {TurnContext} context The turn context.
+     * @returns {boolean} A boolean indicating if the activity is valid.
      */
     public override isValidActivity(context: TurnContext): boolean {
         // Currently only search based message extensions has SSO
@@ -38,8 +38,8 @@ export class TeamsSsoMessageExtensionAuthentication extends MessageExtensionAuth
 
     /**
      * Handles the SSO token exchange.
-     * @param context The turn context.
-     * @returns A promise that resolves to the token response or undefined if token exchange failed.
+     * @param {TurnContext} context The turn context.
+     * @returns {Promise<TokenResponse | undefined>} A promise that resolves to the token response or undefined if token exchange failed.
      */
     public async handleSsoTokenExchange(context: TurnContext): Promise<TokenResponse | undefined> {
         const tokenExchangeRequest = context.activity.value.authentication;
@@ -64,9 +64,9 @@ export class TeamsSsoMessageExtensionAuthentication extends MessageExtensionAuth
 
     /**
      * Handles the signin/verifyState activity.
-     * @param context The turn context.
-     * @param magicCode The magic code from sign-in.
-     * @returns A promise that resolves to undefined. The parent class will trigger silentAuth again.
+     * @param {TurnContext} context The turn context.
+     * @param {string} magicCode The magic code from sign-in.
+     * @returns {Promise<TokenResponse|undefined>} A promise that resolves to undefined. The parent class will trigger silentAuth again.
      */
     public async handleUserSignIn(context: TurnContext, magicCode: string): Promise<TokenResponse | undefined> {
         return undefined; // Let parent class trigger silentAuth again
@@ -74,8 +74,8 @@ export class TeamsSsoMessageExtensionAuthentication extends MessageExtensionAuth
 
     /**
      * Gets the sign-in link for the user.
-     * @param context The turn context.
-     * @returns A promise that resolves to the sign-in link.
+     * @param {TurnContext} context The turn context.
+     * @returns {Promise<string>} A promise that resolves to the sign-in link.
      */
     public async getSignInLink(context: TurnContext): Promise<string> {
         const clientId = this.settings.msalConfig.auth.clientId;

--- a/js/packages/teams-ai/src/dataSources/TextDataSource.spec.ts
+++ b/js/packages/teams-ai/src/dataSources/TextDataSource.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { TextDataSource } from './TextDataSource';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 
 describe('TextDataSource', () => {
     it('should construct and set the name', () => {
@@ -8,7 +8,7 @@ describe('TextDataSource', () => {
         assert.strictEqual(textDataSource.name, 'testname');
     });
 
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     it('renderData should return the trimmed text', async () => {
         const textDataSource = new TextDataSource('testname', 'Hello World!');
         const section = await textDataSource.renderData({} as any, {} as any, tokenizer, 1);

--- a/js/packages/teams-ai/src/dataSources/TextDataSource.ts
+++ b/js/packages/teams-ai/src/dataSources/TextDataSource.ts
@@ -25,8 +25,8 @@ export class TextDataSource implements DataSource {
 
     /**
      * Creates a new `TextDataSource` instance.
-     * @param name Name of the data source.
-     * @param text Text to inject into the prompt.
+     * @param {string} name Name of the data source.
+     * @param {string} text Text to inject into the prompt.
      */
     public constructor(name: string, text: string) {
         this._name = name;
@@ -34,7 +34,7 @@ export class TextDataSource implements DataSource {
     }
 
     /**
-     * Name of the data source.
+     * @returns {string} Name of the data source.
      */
     public get name(): string {
         return this._name;
@@ -42,11 +42,11 @@ export class TextDataSource implements DataSource {
 
     /**
      * Renders the data source as a string of text.
-     * @param context Turn context for the current turn of conversation with the user.
-     * @param memory An interface for accessing state values.
-     * @param tokenizer Tokenizer to use when rendering the data source.
-     * @param maxTokens Maximum number of tokens allowed to be rendered.
-     * @returns The text to inject into the prompt as a `RenderedPromptSection` object.
+     * @param {TurnContext} context Turn context for the current turn of conversation with the user.
+     * @param {Memory} memory An interface for accessing state values.
+     * @param {Tokenizer} tokenizer Tokenizer to use when rendering the data source.
+     * @param {number} maxTokens Maximum number of tokens allowed to be rendered.
+     * @returns {Promise<RenderedPromptSection<string>>} The text to inject into the prompt as a `RenderedPromptSection` object.
      */
     public renderData(
         context: TurnContext,

--- a/js/packages/teams-ai/src/internals/testing/TestMemoryFork.ts
+++ b/js/packages/teams-ai/src/internals/testing/TestMemoryFork.ts
@@ -17,7 +17,10 @@ export class TestMemoryFork implements Memory {
      */
     public deleteValue(path: string): void {
         const { scope, name } = this.getScopeAndName(path);
-        if (this._fork.hasOwnProperty(scope) && this._fork[scope].hasOwnProperty(name)) {
+        if (
+            Object.prototype.hasOwnProperty.call(this._fork, scope) &&
+            Object.prototype.hasOwnProperty.call(this._fork[scope], name)
+        ) {
             delete this._fork[scope][name];
         }
     }
@@ -29,8 +32,8 @@ export class TestMemoryFork implements Memory {
      */
     public hasValue(path: string): boolean {
         const { scope, name } = this.getScopeAndName(path);
-        if (this._fork.hasOwnProperty(scope)) {
-            return this._fork[scope].hasOwnProperty(name);
+        if (Object.prototype.hasOwnProperty.call(this._fork, scope)) {
+            return Object.prototype.hasOwnProperty.call(this._fork[scope], name);
         }
 
         return false;
@@ -44,8 +47,8 @@ export class TestMemoryFork implements Memory {
      */
     public getValue<TValue = unknown>(path: string): TValue {
         const { scope, name } = this.getScopeAndName(path);
-        if (this._fork.hasOwnProperty(scope)) {
-            if (this._fork[scope].hasOwnProperty(name)) {
+        if (Object.prototype.hasOwnProperty.call(this._fork, scope)) {
+            if (Object.prototype.hasOwnProperty.call(this._fork[scope], name)) {
                 return this._fork[scope][name] as TValue;
             }
         }
@@ -61,7 +64,7 @@ export class TestMemoryFork implements Memory {
      */
     public setValue(path: string, value: unknown): void {
         const { scope, name } = this.getScopeAndName(path);
-        if (!this._fork.hasOwnProperty(scope)) {
+        if (!Object.prototype.hasOwnProperty.call(this._fork, scope)) {
             this._fork[scope] = {};
         }
 

--- a/js/packages/teams-ai/src/internals/testing/TestModel.spec.ts
+++ b/js/packages/teams-ai/src/internals/testing/TestModel.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 
 import { PromptTemplate, SystemMessage } from '../../prompts';
-import { GPT3Tokenizer } from '../../tokenizers';
+import { GPTTokenizer } from '../../tokenizers';
 import { TestTurnState } from './TestTurnState';
 import { TestPromptManager } from './TestPromptManager';
 import { TestModel } from './TestModel';
@@ -10,7 +10,7 @@ import { TestModel } from './TestModel';
 describe('TestModel', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const template: PromptTemplate = {
         name: 'test',
         prompt: new SystemMessage('Hello World'),

--- a/js/packages/teams-ai/src/models/OpenAIModel.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.ts
@@ -124,7 +124,7 @@ export class OpenAIModel implements PromptCompletionModel {
 
     /**
      * Creates a new `OpenAIModel` instance.
-     * @param options Options for configuring the model client.
+     * @param {OpenAIModelOptions} options - Options for configuring the model client.
      */
     public constructor(options: OpenAIModelOptions | AzureOpenAIModelOptions) {
         // Check for azure config
@@ -173,12 +173,12 @@ export class OpenAIModel implements PromptCompletionModel {
 
     /**
      * Completes a prompt using OpenAI or Azure OpenAI.
-     * @param context Current turn context.
-     * @param memory An interface for accessing state values.
-     * @param functions Functions to use when rendering the prompt.
-     * @param tokenizer Tokenizer to use when rendering the prompt.
-     * @param template Prompt template to complete.
-     * @returns A `PromptResponse` with the status and message.
+     * @param {TurnContext} context - Current turn context.
+     * @param {Memory} memory - An interface for accessing state values.
+     * @param {PromptFunctions} functions - Functions to use when rendering the prompt.
+     * @param {Tokenizer} tokenizer - Tokenizer to use when rendering the prompt.
+     * @param {PromptTemplate} template - Prompt template to complete.
+     * @returns {Promise<PromptResponse<string>>} A `PromptResponse` with the status and message.
      */
     public async completePrompt(
         context: TurnContext,
@@ -279,10 +279,12 @@ export class OpenAIModel implements PromptCompletionModel {
     }
 
     /**
-     * @param target
-     * @param src
-     * @param fields
      * @private
+     * @template TRequest
+     * @param {Partial<TRequest>} target - The target TRequest.
+     * @param {any} src - The source object.
+     * @param {string[]} fields - List of fields to copy.
+     * @returns {TRequest} The TRequest
      */
     protected copyOptionsToRequest<TRequest>(target: Partial<TRequest>, src: any, fields: string[]): TRequest {
         for (const field of fields) {
@@ -295,9 +297,10 @@ export class OpenAIModel implements PromptCompletionModel {
     }
 
     /**
-     * @param request
-     * @param model
      * @private
+     * @param {CreateChatCompletionRequest} request - The request for Chat Completion
+     * @param {string} model - The string name of the model.
+     * @returns {Promise<AxiosResponse<CreateChatCompletionResponse>>} A Promise containing the CreateChatCompletionResponse response.
      */
     protected createChatCompletion(
         request: CreateChatCompletionRequest,
@@ -318,10 +321,12 @@ export class OpenAIModel implements PromptCompletionModel {
     }
 
     /**
-     * @param url
-     * @param body
-     * @param retryCount
      * @private
+     * @template TData
+     * @param {string} url - Url to post to.
+     * @param {object} body - POST body.
+     * @param {number} retryCount - Number of allowed retries.
+     * @returns {Promise<AxiosResponse<TData>>} Promise containing the POST response.
      */
     protected async post<TData>(url: string, body: object, retryCount = 0): Promise<AxiosResponse<TData>> {
         // Initialize request config

--- a/js/packages/teams-ai/src/planners/ActionPlanner.ts
+++ b/js/packages/teams-ai/src/planners/ActionPlanner.ts
@@ -67,7 +67,7 @@ export interface ActionPlannerOptions<TState extends TurnState = TurnState> {
     /**
      * Optional tokenizer to use.
      * @remarks
-     * If not specified, a new `GPT3Tokenizer` instance will be created.
+     * If not specified, a new `GPTTokenizer` instance will be created.
      */
     tokenizer?: Tokenizer;
 
@@ -106,7 +106,7 @@ export class ActionPlanner<TState extends TurnState = TurnState> implements Plan
 
     /**
      * Creates a new `ActionPlanner` instance.
-     * @param options Options used to configure the planner.
+     * @param {ActionPlannerOptions<TState>} options Options used to configure the planner.
      */
     public constructor(options: ActionPlannerOptions<TState>) {
         this._options = Object.assign(
@@ -144,10 +144,10 @@ export class ActionPlanner<TState extends TurnState = TurnState> implements Plan
      * there is no work to be performed.
      *
      * The planner should take the users input from `state.temp.input`.
-     * @param context Context for the current turn of conversation.
-     * @param state Application state for the current turn of conversation.
-     * @param ai The AI system that is generating the plan.
-     * @returns The plan that was generated.
+     * @param {TurnContext} context Context for the current turn of conversation.
+     * @param {TState} state Application state for the current turn of conversation.
+     * @param {AI<TState>} ai The AI system that is generating the plan.
+     * @returns {Promise<Plan>} The plan that was generated.
      */
     public async beginTask(context: TurnContext, state: TState, ai: AI<TState>): Promise<Plan> {
         return await this.continueTask(context, state, ai);

--- a/js/packages/teams-ai/src/planners/AssistantsPlanner.ts
+++ b/js/packages/teams-ai/src/planners/AssistantsPlanner.ts
@@ -72,7 +72,7 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
 
     /**
      * Creates a new `AssistantsPlanner` instance.
-     * @param options Options for configuring the AssistantsPlanner.
+     * @param {AssistantsPlannerOptions} options - Options for configuring the AssistantsPlanner.
      */
     public constructor(options: AssistantsPlannerOptions) {
         this._options = Object.assign(
@@ -89,6 +89,7 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
 
     /**
      * Gets the OpenAI SDK instance being used.
+     * @returns {OpenAI} The OpenAI instance
      */
     public get openai(): OpenAI {
         return this._openai;
@@ -102,10 +103,10 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
      * there is no work to be performed.
      *
      * The planner should take the users input from `state.temp.input`.
-     * @param context Context for the current turn of conversation.
-     * @param state Application state for the current turn of conversation.
-     * @param ai The AI system that is generating the plan.
-     * @returns The plan that was generated.
+     * @param {TurnContext} context - Context for the current turn of conversation.
+     * @param {TState} state - Application state for the current turn of conversation.
+     * @param {AI<TState>} ai - The AI system that is generating the plan.
+     * @returns {Promise<Plan>} The plan that was generated.
      */
     public beginTask(context: TurnContext, state: TState, ai: AI<TState>): Promise<Plan> {
         return this.continueTask(context, state, ai);
@@ -120,10 +121,10 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
      * to be performed.
      *
      * The output from the last plan step that was executed is passed to the planner via `state.temp.input`.
-     * @param context Context for the current turn of conversation.
-     * @param state Application state for the current turn of conversation.
-     * @param ai The AI system that is generating the plan.
-     * @returns The plan that was generated.
+     * @param {TurnContext} context - Context for the current turn of conversation.
+     * @param {TState} state - Application state for the current turn of conversation.
+     * @param {AI<TState>} ai - The AI system that is generating the plan.
+     * @returns {Promise<Plan>} The plan that was generated.
      */
     public async continueTask(context: TurnContext, state: TState, ai: AI<TState>): Promise<Plan> {
         // Create a new thread if we don't have one already
@@ -145,9 +146,9 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
 
     /**
      * Static helper method for programmatically creating an assistant.
-     * @param apiKey OpenAI API key.
-     * @param request Definition of the assistant to create.
-     * @returns The created assistant.
+     * @param {string} apiKey - OpenAI API key.
+     * @param {OpenAI.Beta.Assistants.AssistantCreateParams} request - Definition of the assistant to create.
+     * @returns {Promise<OpenAI.Beta.Assistants.Assistant>} The created assistant.
      */
     public static async createAssistant(
         apiKey: string,
@@ -163,6 +164,7 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     /**
      * @private
      * Exposed for unit testing.
+     @returns {Promise<OpenAI.Beta.Assistants.Assistant>} - The assistant.
      */
     protected async retrieveAssistant(): Promise<OpenAI.Beta.Assistants.Assistant> {
         // Retrieve the assistant on first request
@@ -174,10 +176,11 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param thread_id
-     * @param body
      * @private
      * Exposed for unit testing.
+     * @param {string} thread_id - The thread id
+     * @param {OpenAI.Beta.Threads.Messages.MessageCreateParams} body - Message body.
+     @returns {Promise<OpenAI.Beta.Threads.Messages.ThreadMessage>} The thread message.
      */
     protected async createMessage(
         thread_id: string,
@@ -187,27 +190,30 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param request
      * @private
      * Exposed for unit testing.
+     * @param {OpenAI.Beta.Threads.ThreadCreateParams} request The Threads request.
+     * @returns {Promise<OpenAI.Beta.Threads.Thread>} The Thread.
      */
     protected async createThread(request: OpenAI.Beta.Threads.ThreadCreateParams): Promise<OpenAI.Beta.Threads.Thread> {
         return await this.openai.beta.threads.create(request);
     }
 
     /**
-     * @param thread_id
      * @private
      * Exposed for unit testing.
+     * @param {string} thread_id - The current thread id
+     * @returns {Promise<OpenAI.Beta.Threads.Messages.ThreadMessagesPage>} The list of messages.
      */
     protected async listMessages(thread_id: string): Promise<OpenAI.Beta.Threads.Messages.ThreadMessagesPage> {
         return await this.openai.beta.threads.messages.list(thread_id);
     }
 
     /**
-     * @param thread_id
      * @private
      * Exposed for unit testing.
+     * @param {string} thread_id - The thread id to create Run.
+     * @returns {Promise<OpenAI.Beta.Threads.Runs.Run>} The created run.
      */
     protected async createRun(thread_id: string): Promise<OpenAI.Beta.Threads.Runs.Run> {
         return await this.openai.beta.threads.runs.create(thread_id, {
@@ -216,19 +222,21 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param thread_id
-     * @param run_id
      * @private
      * Exposed for unit testing.
+     * @param {string} thread_id - The thread id to retrieve the run.
+     * @param {string} run_id - The run id to retrieve.
+     * @returns {OpenAI.Beta.Threads.Runs.Run} The retrieved run.
      */
     protected async retrieveRun(thread_id: string, run_id: string): Promise<OpenAI.Beta.Threads.Runs.Run> {
         return await this.openai.beta.threads.runs.retrieve(thread_id, run_id);
     }
 
     /**
-     * @param thread_id
      * @private
      * Exposed for unit testing.
+     * @param {string} thread_id The thread id to retrieve the run.
+     * @returns {Promise<OpenAI.Beta.Threads.Runs.Run>} The retrieved run.
      */
     protected async retrieveLastRun(thread_id: string): Promise<OpenAI.Beta.Threads.Runs.Run | null> {
         const list = await this.openai.beta.threads.runs.list(thread_id, { limit: 1 });
@@ -240,11 +248,12 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param thread_id
-     * @param run_id
-     * @param tool_outputs
      * @private
      * Exposed for unit testing.
+     * @param {string} thread_id - The current thread id.
+     * @param {string} run_id - The current run id.
+     * @param {OpenAI.Beta.Threads.Runs.RunSubmitToolOutputsParams} tool_outputs - The run's tool output parameters.
+     * @returns {Promise<OpenAI.Beta.Threads.Run.Run>} The tool outputs.
      */
     protected async submitToolOutputs(
         thread_id: string,
@@ -255,8 +264,9 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param run
      * @private
+     * @param {OpenAI.Beta.Threads.Runs.Run} run - The run to be checked for completion.
+     * @returns {boolean} True if completed, otherwise false.
      */
     private isRunCompleted(run: OpenAI.Beta.Threads.Runs.Run): boolean {
         switch (run.status) {
@@ -271,10 +281,11 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param thread_id
-     * @param run_id
-     * @param handleActions
      * @private
+     * @param {string} thread_id - The current thread id.
+     * @param {string} run_id - The run id.
+     * @param {boolean} handleActions - Whether to handle actions. False by default.
+     * @returns {Promise<OpenAI.Beta.Threads.Runs.Run>} The current Run.
      */
     private async waitForRun(
         thread_id: string,
@@ -302,10 +313,11 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param context
-     * @param state
-     * @param ai
      * @private
+     * @param {TurnContext} context - The application Turn Context.
+     * @param {TState} state - The application Turn State.
+     * @param {AI<TState>} ai - The AI instance.
+     * @returns {Promise<Plan>} The action results as Plan.
      */
     private async submitActionResults(context: TurnContext, state: TState, ai: AI<TState>): Promise<Plan> {
         // Get the current assistant state
@@ -353,10 +365,11 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param context
-     * @param state
-     * @param ai
      * @private
+     * @param {TurnContext} context - The application Turn Context.
+     * @param {TurnState} state - The application Turn State.
+     * @param {AI<TState>} ai - The AI instance.
+     * @returns {Promise<Plan>} - The user's input as Plan.
      */
     private async submitUserInput(context: TurnContext, state: TState, ai: AI<TState>): Promise<Plan> {
         // Get the current thread_id
@@ -396,9 +409,10 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param state
-     * @param required_action
      * @private
+     * @param {TurnState} state - The application Turn State.
+     * @param {OpenAI.Beta.Threads.Runs.Run.RequiredAction} required_action - The required action.
+     * @returns {Plan} - The generated Plan.
      */
     private generatePlanFromTools(state: TState, required_action: OpenAI.Beta.Threads.Runs.Run.RequiredAction): Plan {
         const plan: Plan = { type: 'plan', commands: [] };
@@ -416,9 +430,10 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param thread_id
-     * @param last_message_id
      * @private
+     * @param {string} thread_id - The current thread's ID.
+     * @param {string} last_message_id - ID of the last message.
+     * @returns {Promise<Plan>} The generated Plan from messages.
      */
     private async generatePlanFromMessages(thread_id: string, last_message_id: string): Promise<Plan> {
         // Find the new messages
@@ -452,8 +467,9 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param state
      * @private
+     * @param {TurnState} state - The application Turn State.
+     * @returns {AssistantsState} - The current Assistant's State.
      */
     private ensureAssistantsState(state: TState): AssistantsState {
         if (!state.hasValue(this._options.assistants_state_variable!)) {
@@ -468,8 +484,8 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param state
-     * @param assistants_state
+     * @param {TurnState} state - The application Turn State.
+     * @param {AssistantsState} assistants_state - The Assistant's State.
      * @private
      */
     private updateAssistantsState(state: TState, assistants_state: AssistantsState): void {
@@ -477,9 +493,10 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param state
-     * @param input
      * @private
+     * @param {TurnState} state - The application Turn State.
+     * @param {string} input - The thread input.
+     * @returns {Promise<string>} The created thread.
      */
     private async ensureThreadCreated(state: TState, input: string): Promise<string> {
         const assistants_state = this.ensureAssistantsState(state);
@@ -493,8 +510,9 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
     }
 
     /**
-     * @param thread_id
      * @private
+     * @param {string} thread_id - The id of the thread.
+     * @returns {Promise<void>} A Promise.
      */
     private async blockOnInProgressRuns(thread_id: string): Promise<void> {
         // We loop until we're told the last run is completed

--- a/js/packages/teams-ai/src/prompts/AssistantMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/AssistantMessage.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { AssistantMessage } from './AssistantMessage';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
@@ -8,7 +8,7 @@ import { TestTurnState } from '../internals/testing/TestTurnState';
 describe('AssistantMessage', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a AssistantMessage', () => {
@@ -42,7 +42,7 @@ describe('AssistantMessage', () => {
                 const section = new AssistantMessage('Hello World');
                 const rendered = await section.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'assistant: Hello World');
-                assert.equal(rendered.length, 6);
+                assert.equal(rendered.length, 5);
                 assert.equal(rendered.tooLong, false);
             });
         });

--- a/js/packages/teams-ai/src/prompts/ConversationHistory.spec.ts
+++ b/js/packages/teams-ai/src/prompts/ConversationHistory.spec.ts
@@ -2,13 +2,13 @@ import { strict as assert } from 'assert';
 import { ConversationHistory } from './ConversationHistory';
 import { TestAdapter } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { TestTurnState } from '../internals/testing/TestTurnState';
 
 describe('ConversationHistory', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const conversation = {
         history: [
             { role: 'user', content: 'Hello' },
@@ -104,7 +104,7 @@ describe('ConversationHistory', () => {
                 const section = new ConversationHistory('conversation.history', 100);
                 const rendered = await section.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'user: Hello\nassistant: Hi');
-                assert.equal(rendered.length, 8);
+                assert.equal(rendered.length, 7);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -115,7 +115,7 @@ describe('ConversationHistory', () => {
                 const section = new ConversationHistory('conversation.history', 1);
                 const rendered = await section.renderAsText(context, state, functions, tokenizer, 4);
                 assert.equal(rendered.output, 'assistant: Hi');
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -148,7 +148,7 @@ describe('ConversationHistory', () => {
                 const section = new ConversationHistory('conversation.longHistory', 100, true);
                 const rendered = await section.renderAsText(context, state, functions, tokenizer, 2);
                 assert.equal(rendered.output, 'assistant: Sure, where would you like to go?');
-                assert.equal(rendered.length, 12);
+                assert.equal(rendered.length, 11);
                 assert.equal(rendered.tooLong, true);
             });
         });

--- a/js/packages/teams-ai/src/prompts/DataSourceSection.spec.ts
+++ b/js/packages/teams-ai/src/prompts/DataSourceSection.spec.ts
@@ -4,13 +4,13 @@ import { DataSourceSection } from './DataSourceSection';
 import { TextDataSource } from '../dataSources/TextDataSource';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 
 describe('DataSourceSection', () => {
     const textDataSource = new TextDataSource('testname', 'Hello World!');
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a DataSourceSection', () => {

--- a/js/packages/teams-ai/src/prompts/FunctionCallMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/FunctionCallMessage.spec.ts
@@ -4,7 +4,7 @@ import { FunctionCallMessage } from './FunctionCallMessage';
 import { FunctionCall } from './Message';
 import { TestTurnState } from '../internals/testing/TestTurnState';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 
 describe('FunctionCallMessage', () => {
     const functionCall: FunctionCall = {
@@ -13,7 +13,7 @@ describe('FunctionCallMessage', () => {
     };
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a FunctionCallMessage', () => {
@@ -38,7 +38,7 @@ describe('FunctionCallMessage', () => {
                 assert.deepEqual(rendered.output, [
                     { role: 'assistant', content: undefined, function_call: functionCall }
                 ]);
-                assert.equal(rendered.length, 17);
+                assert.equal(rendered.length, 14);
                 assert.equal(rendered.tooLong, false);
             });
         });

--- a/js/packages/teams-ai/src/prompts/FunctionResponseMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/FunctionResponseMessage.spec.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { TestAdapter } from 'botbuilder-core';
 import { TestTurnState } from '../internals/testing/TestTurnState';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { FunctionResponseMessage } from './FunctionResponseMessage';
 
 describe('FunctionResponseMessage', () => {
@@ -10,7 +10,7 @@ describe('FunctionResponseMessage', () => {
     const response = 'bar';
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a FunctionResponseMessage', () => {

--- a/js/packages/teams-ai/src/prompts/GroupSection.spec.ts
+++ b/js/packages/teams-ai/src/prompts/GroupSection.spec.ts
@@ -2,14 +2,14 @@ import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { GroupSection } from './GroupSection';
 import { TextSection } from './TextSection';
 
 describe('GroupSection', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a GroupSection', () => {
@@ -59,7 +59,7 @@ describe('GroupSection', () => {
                 const section = new GroupSection([new TextSection('Hello', 'user'), new TextSection('World', 'user')]);
                 const rendered = await section.renderAsMessages(context, state, functions, tokenizer, 100);
                 assert.deepEqual(rendered.output, [{ role: 'system', content: 'Hello\n\nWorld' }]);
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -73,7 +73,7 @@ describe('GroupSection', () => {
                 ]);
                 const rendered = await section.renderAsMessages(context, state, functions, tokenizer, 100);
                 assert.deepEqual(rendered.output, [{ role: 'system', content: 'Hello\n\nWorld' }]);
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -108,7 +108,7 @@ describe('GroupSection', () => {
                 const section = new GroupSection([new TextSection('Hello', 'user'), new TextSection('World', 'user')]);
                 const rendered = await section.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'Hello\n\nWorld');
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -122,7 +122,7 @@ describe('GroupSection', () => {
                 ]);
                 const rendered = await section.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'Hello\n\nWorld');
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });

--- a/js/packages/teams-ai/src/prompts/Prompt.spec.ts
+++ b/js/packages/teams-ai/src/prompts/Prompt.spec.ts
@@ -4,12 +4,12 @@ import { Prompt } from './Prompt';
 import { TextSection } from './TextSection';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 
 describe('Prompt', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a Prompt', () => {
@@ -113,7 +113,7 @@ describe('Prompt', () => {
                 const prompt = new Prompt([new TextSection('Hello', 'user'), new TextSection('World', 'user')]);
                 const rendered = await prompt.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'Hello\n\nWorld');
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -127,7 +127,7 @@ describe('Prompt', () => {
                 ]);
                 const rendered = await prompt.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'Hello\n\nWorld');
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -163,7 +163,7 @@ describe('Prompt', () => {
                 ]);
                 const rendered = await prompt.renderAsText(context, state, functions, tokenizer, 100);
                 assert.equal(rendered.output, 'Hello\n\nThere Big\n\nWorld');
-                assert.equal(rendered.length, 8);
+                assert.equal(rendered.length, 6);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -195,7 +195,7 @@ describe('Prompt', () => {
                 ]);
                 const rendered = await prompt.renderAsText(context, state, functions, tokenizer, 4);
                 assert.equal(rendered.output, 'Hello\n\nWorld');
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, false);
             });
         });
@@ -229,7 +229,7 @@ describe('Prompt', () => {
                 ]);
                 const rendered = await prompt.renderAsText(context, state, functions, tokenizer, 2);
                 assert.equal(rendered.output, 'Hello\n\nWorld');
-                assert.equal(rendered.length, 4);
+                assert.equal(rendered.length, 3);
                 assert.equal(rendered.tooLong, true);
             });
         });

--- a/js/packages/teams-ai/src/prompts/Prompt.ts
+++ b/js/packages/teams-ai/src/prompts/Prompt.ts
@@ -17,10 +17,10 @@ import { LayoutEngine } from './LayoutEngine';
 export class Prompt extends LayoutEngine {
     /**
      * Creates a new 'Prompt' instance.
-     * @param sections Sections to render.
-     * @param tokens Optional. Sizing strategy for this section. Defaults to `auto`.
-     * @param required Optional. Indicates if this section is required. Defaults to `true`.
-     * @param separator Optional. Separator to use between sections when rendering as text. Defaults to `\n\n`.
+     * @param {PromptSection[]} sections - Sections to render.
+     * @param {number} tokens - Optional. Sizing strategy for this section. Defaults to -1, 'auto'.
+     * @param {boolean} required - Optional. Indicates if this section is required. Defaults to `true`.
+     * @param {string} separator - Optional. Separator to use between sections when rendering as text. Defaults to `\n\n`.
      */
     public constructor(
         sections: PromptSection[],

--- a/js/packages/teams-ai/src/prompts/PromptManager.ts
+++ b/js/packages/teams-ai/src/prompts/PromptManager.ts
@@ -283,7 +283,6 @@ export class PromptManager implements PromptFunctions {
 
             // Load prompt config
             try {
-                // eslint-disable-next-line security/detect-non-literal-fs-filename
                 const config = await fs.readFile(configFile, 'utf-8');
                 template.config = JSON.parse(config);
             } catch (err: unknown) {
@@ -295,7 +294,6 @@ export class PromptManager implements PromptFunctions {
             // Load prompt text
             let sections: PromptSection[] = [];
             try {
-                // eslint-disable-next-line security/detect-non-literal-fs-filename
                 const role = this._options.role || 'system';
                 const prompt = await fs.readFile(promptFile, 'utf-8');
                 sections.push(new TemplateSection(prompt, role));
@@ -307,7 +305,6 @@ export class PromptManager implements PromptFunctions {
 
             // Load optional actions
             try {
-                // eslint-disable-next-line security/detect-non-literal-fs-filename
                 const actions = await fs.readFile(actionsFile, 'utf-8');
                 template.actions = JSON.parse(actions);
             } catch (err: unknown) {
@@ -364,7 +361,6 @@ export class PromptManager implements PromptFunctions {
 
             // Check for prompt existence
             try {
-                // eslint-disable-next-line security/detect-non-literal-fs-filename
                 await fs.access(promptFile);
             } catch (err: unknown) {
                 return false;

--- a/js/packages/teams-ai/src/prompts/PromptSectionBase.spec.ts
+++ b/js/packages/teams-ai/src/prompts/PromptSectionBase.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { TestAdapter, TurnContext } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer, Tokenizer } from '../tokenizers';
+import { GPTTokenizer, Tokenizer } from '../tokenizers';
 import { TurnState } from '../TurnState';
 import { PromptFunctions } from './PromptFunctions';
 import { PromptSectionBase } from './PromptSectionBase';
@@ -44,7 +44,7 @@ export class MultiTestSection extends PromptSectionBase {
 describe('PromptSectionBase', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a TestSection', () => {

--- a/js/packages/teams-ai/src/prompts/SystemMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/SystemMessage.spec.ts
@@ -2,13 +2,13 @@ import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { SystemMessage } from './SystemMessage';
 
 describe('SystemMessage', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a SystemMessage', () => {

--- a/js/packages/teams-ai/src/prompts/TemplateSection.spec.ts
+++ b/js/packages/teams-ai/src/prompts/TemplateSection.spec.ts
@@ -3,11 +3,11 @@ import { TemplateSection } from './TemplateSection';
 import { TestAdapter } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 
 describe('TemplateSection', () => {
     const adapter = new TestAdapter();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const functions = new TestPromptManager()
         .addFunction('test', async (context, state, functions, tokenizer, args) => 'Hello World')
         .addFunction('test2', async (context, state, functions, tokenizer, args) => args[0])

--- a/js/packages/teams-ai/src/prompts/TextSection.spec.ts
+++ b/js/packages/teams-ai/src/prompts/TextSection.spec.ts
@@ -2,13 +2,13 @@ import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { TextSection } from './TextSection';
 
 describe('TextSection', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a TextSection', () => {

--- a/js/packages/teams-ai/src/prompts/UserInputMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/UserInputMessage.spec.ts
@@ -5,14 +5,14 @@ import { createTestTurnContextAndState } from '../internals/testing/TestUtilitie
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TeamsAdapter } from '../TeamsAdapter';
 import { UserInputMessage } from './UserInputMessage';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 
 describe('UserInputMessage', () => {
     const adapter = new TeamsAdapter();
     const userInputMessage = new UserInputMessage(100);
 
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const base64String =
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAAXNSR0IArs4c6QAAAJBJREFUaEPtksEJADAMhJL9l+4OglCC/Z8Q7c6Rt0fumA75rWRFKiIZ6GtJYjG2IlidNKyIJBZjK4LVScOKSGIxtiJYnTSsiCQWYyuC1UnDikhiMbYiWJ00rIgkFmMrgtVJw4pIYjG2IlidNKyIJBZjK4LVScOKSGIxtiJYnTSsiCQWYyuC1UnDikhiMfZMkQcQkQAzneSfdgAAAABJRU5ErkJggg==';
 

--- a/js/packages/teams-ai/src/prompts/UserMessage.spec.ts
+++ b/js/packages/teams-ai/src/prompts/UserMessage.spec.ts
@@ -2,13 +2,13 @@ import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { UserMessage } from './UserMessage';
 
 describe('UserMessage', () => {
     const adapter = new TestAdapter();
     const functions = new TestPromptManager();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a UserMessage', () => {

--- a/js/packages/teams-ai/src/tokenizers/GPTTokenizer.spec.ts
+++ b/js/packages/teams-ai/src/tokenizers/GPTTokenizer.spec.ts
@@ -1,0 +1,29 @@
+import { strict as assert } from 'assert';
+import { GPTTokenizer } from './GPTTokenizer';
+
+describe('GPTTokenizer', () => {
+    describe('constructor', () => {
+        it('should create a GPTTokenizer', () => {
+            const tokenizer = new GPTTokenizer();
+            assert.notEqual(tokenizer, null);
+        });
+    });
+
+    let encoded: number[] = [];
+    describe('encode', () => {
+        it('should encode a string', async () => {
+            const tokenizer = new GPTTokenizer();
+            encoded = await tokenizer.encode('Hello World');
+            assert.equal(encoded.length, 2);
+            assert.equal(typeof encoded[0], 'number');
+        });
+    });
+
+    describe('decode', () => {
+        it('should decode an array of numbers', async () => {
+            const tokenizer = new GPTTokenizer();
+            const decoded = await tokenizer.decode(encoded);
+            assert.equal(decoded, 'Hello World');
+        });
+    });
+});

--- a/js/packages/teams-ai/src/tokenizers/GPTTokenizer.ts
+++ b/js/packages/teams-ai/src/tokenizers/GPTTokenizer.ts
@@ -7,12 +7,13 @@
  */
 
 import { Tokenizer } from './Tokenizer';
-import { encode, decode } from 'gpt-tokenizer/cjs/model/text-davinci-003';
+import { encode, decode } from 'gpt-tokenizer';
 
 /**
- * Tokenizer that uses GPT-3's encoder.
+ * Tokenizer that uses GPT's cl100k_base encoding.
+ * To use GPT-3 encoding, pass in an instance of GPT3Tokenizer.
  */
-export class GPT3Tokenizer implements Tokenizer {
+export class GPTTokenizer implements Tokenizer {
     public decode(tokens: number[]): string {
         return decode(tokens);
     }

--- a/js/packages/teams-ai/src/tokenizers/index.ts
+++ b/js/packages/teams-ai/src/tokenizers/index.ts
@@ -7,4 +7,5 @@
  */
 
 export * from './GPT3Tokenizer';
+export * from './GPTTokenizer';
 export * from './Tokenizer';

--- a/js/packages/teams-ai/src/validators/ActionResponseValidator.spec.ts
+++ b/js/packages/teams-ai/src/validators/ActionResponseValidator.spec.ts
@@ -3,12 +3,12 @@ import { TestAdapter } from 'botbuilder';
 import { TestTurnState } from '../internals/testing/TestTurnState';
 import { ChatCompletionAction } from '../models';
 import { Message } from '../prompts';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { ActionResponseValidator } from './ActionResponseValidator';
 
 describe('ActionResponseValidator', () => {
     const adapter = new TestAdapter();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const actions: ChatCompletionAction[] = [
         {
             name: 'test',

--- a/js/packages/teams-ai/src/validators/DefaultResponseValidator.spec.ts
+++ b/js/packages/teams-ai/src/validators/DefaultResponseValidator.spec.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { DefaultResponseValidator } from './DefaultResponseValidator';
 
 describe('DefaultResponseValidator', () => {
     const adapter = new TestAdapter();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
 
     describe('constructor', () => {
         it('should create a DefaultResponseValidator', () => {

--- a/js/packages/teams-ai/src/validators/JSONResponseValidator.spec.ts
+++ b/js/packages/teams-ai/src/validators/JSONResponseValidator.spec.ts
@@ -3,13 +3,13 @@ import * as sinon from 'sinon';
 import { TestAdapter } from 'botbuilder';
 
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { GPT3Tokenizer } from '../tokenizers';
+import { GPTTokenizer } from '../tokenizers';
 import { JSONResponseValidator } from './JSONResponseValidator';
 import { Schema, ValidationError } from 'jsonschema';
 
 describe('JSONResponseValidator', () => {
     const adapter = new TestAdapter();
-    const tokenizer = new GPT3Tokenizer();
+    const tokenizer = new GPTTokenizer();
     const schema: Schema = {
         type: 'object',
         properties: {

--- a/js/packages/teams-ai/tsconfig.json
+++ b/js/packages/teams-ai/tsconfig.json
@@ -7,5 +7,5 @@
         "sourceMap": true
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "lib"]
+    "exclude": ["node_modules", "lib", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Linked issues

closes: #1171 

## Details

In favor of more accurate token calculation, I have removed `gpt-3-encoder` and replaced with `gpt-tokenizer`, which is a TypeScript rewrite and modernization of the original package. By default, `gpt-tokenizer` uses `cl100k_base` (gpt 3.5 and gpt 4) encoding and can be configured as needed to use different encoders for other models.

As an example, GPT3Tokenizer has been updated to use encoder/decoder for text-davinci-003 and can be passed in to be used in LLMClient. (See `GPT3Tokenizer`)

- Remove package `gpt-3-encoder`
- Add package `gpt-tokenizer` (to replace above)
- Create `GPTTokenizer.ts` as the default encoder.
- `GPT3Tokenizer` now uses `gpt-tokenizer`
- Add unit tests / fix unit tests to use `GPTTokenizer`


## Other changes
- Update docs (`teams-ai.api.json` and `teams-ai.api.md`)
- Prevent test files from being published (`tsconfig`)
- Update inline docs to Application, Meetings, Utilities, ActionAugmentationSection, DefaultAugmentation, MonologueAugmentation, SequenceAugmentation, TeamsBotSSOPrompt, TeamsSSOAdaptiveCardAuthentication, TeamsSSOBotAuthentication, TeamsSSOMessageExtensionAuthentication, TextDataSource, TestMemoryFork, OpenAIModel, ActionPlanner, AssistantsPlanner, LLMClient, Prompt, PromptManager,
- Turn off "no-prototype-builtins" eslint rule
- Fix broken link in `/js/packages/teams-ai/README.md`

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

