### PR TITLE
[PY] Copy activity to new activity when continuing conversation

### DIFF
--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -806,9 +806,14 @@ class Application(Bot, Generic[StateT]):
             and ActivityTypes.message == context.activity.type
             and self._options.long_running_messages
         ):
+            def wrapped_callback(ctx: TurnContext) -> Awaitable:
+                for key in context.activity._attribute_map.keys():
+                    setattr(ctx.activity, key, getattr(context.activity, key))
+                return func(ctx)
+
             return await self._adapter.continue_conversation(
                 reference=context.get_conversation_reference(context.activity),
-                callback=func,
+                callback=wrapped_callback,
                 bot_app_id=self.options.bot_app_id,
             )
 


### PR DESCRIPTION
When `Application` is instantiated with `long_running_messages=True`, the incoming request is converted to a proactive conversation, which creates a new activity. The original code has a bug where the original activity's attributes aren't copied to the new activity, which results in the original activity intent not being handled. Fix this by copying the activity in a new callback function which wraps the original callback function.