### PR TITLE
[JS] fix: `signinVerify` invoke may be processed by wrong OAuth Connection

### DIFF
--- a/js/packages/teams-ai/src/Application.ts
+++ b/js/packages/teams-ai/src/Application.ts
@@ -30,6 +30,7 @@ import { TurnState } from './TurnState';
 import { InputFileDownloader } from './InputFileDownloader';
 import {
     deleteUserInSignInFlow,
+    setSettingNameInContextActivityValue,
     setTokenInState,
     setUserInSignInFlow,
     userInSignInFlow
@@ -724,6 +725,9 @@ export class Application<TState extends TurnState = TurnState> {
                         // user was not in a sign in flow, but auto-sign in is enabled
                         settingName = this.authentication.default;
                     }
+
+                    // Sets the setting name in the context object. It is used in `signIn/verifyState` & `signIn/tokenExchange` route selectors.
+                    setSettingNameInContextActivityValue(context, settingName);
 
                     const response = await this._authentication.signUserIn(context, state, settingName);
 

--- a/js/packages/teams-ai/src/authentication/BotAuthenticationBase.spec.ts
+++ b/js/packages/teams-ai/src/authentication/BotAuthenticationBase.spec.ts
@@ -3,6 +3,7 @@ import { TurnState } from '../TurnState';
 import {
     deleteTokenFromState,
     deleteUserInSignInFlow,
+    setSettingNameInContextActivityValue,
     setTokenInState,
     setUserInSignInFlow,
     userInSignInFlow
@@ -90,6 +91,31 @@ describe('BotAuthenticationBase.ts utility functions', () => {
             assert(response == settingName);
         });
     });
