### PR TITLE
[JS] chore: update node version to LTS

### DIFF
--- a/.github/workflows/js-build-test-lint.yml
+++ b/.github/workflows/js-build-test-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/js-build-test-lint.yml
+++ b/.github/workflows/js-build-test-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
     defaults:
       run:
         shell: bash

--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -13,7 +13,7 @@
         "ai"
     ],
     "engines": {
-        "node": ">=18.0.0"
+        "node": "18.x"
     },
     "bugs": {
         "url": "https://github.com/microsoft/teams-ai/issues"

--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -13,7 +13,7 @@
         "ai"
     ],
     "engines": {
-        "node": "^16 || ^18"
+        "node": ">=18.0.0"
     },
     "bugs": {
         "url": "https://github.com/microsoft/teams-ai/issues"

--- a/pipelines/javascript.yml
+++ b/pipelines/javascript.yml
@@ -14,7 +14,7 @@ pool:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '16.x'
+    versionSpec: '18.x'
   displayName: 'Install Node'
 
 - script: 'npm i -g yarn'


### PR DESCRIPTION
## Linked issues

#minor

## Details

since version `16.x` is EOL https://nodejs.github.io/nodejs.dev/en/about/releases/#:~:text=Major%20Node.js%20versions%20enter%20Current%20release%20status%20for,LTS%20status%20and%20are%20ready%20for%20general%20use. we should now use >= 18.x