### PR TITLE
[JS] chore: prepare for 1.1.1 release

### DIFF
--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -2,7 +2,7 @@
     "name": "@microsoft/teams-ai",
     "author": "Microsoft Corp.",
     "description": "SDK focused on building AI based applications for Microsoft Teams.",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "license": "MIT",
     "keywords": [
         "botbuilder",

--- a/js/samples/01.messaging.a.echoBot/package.json
+++ b/js/samples/01.messaging.a.echoBot/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.22.1",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/02.messageExtensions.a.searchCommand/package.json
+++ b/js/samples/02.messageExtensions.a.searchCommand/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.22.1",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0",

--- a/js/samples/03.adaptiveCards.a.typeAheadBot/package.json
+++ b/js/samples/03.adaptiveCards.a.typeAheadBot/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.22.1",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0",

--- a/js/samples/04.ai.a.teamsChefBot/package.json
+++ b/js/samples/04.ai.a.teamsChefBot/package.json
@@ -20,7 +20,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "@microsoft/teamsfx": "^2.3.0",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/04.ai.b.messageExtensions.AI-ME/package.json
+++ b/js/samples/04.ai.b.messageExtensions.AI-ME/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.22.1",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/04.ai.c.actionMapping.lightBot/package.json
+++ b/js/samples/04.ai.c.actionMapping.lightBot/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.22.1",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/04.ai.d.chainedActions.listBot/package.json
+++ b/js/samples/04.ai.d.chainedActions.listBot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",

--- a/js/samples/04.ai.e.chainedActions.devOpsBot/package.json
+++ b/js/samples/04.ai.e.chainedActions.devOpsBot/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.22.1",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/04.ai.f.vision.cardGazer/package.json
+++ b/js/samples/04.ai.f.vision.cardGazer/package.json
@@ -20,7 +20,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "@microsoft/teamsfx": "^2.3.0",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/04.ai.g.LLAMA/appPackage/build/manifest.local.json
+++ b/js/samples/04.ai.g.LLAMA/appPackage/build/manifest.local.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.16/MicrosoftTeams.schema.json",
+    "version": "1.0.0",
+    "manifestVersion": "1.16",
+    "id": "fbfe2898-f176-401c-9f7d-833051854d67",
+    "packageName": "com.package.name",
+    "name": {
+        "short": "LLAMA-bot-local",
+        "full": "Meta LLAMA bot"
+    },
+    "developer": {
+        "name": "Microsoft Teams",
+        "mpnId": "",
+        "websiteUrl": "https://teams.microsoft.com",
+        "privacyUrl": "https://privacy.microsoft.com/privacystatement",
+        "termsOfUseUrl": "https://www.microsoft.com/legal/terms-of-use"
+    },
+    "description": {
+        "short": "Sample utilizing Meta LLAMA in a custom model",
+        "full": "Sample utilizing Meta LLAMA in a custom model"
+    },
+    "icons": {
+        "outline": "outline.png",
+        "color": "color.png"
+    },
+    "accentColor": "#FFFFFF",
+    "composeExtensions": [
+        {
+            "botId": "5028b225-0ae1-4601-965c-95c107920b07",
+            "commands": [],
+            "canUpdateConfiguration": true
+        }
+    ],
+    "permissions": [
+        "identity",
+        "messageTeamMembers"
+    ],
+    "validDomains": [
+        "zf6zd359-3978.usw2.devtunnels.ms"
+    ]
+}

--- a/js/samples/04.e.twentyQuestions/package.json
+++ b/js/samples/04.e.twentyQuestions/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.22.1",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/05.chatModeration/package.json
+++ b/js/samples/05.chatModeration/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "axios": "^1.6.7",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/06.assistants.a.mathBot/package.json
+++ b/js/samples/06.assistants.a.mathBot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "axios": "^1.6.7",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/06.assistants.b.orderBot/package.json
+++ b/js/samples/06.assistants.b.orderBot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "axios": "^1.6.7",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/06.auth.oauth.adaptiveCard/package.json
+++ b/js/samples/06.auth.oauth.adaptiveCard/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",

--- a/js/samples/06.auth.oauth.bot/package.json
+++ b/js/samples/06.auth.oauth.bot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "botbuilder": "^4.22.1",
         "botbuilder-dialogs": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/06.auth.oauth.messageExtension/package.json
+++ b/js/samples/06.auth.oauth.messageExtension/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "botbuilder": "^4.22.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",

--- a/js/samples/06.auth.teamsSSO.bot/package.json
+++ b/js/samples/06.auth.teamsSSO.bot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "botbuilder": "^4.22.1",
         "botbuilder-dialogs": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/06.auth.teamsSSO.messageExtension/package.json
+++ b/js/samples/06.auth.teamsSSO.messageExtension/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "botbuilder": "^4.22.1",
         "botbuilder-azure-blobs": "^4.22.1",
         "dotenv": "^16.4.5",

--- a/js/samples/07.whoBot/package.json
+++ b/js/samples/07.whoBot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.1.0",
+        "@microsoft/teams-ai": "~1.1.1",
         "botbuilder": "^4.22.1",
         "botbuilder-dialogs": "^4.22.1",
         "dotenv": "^16.4.5",


### PR DESCRIPTION
#minor

This PR bumps the teams-ai package version to 1.1.1 and updates all samples to use the same version.