### PR TITLE
[JS] chore: refactor and linting for CompletionConfig and PromptResponse types and files using those types

### DIFF
--- a/js/packages/teams-ai/src/AI.ts
+++ b/js/packages/teams-ai/src/AI.ts
@@ -7,11 +7,12 @@
  */
 
 import { TurnContext } from 'botbuilder';
+
+import * as actions from './actions';
 import { DefaultModerator } from './moderators';
 import { Moderator } from './moderators/Moderator';
 import { PredictedDoCommand, Planner, Plan } from './planners';
 import { TurnState } from './TurnState';
-import * as actions from './actions';
 
 /**
  * Options for configuring the AI system.
@@ -363,7 +364,7 @@ export class AI<TState extends TurnState = TurnState> {
             let plan: Plan | undefined =
                 step_count == 0 ? await this._options.moderator.reviewInput(context, state) : undefined;
 
-            // Generate plan
+            // Generate plan if moderator did not return one as flag for input.
             if (!plan) {
                 if (step_count == 0) {
                     plan = await this._options.planner.beginTask(context, state, this);
@@ -371,7 +372,7 @@ export class AI<TState extends TurnState = TurnState> {
                     plan = await this._options.planner.continueTask(context, state, this);
                 }
 
-                // Review the plans output
+                // Review the plan's output
                 plan = await this._options.moderator.reviewOutput(context, state, plan);
             }
 
@@ -419,7 +420,9 @@ export class AI<TState extends TurnState = TurnState> {
                             state.temp.actionOutputs[action] = output;
                         } else {
                             // Redirect to UnknownAction handler
-                            output = await this._actions.get(AI.UnknownActionName)!.handler(context, state, plan, action);
+                            output = await this._actions
+                                .get(AI.UnknownActionName)!
+                                .handler(context, state, plan, action);
                         }
                         break;
                     }

--- a/js/packages/teams-ai/src/augmentations/Augmentation.ts
+++ b/js/packages/teams-ai/src/augmentations/Augmentation.ts
@@ -11,7 +11,7 @@ import { PromptResponseValidator } from '../validators';
 import { Plan } from '../planners';
 import { PromptSection } from '../prompts';
 import { Memory } from '../MemoryFork';
-import { PromptResponse } from '../models';
+import { PromptResponse } from '../types';
 
 /**
  * An augmentation is a component that can be added to a prompt template to add additional

--- a/js/packages/teams-ai/src/augmentations/DefaultAugmentation.spec.ts
+++ b/js/packages/teams-ai/src/augmentations/DefaultAugmentation.spec.ts
@@ -2,8 +2,9 @@ import assert from 'assert';
 import { TestAdapter } from 'botbuilder';
 
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { PromptResponse } from '../models';
 import { GPTTokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+
 import { DefaultAugmentation } from './DefaultAugmentation';
 
 describe('DefaultAugmentation', () => {

--- a/js/packages/teams-ai/src/augmentations/DefaultAugmentation.ts
+++ b/js/packages/teams-ai/src/augmentations/DefaultAugmentation.ts
@@ -7,13 +7,15 @@
  */
 
 import { TurnContext } from 'botbuilder-core';
-import { PromptResponse } from '../models';
-import { Plan, PredictedSayCommand } from '../planners';
-import { Tokenizer } from '../tokenizers';
-import { Validation } from '../validators';
-import { Augmentation } from './Augmentation';
-import { PromptSection } from '../prompts';
+
 import { Memory } from '../MemoryFork';
+import { Plan, PredictedSayCommand } from '../planners';
+import { PromptSection } from '../prompts';
+import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+import { Validation } from '../validators';
+
+import { Augmentation } from './Augmentation';
 
 /**
  * The default 'none' augmentation.

--- a/js/packages/teams-ai/src/augmentations/MonologueAugmentation.spec.ts
+++ b/js/packages/teams-ai/src/augmentations/MonologueAugmentation.spec.ts
@@ -1,10 +1,12 @@
 import { strict as assert } from 'assert';
 import { TestAdapter } from 'botbuilder';
 
-import { GPTTokenizer } from '../tokenizers';
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { ChatCompletionAction, PromptResponse } from '../models';
+import { ChatCompletionAction } from '../models';
+import { GPTTokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+
 import { MonologueAugmentation } from './MonologueAugmentation';
 
 describe('MonologueAugmentation', () => {

--- a/js/packages/teams-ai/src/augmentations/MonologueAugmentation.ts
+++ b/js/packages/teams-ai/src/augmentations/MonologueAugmentation.ts
@@ -7,15 +7,18 @@
  */
 
 import { TurnContext } from 'botbuilder-core';
