### PR TITLE
[PY] fix: Use security code stored in state param to get user token

### DIFF
--- a/python/packages/ai/teams/auth/oauth/oauth.py
+++ b/python/packages/ai/teams/auth/oauth/oauth.py
@@ -46,11 +46,14 @@ class OAuth(Auth[StateT]):
 
     async def get_token(self, context: TurnContext) -> Optional[str]:
         client = self._user_token_client(context)
+        code = ""
+        if "state" in context.activity.value:
+            code = context.activity.value["state"]
         res = await client.get_user_token(
             getattr(context.activity.from_property, "id"),
             self._options.connection_name,
             context.activity.channel_id,
-            "",
+            code,
         )
 
         if res and res.token:


### PR DESCRIPTION
## Linked issues

closes: # (issue number)

## Details

The OAuth get_token() function does not use the security code stored in the state param to look up the user token stored when the user signed in earlier. This results in an infinite loop of sign-in prompts when calling Auth's sign_in().

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [ ] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
