### PR TITLE
[C#] chore: fixing check annotations

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/AzureSdkChatMessageExtensions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/AzureSdkChatMessageExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Teams.AI.Tests.AITests.Models
             Assert.Equal($"Invalid ChatCompletionsToolCall type: {nameof(InvalidToolCall)}", ex.Message);
         }
 
-        private class InvalidToolCall : Azure.AI.OpenAI.ChatCompletionsToolCall
+        private sealed class InvalidToolCall : Azure.AI.OpenAI.ChatCompletionsToolCall
         {
             public InvalidToolCall() : base("test-id")
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/ChatMessageExtensionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/ChatMessageExtensionsTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Teams.AI.Tests.AITests.Models
             Assert.Equal("Invalid tool type: invalidToolType", ex.Message);
         }
 
-        private class InvalidToolCall : AI.Models.ChatCompletionsToolCall
+        private sealed class InvalidToolCall : AI.Models.ChatCompletionsToolCall
         {
             public InvalidToolCall() : base("invalidToolType", "test-id")
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/SequentialDelayStrategyTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/SequentialDelayStrategyTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Teams.AI.Tests.AITests.Models
         }
     }
 
-    internal class TestSequentialDelayStrategy : SequentialDelayStrategy
+    internal sealed class TestSequentialDelayStrategy : SequentialDelayStrategy
     {
         public TestSequentialDelayStrategy(List<TimeSpan> delays) : base(delays)
         {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AppConfig.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AppConfig.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication
 {
-    internal class AppConfig : IAppConfig
+    internal sealed class AppConfig : IAppConfig
     {
 #pragma warning disable CS8618 // This class is for test purpose only
         public AppConfig(string clientId, string tenantId)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/OAuthBotAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/OAuthBotAuthenticationTests.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
 {
-    internal class TestOAuthBotAuthentication : OAuthBotAuthentication<TurnState>
+    internal sealed class TestOAuthBotAuthentication : OAuthBotAuthentication<TurnState>
     {
         public TestOAuthBotAuthentication(Application<TurnState> app, OAuthSettings oauthSettings, string settingName, IStorage? storage = null) : base(app, oauthSettings, settingName, storage)
         {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoBotAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoBotAuthenticationTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
 {
     public class TeamsSsoBotAuthenticationTests
     {
-        internal class MockTeamsSsoBotAuthentication<TState> : TeamsSsoBotAuthentication<TState>
+        internal sealed class MockTeamsSsoBotAuthentication<TState> : TeamsSsoBotAuthentication<TState>
             where TState : TurnState, new()
         {
             public MockTeamsSsoBotAuthentication(Application<TState> app, string name, TeamsSsoSettings settings, TeamsSsoPrompt? mockPrompt = null) : base(app, name, settings, null)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoPromptTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoPromptTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
         private const string AuthStartPage = "https://localhost/auth-start.html";
         private const string AccessToken = "test token";
 
-        private class TeamsSsoPromptMock : TeamsSsoPrompt
+        private sealed class TeamsSsoPromptMock : TeamsSsoPrompt
         {
             public TeamsSsoPromptMock(string dialogId, string name, TeamsSsoSettings settings, IConfidentialClientApplicationAdapter msalAdapterMock) : base(dialogId, name, settings)
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthenticationTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         private const string AuthStartPage = "https://localhost/auth-start.html";
         private const string AccessToken = "test token";
 
-        private class TeamsSsoMessageExtensionsAuthenticationMock : TeamsSsoMessageExtensionsAuthentication
+        private sealed class TeamsSsoMessageExtensionsAuthenticationMock : TeamsSsoMessageExtensionsAuthentication
         {
             public TeamsSsoMessageExtensionsAuthenticationMock(TeamsSsoSettings settings, IConfidentialClientApplicationAdapter msalAdapterMock) : base(settings)
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TeamsSsoAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TeamsSsoAuthenticationTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication
         private const string AuthStartPage = "https://localhost/auth-start.html";
         private const string AccessToken = "test token";
 
-        private class TeamsSsoAuthenticationMock<TState> : TeamsSsoAuthentication<TState>
+        private sealed class TeamsSsoAuthenticationMock<TState> : TeamsSsoAuthentication<TState>
             where TState : TurnState, new()
         {
             public TeamsSsoAuthenticationMock(Application<TState> app, string name, TeamsSsoSettings settings, IConfidentialClientApplicationAdapter msalAdapterMock) : base(app, name, settings, null)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TestAuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TestAuthenticationManager.cs
@@ -3,7 +3,7 @@ using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication
 {
-    internal class TestAuthenticationManager : AuthenticationManager<TurnState>
+    internal sealed class TestAuthenticationManager : AuthenticationManager<TurnState>
     {
         public TestAuthenticationManager(AuthenticationOptions<TurnState> options, Application<TurnState> app, IStorage? storage = null) : base(app, options, storage)
         {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateTests.cs
@@ -184,8 +184,10 @@ namespace Microsoft.Teams.AI.Tests.StateTests
             {
                 await state.SaveStateAsync(turnContext, null);
             }
+#pragma warning disable CA1031
             catch (Exception)
             {
+#pragma warning restore CA1031
                 // Ignore the exception, this is the expected behavior is state is not loaded.
             }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/PredictedSayCommand.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/PredictedSayCommand.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Teams.AI.AI.Planners
             Response = response;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="PredictedSayCommand"/> class.
+        /// </summary>
+        /// <param name="response">The response that the AI system should say.</param>
         public PredictedSayCommand(string response)
         {
             Response = new ChatMessage(ChatRole.Assistant)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -763,7 +763,7 @@ namespace Microsoft.Teams.AI
             );
             RouteHandler<TState> routeHandler = async (turnContext, turnState, cancellationToken) =>
             {
-                string token = turnContext.Activity.Value.GetType().GetProperty("Continuation").GetValue(turnContext.Activity.Value) as string;
+                string token = turnContext.Activity.Value.GetType().GetProperty("Continuation").GetValue(turnContext.Activity.Value) as string ?? "";
                 await handler(turnContext, turnState, token, cancellationToken);
 
                 // Check to see if an invoke response has already been added

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
@@ -13,10 +13,12 @@ namespace Microsoft.Teams.AI
         /// </summary>
         /// <param name="context">The turn context</param>
         /// <returns>The sign in response</returns>
+#pragma warning disable 1998  // Await call for non-implemented method
         public async Task<SignInResponse> AuthenticateAsync(ITurnContext context)
         {
             throw new NotImplementedException();
         }
+#pragma warning restore 1998
 
         /// <summary>
         /// Whether the current activity is a valid activity that supports authentication


### PR DESCRIPTION
## Linked issues

closes: #1290

## Details

- async/await on non-implemented method
- null literal assignment
- missing XML comment
- general catch
- sealed classes

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