-import { ChatCompletionAction, PromptResponse } from '../models';
-import { Plan, PredictedCommand, PredictedDoCommand, PredictedSayCommand } from '../planners';
+import { Schema } from 'jsonschema';
+
+import { Memory } from '../MemoryFork';
+import { ChatCompletionAction } from '../models';
+import { Message, PromptSection } from '../prompts';
 import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+import { Plan, PredictedCommand, PredictedDoCommand, PredictedSayCommand } from '../planners';
 import { ActionResponseValidator, JSONResponseValidator, Validation } from '../validators';
+
 import { Augmentation } from './Augmentation';
 import { ActionAugmentationSection } from './ActionAugmentationSection';
-import { Schema } from 'jsonschema';
-import { Message, PromptSection } from '../prompts';
-import { Memory } from '../MemoryFork';
 
 /**
  * @private

--- a/js/packages/teams-ai/src/augmentations/SequenceAugmentation.spec.ts
+++ b/js/packages/teams-ai/src/augmentations/SequenceAugmentation.spec.ts
@@ -3,8 +3,10 @@ import { TestAdapter } from 'botbuilder';
 
 import { TestPromptManager } from '../internals/testing/TestPromptManager';
 import { TestTurnState } from '../internals/testing/TestTurnState';
-import { ChatCompletionAction, PromptResponse } from '../models';
+import { ChatCompletionAction } from '../models';
 import { GPTTokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+
 import { SequenceAugmentation } from './SequenceAugmentation';
 
 describe('SequenceAugmentation', () => {

--- a/js/packages/teams-ai/src/augmentations/SequenceAugmentation.ts
+++ b/js/packages/teams-ai/src/augmentations/SequenceAugmentation.ts
@@ -7,15 +7,18 @@
  */
 
 import { TurnContext } from 'botbuilder-core';
-import { ChatCompletionAction, PromptResponse } from '../models';
-import { Plan, PredictedDoCommand, PredictedSayCommand } from '../planners';
-import { Tokenizer } from '../tokenizers';
-import { ActionResponseValidator, JSONResponseValidator, Validation } from '../validators';
-import { Augmentation } from './Augmentation';
-import { Message, PromptSection } from '../prompts';
-import { Memory } from '../MemoryFork';
-import { ActionAugmentationSection } from './ActionAugmentationSection';
 import { Schema } from 'jsonschema';
+
+import { Memory } from '../MemoryFork';
+import { ChatCompletionAction } from '../models';
+import { Plan, PredictedDoCommand, PredictedSayCommand } from '../planners';
+import { Message, PromptSection } from '../prompts';
+import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+import { ActionResponseValidator, JSONResponseValidator, Validation } from '../validators';
+
+import { Augmentation } from './Augmentation';
+import { ActionAugmentationSection } from './ActionAugmentationSection';
 
 /**
  * JSON schema for a `Plan`.

--- a/js/packages/teams-ai/src/internals/testing/TestModel.ts
+++ b/js/packages/teams-ai/src/internals/testing/TestModel.ts
@@ -9,7 +9,8 @@
 import { TurnContext } from 'botbuilder';
 
 import { Memory } from '../../MemoryFork';
-import { PromptCompletionModel, PromptResponse, PromptResponseStatus } from '../../models/PromptCompletionModel';
+import { PromptCompletionModel } from '../../models/PromptCompletionModel';
+import { PromptResponse, PromptResponseStatus } from '../../types';
 import { Message, PromptFunctions, PromptTemplate } from '../../prompts';
 import { Tokenizer } from '../../tokenizers';
 

--- a/js/packages/teams-ai/src/models/LlamaModel.ts
+++ b/js/packages/teams-ai/src/models/LlamaModel.ts
@@ -3,9 +3,10 @@ import { TurnContext } from 'botbuilder';
 
 import { Colorize } from '../internals/Colorize';
 import { Memory } from '../MemoryFork';
+import { PromptCompletionModel } from '../models';
 import { Message, PromptFunctions, PromptTemplate } from '../prompts';
-import { PromptCompletionModel, PromptResponse } from '../models';
 import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
 
 export interface LlamaModelOptions {
     apiKey: string;

--- a/js/packages/teams-ai/src/models/PromptCompletionModel.ts
+++ b/js/packages/teams-ai/src/models/PromptCompletionModel.ts
@@ -6,12 +6,14 @@
  * Licensed under the MIT License.
  */
 
