### PR TITLE
feat: do not run poetry install during local debug

### DIFF
--- a/python/samples/04.ai.c.actionMapping.lightBot/teamsapp.local.yml
+++ b/python/samples/04.ai.c.actionMapping.lightBot/teamsapp.local.yml
@@ -63,15 +63,6 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
 deploy:
-  # prerequisite: pip install
-  - uses: script
-    with:
-      run: pip install poetry
-
-  - uses: script
-    with:
-      run: poetry install
-
   # Defines what the `deploy` lifecycle step does with Teams Toolkit.
   # Runs after `provision` during Start Debugging (F5) or run manually using `teamsfx deploy --env local`.
   # Provides the Teams Toolkit .env file values to the apps runtime so they can be accessed with `process.env`.

--- a/python/samples/05.chatModeration/teamsapp.local.yml
+++ b/python/samples/05.chatModeration/teamsapp.local.yml
@@ -63,15 +63,6 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
 deploy:
-  # prerequisite: pip install
-  - uses: script
-    with:
-      run: pip install poetry
-
-  - uses: script
-    with:
-      run: poetry install
-
   # Defines what the `deploy` lifecycle step does with Teams Toolkit.
   # Runs after `provision` during Start Debugging (F5) or run manually using `teamsfx deploy --env local`.
   # Provides the Teams Toolkit .env file values to the apps runtime so they can be accessed with `process.env`.


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details

Do not run poetry install during local debug, so we don't need to maintain the install commands to ensure compatibility under different environment.
VS Code Python extension will take care of dependency install as virtual environment management. This is also recommended by Python team.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

