### PR TITLE
[JS] fix: correct api key logic

### DIFF
--- a/js/packages/teams-ai/src/models/OpenAIModel.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.ts
@@ -395,18 +395,18 @@ export class OpenAIModel implements PromptCompletionModel {
             requestConfig.headers['User-Agent'] = this.UserAgent;
         }
 
-        if ('apiKey' in this.options) {
-            requestConfig.headers['api-key'] = this.options.apiKey || '';
-        }
+        if (this._useAzure) {
+            let apiKey = (this.options as AzureOpenAIModelOptions).azureApiKey;
+            const azureADTokenProvider = (this.options as AzureOpenAIModelOptions).azureADTokenProvider;
 
-        if ('azureApiKey' in this.options || 'azureADTokenProvider' in this.options) {
-            let apiKey = this.options.azureApiKey;
-
-            if (!apiKey && this.options.azureADTokenProvider) {
-                apiKey = await this.options.azureADTokenProvider();
+            if (!apiKey && azureADTokenProvider) {
+                apiKey = await azureADTokenProvider();
+                requestConfig.headers['Authorization'] = `Bearer ${apiKey}`;
+            } else {
+                requestConfig.headers['api-key'] = apiKey || '';
             }
-
-            requestConfig.headers['Authorization'] = `Bearer ${apiKey}`;
+        } else if ('apiKey' in this.options) {
+            requestConfig.headers['Authorization'] = `Bearer ${this.options.apiKey || ''}`;
         }
 
         if ('organization' in this.options && this.options.organization) {


### PR DESCRIPTION
## Linked issues

closes: #1746

## Details

Proposal to fix the wrong api-key header.
Feel free to comment or create other fixes.

#### Change details

- For OpenAI (`apiKey`), use `"Authorization": "Bearer xxx"`
- For Azure OpenAI (`azureApiKey`), use `"api-key": "xxx"`
- For Azure OpenAI (`azureADTokenProvider`), use `"Authorization": "Bearer xxx"`

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
