### PR TITLE
[repo] fix: removed HTTPS requirement for AOAI Embeddings

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Embeddings/AzureOpenAIEmbeddingsOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Embeddings/AzureOpenAIEmbeddingsOptions.cs
@@ -43,10 +43,6 @@ namespace Microsoft.Teams.AI.AI.Embeddings
             Verify.ParamNotNull(azureEndpoint);
 
             azureEndpoint = azureEndpoint.Trim();
-            if (!azureEndpoint.StartsWith("https://"))
-            {
-                throw new ArgumentException($"Model created with an invalid endpoint of `{azureEndpoint}`. The endpoint must be a valid HTTPS url.");
-            }
 
             this.AzureApiKey = azureApiKey;
             this.AzureDeployment = azureDeployment;

--- a/js/packages/teams-ai/src/embeddings/OpenAIEmbeddings.ts
+++ b/js/packages/teams-ai/src/embeddings/OpenAIEmbeddings.ts
@@ -157,12 +157,6 @@ export class OpenAIEmbeddings implements EmbeddingsModel {
                 endpoint = endpoint.substring(0, endpoint.length - 1);
             }
 
-            if (!endpoint.toLowerCase().startsWith('https://')) {
-                throw new Error(
-                    `Client created with an invalid endpoint of '${endpoint}'. The endpoint must be a valid HTTPS url.`
-                );
-            }
-
             this.options.azureEndpoint = endpoint;
         } else {
             this._useAzure = false;

--- a/python/packages/ai/teams/ai/embeddings/azure_openai_embeddings.py
+++ b/python/packages/ai/teams/ai/embeddings/azure_openai_embeddings.py
@@ -51,12 +51,6 @@ class AzureOpenAIEmbeddings(EmbeddingsModel):
         if endpoint[-1] == "/":
             endpoint = endpoint[0 : (len(endpoint) - 1)]
 
-        if not endpoint.lower().startswith("https://"):
-            raise ValueError(f"""
-                Client created with an invalid endpoint of \"{endpoint}\".
-                The endpoint must be a valid HTTPS url.
-                """)
-
         self.options.azure_endpoint = endpoint
 
     async def create_embeddings(

--- a/python/packages/ai/tests/ai/embeddings/test_azure_openai_embeddings.py
+++ b/python/packages/ai/tests/ai/embeddings/test_azure_openai_embeddings.py
@@ -93,19 +93,11 @@ class TestOpenAIEmbeddings(IsolatedAsyncioTestCase):
     embeddings: AzureOpenAIEmbeddings
     options_with_array: AzureOpenAIEmbeddingsOptions
     embeddings_with_array: AzureOpenAIEmbeddings
-    options_error: AzureOpenAIEmbeddingsOptions
 
     def setUp(self):
         self.options = AzureOpenAIEmbeddingsOptions(
             azure_api_key="empty",
             azure_endpoint="https://mock.openai.azure.com/",
-            azure_deployment="text-embedding-ada-002",
-            log_requests=True,
-            retry_policy=[2, 4],
-        )
-        self.options_error = AzureOpenAIEmbeddingsOptions(
-            azure_api_key="empty",
-            azure_endpoint="www.mock.openai.azure.com/",
             azure_deployment="text-embedding-ada-002",
             log_requests=True,
             retry_policy=[2, 4],
@@ -121,10 +113,6 @@ class TestOpenAIEmbeddings(IsolatedAsyncioTestCase):
                 "User-Agent": "123",
             },
         )
-
-    async def test_endpoint_error(self):
-        with pytest.raises(ValueError):
-            AzureOpenAIEmbeddings(self.options_error)
 
     @mock.patch("openai.AsyncAzureOpenAI", return_value=MockAsyncAzureOpenAI)
     async def test_string_embedding(self, mock_async_azure_open_ai):

--- a/python/packages/ai/tests/ai/embeddings/test_azure_openai_embeddings.py
+++ b/python/packages/ai/tests/ai/embeddings/test_azure_openai_embeddings.py
@@ -8,7 +8,6 @@ from unittest import IsolatedAsyncioTestCase, mock
 
 import httpx
 import openai
-import pytest
 
 from teams.ai.embeddings.azure_openai_embeddings import AzureOpenAIEmbeddings
 from teams.ai.embeddings.azure_openai_embeddings_options import (


### PR DESCRIPTION
## Linked issues

closes: #1688

## Details

Removed HTTPS url requirement from JS, C#, and Python.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
