### PR TITLE
[JS] fix: retrieving name and parameter values from monologue augmentations

### DIFF
--- a/python/packages/ai/teams/ai/augmentations/monologue_augmentation.py
+++ b/python/packages/ai/teams/ai/augmentations/monologue_augmentation.py
@@ -231,7 +231,8 @@ class MonologueAugmentation(Augmentation[InnerMonologue]):
         # Identify the action to perform
         if response.message and response.message.content:
             command: PredictedCommand
-            monologue: InnerMonologue = response.message.content
+            # Double encoding/decoding required for class
+            monologue = InnerMonologue.from_dict(InnerMonologue.to_dict(response.message.content))
 
             if monologue.action.name == "SAY":
                 params = monologue.action.parameters


### PR DESCRIPTION
## Linked issues

closes: #1396

## Details

Resolves attribute error of the InnerMonologue object- by performing a double conversion to an Inner Monologue.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
