### PR TITLE
[PY] fix: bad grammar to avoid no attribute error

### DIFF
--- a/python/packages/ai/teams/ai/augmentations/monologue_augmentation.py
+++ b/python/packages/ai/teams/ai/augmentations/monologue_augmentation.py
@@ -233,14 +233,14 @@ class MonologueAugmentation(Augmentation[InnerMonologue]):
             command: PredictedCommand
             monologue: InnerMonologue = response.message.content
 
-            if monologue.action.name == "SAY":
-                params = monologue.action.parameters
+            if monologue['action']['name'] == "SAY":
+                params = monologue['action']['parameters']
                 response_val = cast(str, params.get("text")) if params else ""
                 command = PredictedSayCommand(response=response_val)
             else:
                 command = PredictedDoCommand(
-                    action=monologue.action.name,
-                    parameters=monologue.action.parameters if monologue.action.parameters else {},
+                    action=monologue['action']['name'],
+                    parameters=monologue['action']['parameters'] if monologue['action']['parameters'] else {},
                 )
             return Plan(commands=[command])
         return Plan()

--- a/python/packages/ai/tests/ai/augmentations/test_monologue_augmentation.py
+++ b/python/packages/ai/tests/ai/augmentations/test_monologue_augmentation.py
@@ -137,10 +137,10 @@ class TestMonologueAugmentation(IsolatedAsyncioTestCase):
             PromptResponse[InnerMonologue](
                 message=Message(
                     role="assistant",
-                    content=InnerMonologue(
-                        thoughts=Thoughts(thought="test", reasoning="test", plan="test"),
-                        action=Action(name="SAY", parameters={"text": "hello world"}),
-                    ),
+                    content=InnerMonologue({
+                        "thoughts": {"thought": "test", "reasoning": "test", "plan": "test"},
+                        "action": {"name": "SAY", "parameters": {"text": "hello world"}},
+                    }),
                 )
             ),
         )
@@ -157,10 +157,10 @@ class TestMonologueAugmentation(IsolatedAsyncioTestCase):
             PromptResponse[InnerMonologue](
                 message=Message(
                     role="assistant",
-                    content=InnerMonologue(
-                        thoughts=Thoughts(thought="test", reasoning="test", plan="test"),
-                        action=Action(name="test", parameters={"foo": "bar"}),
-                    ),
+                    content=InnerMonologue({
+                        "thoughts": {"thought": "test", "reasoning": "test", "plan": "test"},
+                        "action": {"name": "test", "parameters": {"foo": "bar"}},
+                    }),
                 )
             ),
         )


### PR DESCRIPTION
## Linked issues

closes: #1396

## Details

1. Configure a monologue type augmentation type prompt.
2. Use this prompt to create your action planner to process messages.
3. When calling `create_plan_from_response()` using monologue, error reports: AttributeError: 'dict' object has no attribute 'action'
![image](https://github.com/microsoft/teams-ai/assets/109947924/1a153668-f044-4fa4-9544-0d40b6e5a092)


#### Change details

Fix bad grammer for monologue, which is dict type. Change `monologue.action.name` to `monologue['action'][''name]`

**code snippets**:
```
if monologue['action']['name'] == "SAY":
    params = monologue['action']['parameters']
    response_val = cast(str, params.get("text")) if params else ""
    command = PredictedSayCommand(response=response_val)
else:
    command = PredictedDoCommand(
        action=monologue['action']['name'],
        parameters=monologue['action']['parameters'] if monologue['action']['parameters'] else {},
    )
```
**screenshots**:

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