+import EventEmitter from 'events';
+
 import { TurnContext } from 'botbuilder-core';
 import { Message, PromptFunctions, PromptTemplate } from '../prompts';
 import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
 import { Memory } from '../MemoryFork';
 import StrictEventEmitter from '../external/strict-event-emitter-types';
-import EventEmitter from 'events';
 
 /**
  * Events emitted by a PromptCompletionModel.
@@ -26,7 +28,14 @@ export interface PromptCompletionModelEvents {
      * @param template Prompt template being completed.
      * @param streaming `true` if the prompts response is being streamed.
      */
-    beforeCompletion: (context: TurnContext, memory: Memory, functions: PromptFunctions, tokenizer: Tokenizer, template: PromptTemplate, streaming: boolean) => void;
+    beforeCompletion: (
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        template: PromptTemplate,
+        streaming: boolean
+    ) => void;
 
     /**
      * Triggered when a chunk is received from the model via streaming.
@@ -35,7 +44,7 @@ export interface PromptCompletionModelEvents {
      * @param chunk Message delta received from the model.
      */
     chunkReceived: (context: TurnContext, memory: Memory, chunk: PromptChunk) => void;
-    
+
     /**
      * Triggered after the model finishes returning a response.
      * @param context Current turn context.
@@ -48,17 +57,32 @@ export interface PromptCompletionModelEvents {
 /**
  * Type signature for the `beforeCompletion` event of a `PromptCompletionModel`.
  */
-export type PromptCompletionModelBeforeCompletionEvent = (context: TurnContext, memory: Memory, functions: PromptFunctions, tokenizer: Tokenizer, template: PromptTemplate, streaming: boolean) => void;
+export type PromptCompletionModelBeforeCompletionEvent = (
+    context: TurnContext,
+    memory: Memory,
+    functions: PromptFunctions,
+    tokenizer: Tokenizer,
+    template: PromptTemplate,
+    streaming: boolean
+) => void;
 
 /**
  * Type signature for the `chunkReceived` event of a `PromptCompletionModel`.
  */
-export type PromptCompletionModelChunkReceivedEvent = (context: TurnContext, memory: Memory, chunk: PromptChunk) => void;
+export type PromptCompletionModelChunkReceivedEvent = (
+    context: TurnContext,
+    memory: Memory,
+    chunk: PromptChunk
+) => void;
 
 /**
  * Type signature for the `responseReceived` event of a `PromptCompletionModel`.
  */
-export type PromptCompletionModelResponseReceivedEvent = (context: TurnContext, memory: Memory, response: PromptResponse<string>) => void;
+export type PromptCompletionModelResponseReceivedEvent = (
+    context: TurnContext,
+    memory: Memory,
+    response: PromptResponse<string>
+) => void;
 
 /**
  * Helper type that strongly types the the EventEmitter for a PromptCOmpletionModel instance.
@@ -90,45 +114,6 @@ export interface PromptCompletionModel {
         tokenizer: Tokenizer,
         template: PromptTemplate
     ): Promise<PromptResponse<string>>;
-}
-
-/**
- * Status of the prompt response.
- * @remarks
- * `success` - The prompt was successfully completed.
- * `error` - An error occurred while completing the prompt.
- * `rate_limited` - The request was rate limited.
- * `invalid_response` - The response was invalid.
- * `too_long` - The rendered prompt exceeded the `max_input_tokens` limit.
- */
-export type PromptResponseStatus = 'success' | 'error' | 'rate_limited' | 'invalid_response' | 'too_long';
-
-/**
- * Response returned by a `PromptCompletionClient`.
- * @template TContent Optional. Type of the content in the message. Defaults to `unknown`.
- */
-export interface PromptResponse<TContent = unknown> {
-    /**
-     * Status of the prompt response.
-     */
-    status: PromptResponseStatus;
-
-    /**
-     * User input message sent to the model. `undefined` if no input was sent.
-     */
-    input?: Message<any>;
-
-    /**
-     * Message returned.
-     * @remarks
-     * This will be a `Message<TContent>` object if the status is `success`, otherwise it will be a `string`.
-     */
-    message?: Message<TContent>;
-
-    /**
-     * Error returned.
-     */
-    error?: Error;
 }
 
 /**

--- a/js/packages/teams-ai/src/models/TestModel.ts
+++ b/js/packages/teams-ai/src/models/TestModel.ts
@@ -7,11 +7,8 @@
  */
 
 import { PromptFunctions, PromptTemplate } from '../prompts';
