### PR TITLE
[PY] Avoid returning token prematurely on signin/verifyState invoke

### DIFF
--- a/python/packages/ai/teams/auth/auth_manager.py
+++ b/python/packages/ai/teams/auth/auth_manager.py
@@ -65,7 +65,7 @@ class AuthManager(Generic[StateT]):
         token: Optional[str] = await auth.get_token(context)
         res = SignInResponse("pending")
 
-        if token:
+        if token and not self._is_verify_state_activity(context):
             cast(TempState, state.temp).auth_tokens[key] = token
             return SignInResponse("complete")
 


### PR DESCRIPTION
The original code skips calling `auth.verify_state` on sign-in. This fix is only a band-aid, as there is no handler registered to process `signin/verifyState` invokes, so these requests ultimately end up receiving 501 Not Implemented responses.