### PR TITLE
[JS] chore: Remove devTools folder from sample app

### DIFF
--- a/js/samples/08.datasource.azureOpenAI/devTools/teamsapptester/package.json
+++ b/js/samples/08.datasource.azureOpenAI/devTools/teamsapptester/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "@microsoft/teams-app-test-tool": "~0.1.0-beta"
-  }
-}


### PR DESCRIPTION
#minor

Remove folder `devTools` from sample app, otherwise it would fail to run 'Debug in Test Tool' in Teams Toolkit with following error message:

![image](https://github.com/microsoft/teams-ai/assets/15644078/bc2c7840-e4e4-482c-87b5-8191d2ab0ecc)


The folder `devTools` is already included in [.gitignore](https://github.com/microsoft/teams-ai/blob/main/js/samples/08.datasource.azureOpenAI/.gitignore#L115) but was committed by accident, it's safe to remove it.