-import { 
-    PromptCompletionModel, 
-    PromptCompletionModelEmitter, 
-    PromptResponse 
-} from './PromptCompletionModel';
+import { PromptCompletionModel, PromptCompletionModelEmitter } from './PromptCompletionModel';
+import { PromptResponse } from '../types';
 import { Tokenizer } from '../tokenizers';
 import { TurnContext } from 'botbuilder';
 import { Memory } from '../MemoryFork';
@@ -22,18 +19,36 @@ import EventEmitter from 'events';
  */
 export class TestModel implements PromptCompletionModel {
     private readonly _events: PromptCompletionModelEmitter = new EventEmitter() as PromptCompletionModelEmitter;
-    private readonly _handler: (model: TestModel, context: TurnContext, memory: Memory, functions: PromptFunctions, tokenizer: Tokenizer, template: PromptTemplate) => Promise<PromptResponse<string>>;
+    private readonly _handler: (
+        model: TestModel,
+        context: TurnContext,
+        memory: Memory,
+        functions: PromptFunctions,
+        tokenizer: Tokenizer,
+        template: PromptTemplate
+    ) => Promise<PromptResponse<string>>;
 
     /**
      * Creates a new `OpenAIModel` instance.
      * @param {OpenAIModelOptions} options - Options for configuring the model client.
+     * @param handler
      */
-    public constructor(handler: (model: TestModel, context: TurnContext, memory: Memory, functions: PromptFunctions, tokenizer: Tokenizer, template: PromptTemplate) => Promise<PromptResponse<string>>) {
+    public constructor(
+        handler: (
+            model: TestModel,
+            context: TurnContext,
+            memory: Memory,
+            functions: PromptFunctions,
+            tokenizer: Tokenizer,
+            template: PromptTemplate
+        ) => Promise<PromptResponse<string>>
+    ) {
         this._handler = handler;
     }
 
     /**
      * Events emitted by the model.
+     * @returns {PromptCompletionModelEmitter} An event emitter for the model.
      */
     public get events(): PromptCompletionModelEmitter {
         return this._events;
@@ -58,7 +73,16 @@ export class TestModel implements PromptCompletionModel {
         return this._handler(this, context, memory, functions, tokenizer, template);
     }
 
-    public static createTestModel(handler: (model: TestModel, context: TurnContext, memory: Memory, functions: PromptFunctions, tokenizer: Tokenizer, template: PromptTemplate) => Promise<PromptResponse<string>>): TestModel {
+    public static createTestModel(
+        handler: (
+            model: TestModel,
+            context: TurnContext,
+            memory: Memory,
+            functions: PromptFunctions,
+            tokenizer: Tokenizer,
+            template: PromptTemplate
+        ) => Promise<PromptResponse<string>>
+    ): TestModel {
         return new TestModel(handler);
     }
 
@@ -87,12 +111,14 @@ export class TestModel implements PromptCompletionModel {
         return new TestModel(async (model, context, memory, functions, tokenizer, template) => {
             model.events.emit('beforeCompletion', context, memory, functions, tokenizer, template, true);
             let content: string = '';
-            for (let i = 0; i <chunks.length; i++) {
+            for (let i = 0; i < chunks.length; i++) {
                 await new Promise((resolve) => setTimeout(resolve, delay));
                 const text = chunks[i];
                 content += text;
                 if (i === 0) {
-                    model.events.emit('chunkReceived', context, memory, { delta: { role: 'assistant', content: text } });
+                    model.events.emit('chunkReceived', context, memory, {
+                        delta: { role: 'assistant', content: text }
+                    });
                 } else {
                     model.events.emit('chunkReceived', context, memory, { delta: { content: text } });
                 }

--- a/js/packages/teams-ai/src/planners/ActionPlanner.ts
+++ b/js/packages/teams-ai/src/planners/ActionPlanner.ts
@@ -6,18 +6,21 @@
  * Licensed under the MIT License.
  */
 
-import { Planner, Plan } from './Planner';
-import { TurnState } from '../TurnState';
 import { TurnContext } from 'botbuilder';
+
 import { AI } from '../AI';
-import { PromptTemplate, PromptManager } from '../prompts';
-import { PromptCompletionModel, PromptResponse } from '../models';
-import { PromptResponseValidator } from '../validators';
-import { Memory } from '../MemoryFork';
-import { Tokenizer } from '../tokenizers';
-import { Utilities } from '../Utilities';
 import { DefaultAugmentation } from '../augmentations';
+import { Memory } from '../MemoryFork';
+import { PromptCompletionModel } from '../models';
+import { PromptTemplate, PromptManager } from '../prompts';
+import { Tokenizer } from '../tokenizers';
+import { TurnState } from '../TurnState';
+import { Utilities } from '../Utilities';
+import { PromptResponse } from '../types';
+import { PromptResponseValidator } from '../validators';
+
 import { LLMClient } from './LLMClient';
+import { Planner, Plan } from './Planner';
 
 /**
  * Factory function used to create a prompt template.

--- a/js/packages/teams-ai/src/planners/LLMClient.ts
+++ b/js/packages/teams-ai/src/planners/LLMClient.ts
@@ -6,14 +6,21 @@
  * Licensed under the MIT License.
  */
 
-import { ConversationHistory, Message, Prompt, PromptFunctions, PromptTemplate } from '../prompts';
-import { PromptResponse, PromptCompletionModel, PromptCompletionModelBeforeCompletionEvent, PromptCompletionModelChunkReceivedEvent, PromptCompletionModelResponseReceivedEvent } from '../models';
-import { Validation, PromptResponseValidator, DefaultResponseValidator } from '../validators';
-import { Memory, MemoryFork } from '../MemoryFork';
-import { Colorize } from '../internals';
 import { TurnContext } from 'botbuilder';
-import { GPTTokenizer, Tokenizer } from '../tokenizers';
+
+import { Colorize } from '../internals';
+import { Memory, MemoryFork } from '../MemoryFork';
+import {
+    PromptCompletionModel,
+    PromptCompletionModelBeforeCompletionEvent,
+    PromptCompletionModelChunkReceivedEvent,
+    PromptCompletionModelResponseReceivedEvent
+} from '../models';
+import { ConversationHistory, Message, Prompt, PromptFunctions, PromptTemplate } from '../prompts';
 import { StreamingResponse } from '../StreamingResponse';
+import { GPTTokenizer, Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+import { Validation, PromptResponseValidator, DefaultResponseValidator } from '../validators';
 
 /**
  * Options for an LLMClient instance.
@@ -186,7 +193,7 @@ export interface ConfiguredLLMClientOptions<TContent = any> {
  * @template TContent Optional. Type of message content returned for a 'success' response. The `response.message.content` field will be of type TContent. Defaults to `any`.
  */
 export class LLMClient<TContent = any> {
-    private readonly _startStreamingMessage: string|undefined;
+    private readonly _startStreamingMessage: string | undefined;
 
     /**
      * Configured options for this LLMClient instance.
@@ -220,7 +227,6 @@ export class LLMClient<TContent = any> {
         }
 
         this._startStreamingMessage = options.startStreamingMessage;
-
     }
 
     /**
@@ -294,8 +300,15 @@ export class LLMClient<TContent = any> {
     ): Promise<PromptResponse<TContent>> {
         // Define event handlers
         let isStreaming = false;
-        let streamer: StreamingResponse|undefined;
-        const beforeCompletion: PromptCompletionModelBeforeCompletionEvent = async (ctx, memory, functions, tokenizer, template, streaming) => {
+        let streamer: StreamingResponse | undefined;
+        const beforeCompletion: PromptCompletionModelBeforeCompletionEvent = async (
+            ctx,
+            memory,
+            functions,
+            tokenizer,
+            template,
+            streaming
+        ) => {
             // Ignore events for other contexts
             if (context !== ctx) {
                 return;
@@ -325,7 +338,7 @@ export class LLMClient<TContent = any> {
                 await streamer.sendTextChunk(text);
             }
         };
-        
+
         const responseReceived: PromptCompletionModelResponseReceivedEvent = async (ctx, memory, response) => {
             // Ignore events for other contexts
             if (context !== ctx || !streamer) {
@@ -334,8 +347,8 @@ export class LLMClient<TContent = any> {
 
             // End the stream
             await streamer.endStream();
-        }
-    
+        };
+
         // Subscribe to model events
         if (this.options.model.events) {
             this.options.model.events.on('beforeCompletion', beforeCompletion);

--- a/js/packages/teams-ai/src/prompts/PromptManager.ts
+++ b/js/packages/teams-ai/src/prompts/PromptManager.ts
@@ -14,8 +14,10 @@ import { MonologueAugmentation, SequenceAugmentation } from '../augmentations';
 import { DataSource } from '../dataSources';
 import { Memory } from '../MemoryFork';
 import { Tokenizer } from '../tokenizers';
+import { CompletionConfig } from '../types';
+
 import { ConversationHistory } from './ConversationHistory';
-import { CompletionConfig, PromptTemplate } from './PromptTemplate';
+import { PromptTemplate } from './PromptTemplate';
 import { DataSourceSection } from './DataSourceSection';
 import { GroupSection } from './GroupSection';
 import { Prompt } from './Prompt';
@@ -386,7 +388,10 @@ export class PromptManager implements PromptFunctions {
                 max_input_tokens: 2048,
                 presence_penalty: 0.0,
                 temperature: 0.0,
-                top_p: 0.0
+                top_p: 0.0,
+                include_tools: false,
+                tool_choice: 'auto',
+                parallel_tool_calls: true
             } as CompletionConfig,
             template.config.completion
         );

--- a/js/packages/teams-ai/src/prompts/PromptTemplate.ts
+++ b/js/packages/teams-ai/src/prompts/PromptTemplate.ts
@@ -9,6 +9,7 @@
 import { PromptSection } from './PromptSection';
 import { ChatCompletionAction } from '../models';
 import { Augmentation } from '../augmentations';
+import { CompletionConfig } from '../types';
 
 /**
  * Prompt template cached by the prompt manager.
@@ -78,97 +79,6 @@ export interface PromptTemplateConfig {
      * Passing the name of a model to use here will override the default model used by a planner.
      */
     default_backends?: string[];
-}
-
-/**
- * Interface for the completion configuration portion of a prompt template.
- */
-export interface CompletionConfig {
-    /**
-     * Optional. Type of completion to use. Defaults to using the completion type of the configured default model.
-     * @remarks
-     * New in schema version 1.1.
-     */
-    completion_type?: 'chat' | 'text';
-
-    /**
-     * The models frequency_penalty as a number between 0 and 1.
-     * @remarks
-     * Defaults to 0.
-     */
-    frequency_penalty: number;
-
-    /**
-     * If true, the prompt will be augmented with the conversation history.
-     * @remarks
-     * New in schema version 1.1.
-     * Defaults to true.
-     */
-    include_history: boolean;
-
-    /**
-     * If true, the prompt will be augmented with the users input.
-     * @remarks
-     * New in schema version 1.1.
-     * Defaults to true.
-     */
-    include_input: boolean;
-
-    /**
-     * If true, the prompt will be augmented with any images uploaded by the user.
-     * @remarks
-     * New in schema version 1.1.
-     * Defaults to false.
-     */
-    include_images: boolean;
-
-    /**
-     * The maximum number of tokens to generate.
-     * @remarks
-     * Defaults to 150.
-     */
-    max_tokens: number;
-
-    /**
-     * The maximum number of tokens allowed in the input.
-     * @remarks
-     * New in schema version 1.1.
-     * Defaults to 2048.
-     */
-    max_input_tokens: number;
-
-    /**
-     * Optional. Name of the model to use otherwise the configured default model is used.
-     * @remarks
-     * New in schema version 1.1.
-     */
-    model?: string;
-
-    /**
-     * The models presence_penalty as a number between 0 and 1.
-     * @remarks
-     * Defaults to 0.
-     */
-    presence_penalty: number;
-
-    /**
-     * Optional. Array of stop sequences that when hit will stop generation.
-     */
-    stop_sequences?: string[];
-
-    /**
-     * The models temperature as a number between 0 and 2.
-     * @remarks
-     * Defaults to 0.
-     */
-    temperature: number;
-
-    /**
-     * The models top_p as a number between 0 and 2.
-     * @remarks
-     * Defaults to 0.
-     */
-    top_p: number;
 }
 
 /**

--- a/js/packages/teams-ai/src/types/CompletionConfig.ts
+++ b/js/packages/teams-ai/src/types/CompletionConfig.ts
@@ -1,0 +1,115 @@
+/**
+ * @module teams-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import Chat from 'openai';
+
+/**
+ * Interface for the completion configuration portion of a prompt template.
+ */
+export interface CompletionConfig {
+    /**
+     * Optional. Type of completion to use. Defaults to using the completion type of the configured default model.
+     * @remarks
+     * New in schema version 1.1.
+     */
+    completion_type?: 'chat' | 'text';
+
+    /**
+     * The models frequency_penalty as a number between 0 and 1.
+     * @remarks
+     * Defaults to 0.
+     */
+    frequency_penalty: number;
+
+    /**
+     * If true, the prompt will be augmented with the conversation history.
+     * @remarks
+     * New in schema version 1.1.
+     * Defaults to true.
+     */
+    include_history: boolean;
+
+    /**
+     * If true, the prompt will be augmented with the users input.
+     * @remarks
+     * New in schema version 1.1.
+     * Defaults to true.
+     */
+    include_input: boolean;
+
+    /**
+     * If true, the prompt will be augmented with any images uploaded by the user.
+     * @remarks
+     * New in schema version 1.1.
+     * Defaults to false.
+     */
+    include_images: boolean;
+
+    /**
+     * The maximum number of tokens to generate.
+     * @remarks
+     * Defaults to 150.
+     */
+    max_tokens: number;
+
+    /**
+     * The maximum number of tokens allowed in the input.
+     * @remarks
+     * New in schema version 1.1.
+     * Defaults to 2048.
+     */
+    max_input_tokens: number;
+
+    /**
+     * Optional. Name of the model to use otherwise the configured default model is used.
+     * @remarks
+     * New in schema version 1.1.
+     */
+    model?: string;
+
+    /**
+     * The models presence_penalty as a number between 0 and 1.
+     * @remarks
+     * Defaults to 0.
+     */
+    presence_penalty: number;
+
+    /**
+     * Optional. Array of stop sequences that when hit will stop generation.
+     */
+    stop_sequences?: string[];
+
+    /**
+     * The models temperature as a number between 0 and 2.
+     * @remarks
+     * Defaults to 0.
+     */
+    temperature: number;
+
+    /**
+     * The models top_p as a number between 0 and 2.
+     * @remarks
+     * Defaults to 0.
+     */
+    top_p: number;
+
+    /**
+     * Optional. If true, function calling will be enabled with the LLM. Defaults to false.
+     */
+    include_tools?: boolean;
+
+    /**
+     * Optional. Defines the tools function calling behavior. Defaults to 'auto'.
+     */
+    tool_choice?: Chat.ChatCompletionToolChoiceOption;
+
+    /**
+     * Opetional. Enables parallel tools function calling. Defaults to true.
+     */
+    parallel_tool_calls?: boolean;
+}

--- a/js/packages/teams-ai/src/types/OpenAIFunction.ts
+++ b/js/packages/teams-ai/src/types/OpenAIFunction.ts
@@ -1,0 +1,32 @@
+/**
+ * @module teams-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Interface that adheres to OpenAI tools/function calling.
+ */
+export interface OpenAIFunction {
+    /**
+     * The function name to call.
+     */
+    name: string;
+
+    /**
+     * The function handler to call. It may be asynchronous, accepts any number of arguments, and must return a string.
+     */
+    handler: (...args: any[]) => string | Promise<string>;
+
+    /**
+     * Optional. Description of the function.
+     */
+    description?: string;
+
+    /**
+     * Parameters the function accepts, described as a JSON object.
+     */
+    parameters?: Record<string, any>;
+}

--- a/js/packages/teams-ai/src/types/PromptResponse.ts
+++ b/js/packages/teams-ai/src/types/PromptResponse.ts
@@ -1,0 +1,48 @@
+import { Message } from '../prompts';
+
+/**
+ * Status of the prompt response.
+ * @remarks
+ * `success` - The prompt was successfully completed.
+ * `error` - An error occurred while completing the prompt.
+ * `rate_limited` - The request was rate limited.
+ * `invalid_response` - The response was invalid.
+ * `too_long` - The rendered prompt exceeded the `max_input_tokens` limit.
+ */
+
+export type PromptResponseStatus =
+    | 'success'
+    | 'error'
+    | 'rate_limited'
+    | 'invalid_response'
+    | 'too_long'
+    | 'tools_error';
+
+/**
+ * Response returned by a `PromptCompletionClient`.
+ * @template TContent Optional. Type of the content in the message. Defaults to `unknown`.
+ */
+
+export interface PromptResponse<TContent = unknown> {
+    /**
+     * Status of the prompt response.
+     */
+    status: PromptResponseStatus;
+
+    /**
+     * User input message sent to the model. `undefined` if no input was sent.
+     */
+    input?: Message<any>;
+
+    /**
+     * Message returned.
+     * @remarks
+     * This will be a `Message<TContent>` object if the status is `success`, otherwise it will be a `string`.
+     */
+    message?: Message<TContent>;
+
+    /**
+     * Error returned.
+     */
+    error?: Error;
+}

--- a/js/packages/teams-ai/src/types/index.ts
+++ b/js/packages/teams-ai/src/types/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @module teams-ai
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export * from './CompletionConfig';
+export * from './OpenAIFunction';
+export * from './PromptResponse';

--- a/js/packages/teams-ai/src/validators/ActionResponseValidator.ts
+++ b/js/packages/teams-ai/src/validators/ActionResponseValidator.ts
@@ -1,10 +1,13 @@
 import { TurnContext } from 'botbuilder';
-import { ChatCompletionAction, PromptResponse } from '../models';
+
+import { Memory } from '../MemoryFork';
+import { ChatCompletionAction } from '../models';
+import { Message } from '../prompts';
+import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+
 import { JSONResponseValidator } from './JSONResponseValidator';
 import { PromptResponseValidator, Validation } from './PromptResponseValidator';
-import { Tokenizer } from '../tokenizers';
-import { Message } from '../prompts';
-import { Memory } from '../MemoryFork';
 
 /**
  * A validated action call.

--- a/js/packages/teams-ai/src/validators/DefaultResponseValidator.ts
+++ b/js/packages/teams-ai/src/validators/DefaultResponseValidator.ts
@@ -7,10 +7,12 @@
  */
 
 import { TurnContext } from 'botbuilder';
-import { Tokenizer } from '../tokenizers';
-import { PromptResponse } from '../models';
-import { Validation, PromptResponseValidator } from './PromptResponseValidator';
+
 import { Memory } from '../MemoryFork';
+import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+
+import { Validation, PromptResponseValidator } from './PromptResponseValidator';
 
 /**
  * Default response validator that always returns true.

--- a/js/packages/teams-ai/src/validators/JSONResponseValidator.ts
+++ b/js/packages/teams-ai/src/validators/JSONResponseValidator.ts
@@ -1,10 +1,12 @@
 import { TurnContext } from 'botbuilder';
 import { Validator, Schema, ValidationError } from 'jsonschema';
-import { Tokenizer } from '../tokenizers';
-import { PromptResponse } from '../models';
-import { Validation, PromptResponseValidator } from './PromptResponseValidator';
-import { Response } from './Response';
+
 import { Memory } from '../MemoryFork';
+import { Validation, PromptResponseValidator } from './PromptResponseValidator';
+import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
+
+import { Response } from './Response';
 
 /**
  * Parses any JSON returned by the model and optionally verifies it against a JSON schema.

--- a/js/packages/teams-ai/src/validators/PromptResponseValidator.ts
+++ b/js/packages/teams-ai/src/validators/PromptResponseValidator.ts
@@ -7,9 +7,10 @@
  */
 
 import { TurnContext } from 'botbuilder';
-import { Tokenizer } from '../tokenizers';
-import { PromptResponse } from '../models';
+
 import { Memory } from '../MemoryFork';
+import { Tokenizer } from '../tokenizers';
+import { PromptResponse } from '../types';
 
 /**
  * A validator that can be used to validate prompt responses.


### PR DESCRIPTION
## Linked issues

#minor

## Details
- Create `OpenAIFunction` interface
- Move `CompletionConfig` to types folder
- Add `include_tools`, `tool_choice`, and `parallel_tool_calls` to `CompletionConfig`
- Move `PromptResponses` to types folder
- Add 'tools_error' to `PromptResponseStatus`
- Update files that use the above types
- Linting cleanup of `OpenAIModel.ts`
- Linting cleanup of `AI.ts`

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes


