### PR TITLE
[JS] fix: #1526: Fix typeahead sample's dynamic command

### DIFF
--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/src/cards/dynamicSearchCard.ts
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/src/cards/dynamicSearchCard.ts
@@ -10,7 +10,7 @@ import { Attachment, CardFactory } from 'botbuilder';
 export function createDynamicSearchCard(): Attachment {
     return CardFactory.adaptiveCard({
         $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-        version: '1.3',
+        version: '1.6',
         type: 'AdaptiveCard',
         body: [
             {
@@ -21,35 +21,19 @@ export function createDynamicSearchCard(): Attachment {
             {
                 columns: [
                     {
-                        width: 'stretch',
                         items: [
                             {
-                                choices: [
-                                    {
-                                        title: '@microsoft/teams-ai',
-                                        value: 'microsoft_teams_ai'
-                                    },
-                                    {
-                                        title: '@microsoft/botframework-webchat',
-                                        value: 'microsoft_botframework_webchat'
-                                    },
-                                    {
-                                        title: '@microsoft/botframework-emulator',
-                                        value: 'microsoft_botframework_emulator'
-                                    }
-                                ],
                                 'choices.data': {
                                     type: 'Data.Query',
                                     dataset: 'npmpackages'
                                 },
-                                id: 'choiceSelect',
+                                id: 'dynamicSelect',
                                 type: 'Input.ChoiceSet',
                                 placeholder: 'Package name',
                                 label: 'NPM package search',
                                 isRequired: true,
-                                errorMessage: 'There was an error',
-                                isMultiSelect: true,
-                                style: 'filtered'
+                                errorMessage: 'There was an error x',
+                                isMultiSelect: true
                             }
                         ],
                         type: 'Column'
@@ -61,7 +45,7 @@ export function createDynamicSearchCard(): Attachment {
         actions: [
             {
                 type: 'Action.Submit',
-                title: 'Submit',
+                title: 'DynamicSubmit',
                 data: {
                     verb: 'DynamicSubmit'
                 }

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/src/cards/dynamicSearchCard.ts
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/src/cards/dynamicSearchCard.ts
@@ -32,7 +32,7 @@ export function createDynamicSearchCard(): Attachment {
                                 placeholder: 'Package name',
                                 label: 'NPM package search',
                                 isRequired: true,
-                                errorMessage: 'There was an error x',
+                                errorMessage: 'There was an error',
                                 isMultiSelect: true
                             }
                         ],

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/src/index.ts
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/src/index.ts
@@ -128,13 +128,16 @@ app.adaptiveCards.search('npmpackages', async (context: TurnContext, state: Turn
     return npmPackages;
 });
 
+interface DynamicSubmitData {
+    dynamicSelect?: string;
+}
 interface SubmitData {
     choiceSelect?: string;
 }
 
 // Listen for submit buttons
-app.adaptiveCards.actionSubmit('DynamicSubmit', async (context, _state, data: SubmitData) => {
-    await context.sendActivity(`Dynamically selected option is: ${data.choiceSelect}`);
+app.adaptiveCards.actionSubmit('DynamicSubmit', async (context, _state, data: DynamicSubmitData) => {
+    await context.sendActivity(`Dynamically selected option is: ${data.dynamicSelect}`);
 });
 
 app.adaptiveCards.actionSubmit('StaticSubmit', async (context, _state, data: SubmitData) => {


### PR DESCRIPTION
## Linked issues

closes: #1526

## Details

Fix 'dynamic' command of type ahead sample 
![image](https://github.com/microsoft/teams-ai/assets/14900841/c997f0c0-1f15-4eb0-a738-36f7f28a09d1)

I guess technically this is a workaround, but the name of the button must match the verb's name in the card, per documentation.

![image](https://github.com/microsoft/teams-ai/assets/14900841/d7290241-c341-49c2-b7cc-35693dad2c53)

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

- Updated card schema to 1.6 (minimum for dynamic input)
- Updated submit button name to match card id
- Add interface that matches id of card (`DynamicSelect`)

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
