### PR TITLE
[PY] fix: Fix Application's activity selector to not cast ActivityTypes to str

### DIFF
--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -211,7 +211,7 @@ class Application(Bot, Generic[StateT]):
         """
 
         def __selector__(context: TurnContext):
-            return type == str(context.activity.type)
+            return type == context.activity.type
 
         def __call__(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             self._routes.append(Route[StateT](__selector__, func))


### PR DESCRIPTION
`ActivityTypes` inherits from `str` (in addition to `Enum`), so does not need to be cast to `str` before being compared to `context.activity.type`. Casting to `str` will convert a value to something like `ActivityTypes.message`, which will fail the selector comparison.

#minor