### PR TITLE
[PY] fix: Use download url if possible in TeamsAttachmentDownloader

### DIFF
--- a/python/packages/ai/teams/teams_attachment_downloader/teams_attachment_downloader.py
+++ b/python/packages/ai/teams/teams_attachment_downloader/teams_attachment_downloader.py
@@ -88,8 +88,10 @@ class TeamsAttachmentDownloader(InputFileDownloader):
                 # Build request for downloading file if access token is available
                 headers.update({"Authorization": f"Bearer {access_token}"})
 
+            download_url = attachment.content.get('downloadUrl', attachment.content_url) if attachment.content and isinstance(
+                attachment.content, dict) else attachment.content_url
             async with aiohttp.ClientSession() as session:
-                async with session.get(attachment.content_url, headers=headers) as response:
+                async with session.get(download_url, headers=headers) as response:
                     content = await response.read()
 
                     content_type = attachment.content_type

--- a/python/packages/ai/teams/teams_attachment_downloader/teams_attachment_downloader.py
+++ b/python/packages/ai/teams/teams_attachment_downloader/teams_attachment_downloader.py
@@ -88,8 +88,9 @@ class TeamsAttachmentDownloader(InputFileDownloader):
                 # Build request for downloading file if access token is available
                 headers.update({"Authorization": f"Bearer {access_token}"})
 
-            download_url = attachment.content.get('downloadUrl', attachment.content_url) if attachment.content and isinstance(
-                attachment.content, dict) else attachment.content_url
+            download_url = attachment.content_url
+            if attachment.content and isinstance(attachment.content, dict):
+                download_url = attachment.content.get('downloadUrl', attachment.content_url)
             async with aiohttp.ClientSession() as session:
                 async with session.get(download_url, headers=headers) as response:
                     content = await response.read()
@@ -101,7 +102,8 @@ class TeamsAttachmentDownloader(InputFileDownloader):
 
                     return InputFile(content, content_type, attachment.content_url)
         else:
-            content = bytes(attachment.content) if attachment.content else bytes()
+            content = bytes(
+                attachment.content) if attachment.content else bytes()
             return InputFile(content, attachment.content_type, attachment.content_url)
 
     async def _get_access_token(self):

--- a/python/packages/ai/tests/test_teams_attachment_downloader.py
+++ b/python/packages/ai/tests/test_teams_attachment_downloader.py
@@ -151,7 +151,10 @@ class TestTeamsAttachmentDownloader(IsolatedAsyncioTestCase):
         mock_get.return_value.__aenter__.return_value = response_obj
         mocked_content = await response_obj.read()
         attachment = Attachment(
-            content_url="https://example.com/file.png", content_type="image/png", name="file.png", content={"downloadUrl": "https://example.com/special_download_url_file.png"}
+            content_url="https://example.com/file.png",
+            content_type="image/png",
+            name="file.png",
+            content={"downloadUrl": "https://example.com/special_download_url_file.png"}
         )
 
         context = self.create_mock_context()

--- a/python/packages/ai/tests/test_teams_attachment_downloader.py
+++ b/python/packages/ai/tests/test_teams_attachment_downloader.py
@@ -146,6 +146,39 @@ class TestTeamsAttachmentDownloader(IsolatedAsyncioTestCase):
         )
 
     @mock.patch("aiohttp.ClientSession.get")
+    async def test_should_download_file_with_download_url(self, mock_get):
+        response_obj = MockedResponse()
+        mock_get.return_value.__aenter__.return_value = response_obj
+        mocked_content = await response_obj.read()
+        attachment = Attachment(
+            content_url="https://example.com/file.png", content_type="image/png", name="file.png", content={"downloadUrl": "https://example.com/special_download_url_file.png"}
+        )
+
+        context = self.create_mock_context()
+        context.activity.type = "message"
+        context.activity.text = "Here is the attachment"
+        context.activity.attachments = [attachment]
+        downloader = TeamsAttachmentDownloader(
+            TeamsAttachmentDownloaderOptions(bot_app_id="botAppId", adapter=TeamsAdapter({}))
+        )
+
+        input_files = await downloader.download_files(context)
+
+        assert mock_get.call_count == 1
+        assert mock_get.call_args[0][0] == "https://example.com/special_download_url_file.png"
+        self.assertEqual(
+            input_files,
+            [
+                InputFile(
+                    content=mocked_content,
+                    content_type="image/png",
+                    content_url="https://example.com/file.png",
+                )
+            ],
+        )
+
+
+    @mock.patch("aiohttp.ClientSession.get")
     async def test_should_download_local_file(self, mock_get):
         response_obj = MockedResponse()
         mock_get.return_value.__aenter__.return_value = response_obj


### PR DESCRIPTION
## Linked issues

closes: #1789

## Details

If download_url is available, it uses that to download the corresponding file in TeamsAttachmentDownloader. This is using the guidance here: https://devblogs.microsoft.com/microsoft365dev/working-with-files-in-your-microsoft-teams-bot/

#### Change details

Looks like a similar 

> Describe your changes, with screenshots and code snippets as appropriate

Looks like similar logic is in the C# codebase too: https://github.com/microsoft/teams-ai/blob/0534743ff7a65d7e8718111a53c0afee22179a4b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TeamsAttachmentDownloader.cs#L83

I added a unit test and also tested it locally by sending myself a markdown file. Without this change, I got a 403 error. With this, the file was successfully downloaded.