### PR TITLE
[PY] fix: Updated EmbeddingsResponse class output property to Optional[Union[Li…

### DIFF
--- a/python/packages/ai/teams/ai/embeddings/embeddings_response.py
+++ b/python/packages/ai/teams/ai/embeddings/embeddings_response.py
@@ -24,7 +24,7 @@ class EmbeddingsResponse:
     status: EmbeddingsResponseStatus
     "Status of the embeddings response."
 
-    output: Optional[Union[List[List[int]], str]] = None
+    output: Optional[Union[List[List[float]], str]] = None
     "Optional. Embeddings for the given inputs or the error string."
 
     message: Optional[str] = None


### PR DESCRIPTION
## Linked issues

closes: #1646

## Details

Modified the EmbeddingsResponse class' output property in teams.ai.embeddings from Optional[Union[List[List[int]], str]] to Optional[Union[List[List[float]], str]], as embeddings are floats and not ints.

#### Change details

`class EmbeddingsResponse` in `teams.ai.embeddings.embeddings_response.py`

before:
```
@dataclass
class EmbeddingsResponse:
...
    output: Optional[Union[List[List[int]], str]] = None
    "Optional. Embeddings for the given inputs or the error string."
...
```
after:
```
@dataclass
class EmbeddingsResponse:
...
    output: Optional[Union[List[List[float]], str]] = None
    "Optional. Embeddings for the given inputs or the error string."
...
```
## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