+
+    describe('setSettingNameInContextActivityValue()', async () => {
+        it('should create an object with the value and assign it to `context.activity.value`', async () => {
+            const [context, _] = await createTurnContextAndState({});
+            const settingName = 'test setting name';
+
+            setSettingNameInContextActivityValue(context, settingName);
+
+            assert(context.activity.value['settingName'] == settingName);
+        });
+
+        it('should assign the value to the `context.activity.value', async () => {
+            const [context, _] = await createTurnContextAndState({
+                value: {
+                    testProperty: 'testValue'
+                }
+            });
+            const settingName = 'test setting name';
+
+            setSettingNameInContextActivityValue(context, settingName);
+
+            assert(context.activity.value['settingName'] == settingName);
+            assert(context.activity.value['testProperty'] == 'testValue');
+        });
+    })
 
     describe('setUserInSignInFlow()', async () => {
         it('should set user in sign in flow', async () => {

--- a/js/packages/teams-ai/src/authentication/BotAuthenticationBase.ts
+++ b/js/packages/teams-ai/src/authentication/BotAuthenticationBase.ts
@@ -223,12 +223,20 @@ export abstract class BotAuthenticationBase<TState extends TurnState> {
         return (state.conversation as any)[userDialogStatePropertyName] as DialogState;
     }
 
-    protected async verifyStateRouteSelector(context: TurnContext): Promise<boolean> {
-        return context.activity.type === ActivityTypes.Invoke && context.activity.name === verifyStateOperationName;
+    public async verifyStateRouteSelector(context: TurnContext): Promise<boolean> {
+        return (
+            context.activity.type === ActivityTypes.Invoke &&
+            context.activity.name === verifyStateOperationName &&
+            this._settingName == context.activity.value['settingName']
+        );
     }
 
-    protected async tokenExchangeRouteSelector(context: TurnContext): Promise<boolean> {
-        return context.activity.type === ActivityTypes.Invoke && context.activity.name === tokenExchangeOperationName;
+    public async tokenExchangeRouteSelector(context: TurnContext): Promise<boolean> {
+        return (
+            context.activity.type === ActivityTypes.Invoke &&
+            context.activity.name === tokenExchangeOperationName &&
+            this._settingName == context.activity.value['settingName']
+        );
     }
 
     /**
@@ -256,6 +264,22 @@ export abstract class BotAuthenticationBase<TState extends TurnState> {
         state: TState,
         dialogStateProperty: string
     ): Promise<DialogTurnResult<TokenResponse>>;
+}
+
+/**
+ * Sets the setting name in the context.activity.value object.
+ * The setting name is needed in signIn/verifyState` and `signIn/tokenExchange` route selector to accurately route to the correct authentication setting.
+ * @param {TurnContext} context The turn context object
+ * @param {string} settingName The auth setting name
+ */
+export function setSettingNameInContextActivityValue(context: TurnContext, settingName: string) {
+    if (typeof context.activity.value == 'object') {
+        context.activity.value['settingName'] = settingName;
+    } else {
+        context.activity.value = {
+            settingName: settingName
+        };
+    }
 }
 
 /**

--- a/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.spec.ts
+++ b/js/packages/teams-ai/src/authentication/OAuthBotAuthentication.spec.ts
@@ -88,7 +88,11 @@ describe('OAuthBotAuthentication', () => {
             it(`should register route to handle ${activityName}`, async () => {
                 const appSpy = sinon.stub(app, 'addRoute');
 
-                const context = new TurnContext(adapter, { type: 'invoke', name: activityName });
+                const context = new TurnContext(adapter, {
+                    type: 'invoke',
+                    name: activityName,
+                    value: { settingName: settingName }
+                });
 
                 // the selector function used to register the route
                 const selectorFunctionsUsed: RouteSelector[] = [];
@@ -373,6 +377,130 @@ describe('OAuthBotAuthentication', () => {
             assert(result.status == DialogTurnStatus.waiting);
 
             stub.restore();
+        });
+    });
+
+    describe('verifyStateRouteSelector', () => {
+        it('should return true if invoke activity name is `signin/verifyState` & the setting name matches', async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'invoke',
+                name: 'signin/verifyState',
+                value: {
+                    settingName: settingName
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.verifyStateRouteSelector(context);
+
+            assert(response == true);
+        });
+
+        it(`should return false if it's not an invoke activity`, async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'not invoke',
+                name: 'signIn/verifyState',
+                value: {
+                    settingName: settingName
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.verifyStateRouteSelector(context);
+
+            assert(response == false);
+        });
+
+        it(`should return false if it's not 'signIn/verifyState' invoke activity`, async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'invoke',
+                name: 'not signin/verifyState',
+                value: {
+                    settingName: settingName
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.verifyStateRouteSelector(context);
+
+            assert(response == false);
+        });
+
+        it(`should return false if it's setting name is not set or is incorrect`, async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'invoke',
+                name: 'signin/verifyState',
+                value: {
+                    settingName: 'incorrect setting name'
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.verifyStateRouteSelector(context);
+
+            assert(response == false);
+        });
+    });
+
+    describe('tokenExchangeRouteSelector', () => {
+        it('should return true if invoke activity name is `signin/tokenExchange` & the setting name matches', async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'invoke',
+                name: 'signin/tokenExchange',
+                value: {
+                    settingName: settingName
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.tokenExchangeRouteSelector(context);
+
+            assert(response == true);
+        });
+
+        it(`should return false if it's not an invoke activity`, async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'not invoke',
+                name: 'signin/tokenExchange',
+                value: {
+                    settingName: settingName
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.tokenExchangeRouteSelector(context);
+
+            assert(response == false);
+        });
+
+        it(`should return false if it's not 'signin/tokenExchange' invoke activity`, async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'invoke',
+                name: 'not signin/tokenExchange',
+                value: {
+                    settingName: settingName
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.tokenExchangeRouteSelector(context);
+
+            assert(response == false);
+        });
+
+        it(`should return false if it's setting name is not set or is incorrect`, async () => {
+            const [context, _] = await createTurnContextAndState({
+                type: 'invoke',
+                name: 'signin/tokenExchange',
+                value: {
+                    settingName: 'incorrect setting name'
+                }
+            });
+
+            const botAuth = new OAuthBotAuthentication(app, settings, settingName);
+            const response = await botAuth.tokenExchangeRouteSelector(context);
+
+            assert(response == false);
         });
     });
 });

--- a/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.spec.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.spec.ts
@@ -106,7 +106,13 @@ describe('TeamsSsoBotAuthentication', () => {
             const msal = new ConfidentialClientApplication(settings.msalConfig);
             new TeamsSsoBotAuthentication(app, settings, settingName, msal);
 
-            const context = new TurnContext(adapter, { type: 'invoke', name: 'signin/verifyState' });
+            const context = new TurnContext(adapter, {
+                type: 'invoke',
+                name: 'signin/verifyState',
+                value: {
+                    settingName: settingName
+                }
+            });
 
             assert(await selectors[0](context)); // The first selector is for signin/verifyState
         });
@@ -128,7 +134,7 @@ describe('TeamsSsoBotAuthentication', () => {
             const context = new TurnContext(adapter, {
                 type: 'invoke',
                 name: 'signin/tokenExchange',
-                value: { id: `00000000-0000-0000-0000-000000000000-${settingName}` }
+                value: { id: `00000000-0000-0000-0000-000000000000-${settingName}`, settingName: settingName }
             });
 
             assert(await selectors[1](context)); // The second selector is for signin/tokenExchange

--- a/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.ts
+++ b/js/packages/teams-ai/src/authentication/TeamsSsoBotAuthentication.ts
@@ -100,7 +100,7 @@ export class TeamsSsoBotAuthentication<TState extends TurnState> extends BotAuth
      * @param {TurnContext} context - The turn context object.
      * @returns {Promise<boolean>} A promise that resolves to a boolean indicating whether the token exchange route should be processed by current class instance.
      */
-    protected async tokenExchangeRouteSelector(context: TurnContext): Promise<boolean> {
+    public async tokenExchangeRouteSelector(context: TurnContext): Promise<boolean> {
         return (
             (await super.tokenExchangeRouteSelector(context)) &&
             this._tokenExchangeIdRegex.test(context.activity.value.id)


### PR DESCRIPTION
## Linked issues

closes: #minor

#816 - keeping it open until JS/C#/PY fixes have been implemented.

## Details

A detailed description of the problem can be found in the linked issue. The solution - in simple terms - was to add the `settingName` property in the `context.activity.value` property so that the route selectors for `signin/verifyState` and `signin/tokenExchange` will trigger the correct authentication setting. 

#### Change details

* Added a method to populate setting name in the `context.activity.value` property.
* Updated `tokenExchangeRouteSelector` & `verifyStateRouteSelector` to check for the `settingName` in the context object.


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
