### PR TITLE
[PY] fix: update prompts folder path for AI samples to absolute

### DIFF
--- a/python/samples/04.ai.a.twentyQuestions/src/bot.py
+++ b/python/samples/04.ai.a.twentyQuestions/src/bot.py
@@ -53,7 +53,7 @@ elif config.AZURE_OPENAI_KEY and config.AZURE_OPENAI_ENDPOINT:
         )
     )
 
-prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.getcwd()}/src/prompts"))
+prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.path.dirname(os.path.abspath(__file__))}/prompts"))
 storage = MemoryStorage()
 app = Application[AppTurnState](
     ApplicationOptions(

--- a/python/samples/04.ai.b.messageExtensions.AI-ME/src/bot.py
+++ b/python/samples/04.ai.b.messageExtensions.AI-ME/src/bot.py
@@ -49,7 +49,7 @@ elif config.AZURE_OPENAI_KEY and config.AZURE_OPENAI_ENDPOINT:
         )
     )
 
-prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.getcwd()}/prompts"))
+prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.path.dirname(os.path.abspath(__file__))}/prompts"))
 
 planner = ActionPlanner(ActionPlannerOptions(model, prompts, "generate"))
 

--- a/python/samples/04.ai.c.actionMapping.lightBot/src/bot.py
+++ b/python/samples/04.ai.c.actionMapping.lightBot/src/bot.py
@@ -48,7 +48,7 @@ elif config.AZURE_OPENAI_KEY and config.AZURE_OPENAI_ENDPOINT:
         )
     )
 
-prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.getcwd()}/src/prompts"))
+prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.path.dirname(os.path.abspath(__file__))}/prompts"))
 storage = MemoryStorage()
 app = Application[AppTurnState](
     ApplicationOptions(

--- a/python/samples/04.ai.d.chainedActions.listBot/src/bot.py
+++ b/python/samples/04.ai.d.chainedActions.listBot/src/bot.py
@@ -47,7 +47,7 @@ elif config.AZURE_OPENAI_KEY and config.AZURE_OPENAI_ENDPOINT:
         )
     )
 
-prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.getcwd()}/src/prompts"))
+prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.path.dirname(os.path.abspath(__file__))}/prompts"))
 storage = MemoryStorage()
 app = Application[AppTurnState](
     ApplicationOptions(

--- a/python/samples/04.ai.e.chainedActions.devOpsBot/src/bot.py
+++ b/python/samples/04.ai.e.chainedActions.devOpsBot/src/bot.py
@@ -47,7 +47,7 @@ elif config.AZURE_OPENAI_KEY and config.AZURE_OPENAI_ENDPOINT:
         )
     )
 
-prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.getcwd()}/src/prompts"))
+prompts = PromptManager(PromptManagerOptions(prompts_folder=f"{os.path.dirname(os.path.abspath(__file__))}/prompts"))
 storage = MemoryStorage()
 app = Application[AppTurnState](
     ApplicationOptions(

--- a/python/samples/05.chatModeration/src/bot.py
+++ b/python/samples/05.chatModeration/src/bot.py
@@ -62,8 +62,7 @@ elif config.AZURE_OPENAI_KEY and config.AZURE_OPENAI_ENDPOINT:
 
 prompts = PromptManager(
     PromptManagerOptions(
-        prompts_folder=f"{os.getcwd()}/src/prompts"
-        )
+        prompts_folder=f"{os.path.dirname(os.path.abspath(__file__))}/prompts")
     )
 
 planner = ActionPlanner(


### PR DESCRIPTION
## Linked issues

closes: #1639 

## Details

- updated path to prompts folder - previous use of `os.cwd` will use the path where its being executed (hence devs may execute from different entry points and error will be thrown when trying to access config file)

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
