### PR TITLE
bug fix

### DIFF
--- a/js/packages/teams-ai/src/authentication/MessageExtensionAuthenticationBase.ts
+++ b/js/packages/teams-ai/src/authentication/MessageExtensionAuthenticationBase.ts
@@ -1,4 +1,4 @@
-import { ActivityTypes, InvokeResponse, TokenResponse, TurnContext } from 'botbuilder';
+import { ActivityTypes, CardAction, InvokeResponse, TokenResponse, TurnContext } from 'botbuilder';
 import { MessageExtensionsInvokeNames } from '../MessageExtensions';
 
 /**
@@ -6,6 +6,14 @@ import { MessageExtensionsInvokeNames } from '../MessageExtensions';
  * Base class to handle authentication for Teams Message Extension.
  */
 export abstract class MessageExtensionAuthenticationBase {
+    private readonly title: string;
+    private readonly text: string;
+
+    public constructor(title?: string, text?: string) {
+        this.title = title ?? 'Bot Service OAuth';
+        this.text = text ?? "You'll need to signin to use this app.";
+    }
+
     /**
      * Authenticates the user.
      * @param {TurnContext} context - The turn context.
@@ -65,8 +73,10 @@ export abstract class MessageExtensionAuthenticationBase {
                         {
                             type: 'openUrl',
                             value: signInLink,
-                            title: 'Bot Service OAuth'
-                        }
+                            title: this.title,
+                            text: this.text,
+                            displayText: this.text
+                        } as CardAction
                     ]
                 }
             }

--- a/js/packages/teams-ai/src/authentication/OAuthMessageExtensionAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthMessageExtensionAuthentication.ts
@@ -18,7 +18,7 @@ export class OAuthPromptMessageExtensionAuthentication extends MessageExtensionA
      * @param {OAuthSettings} settings The OAuthPromptSettings.
      */
     public constructor(private readonly settings: OAuthSettings) {
-        super();
+        super(settings.title, settings.text);
     }
 
     /**


### PR DESCRIPTION
## Linked issues

closes: #1417  (issue number)

## Details

Provide a list of your changes here. If you are fixing a bug, please provide steps to reproduce the bug.

#### Change details
* Updating `MessageExtensionAuthenticationBase` class to take in "title" and "text" paramters in it's constructor which it then uses to populate the auth invoke response. If not provided, it uses default hardcoded strings.
* I've only updated this for `OAuthMessageExtensionAuthentication` as the `TeamsSsoMessageExtensionAuthentication` settings (TeamsSsoSetting) does not currently support `title` and `text` properties.

**screenshots**:

I tested it in the ME OAuth bot and the title updated correctly. The text however did not, it is most likely a frontend issue. I've reached out to them about it.
![image](https://github.com/microsoft/teams-ai/assets/115390646/aafa8753-80bb-4348-a95d-a87d9d29fc12)


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
