### PR TITLE
[PY] fix: Remove unpacking to list for file downloads

### DIFF
--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -751,7 +751,8 @@ class Application(Bot, Generic[StateT]):
             input_files = state.temp.input_files if state.temp.input_files else []
             for file_downloader in self._options.file_downloaders:
                 files = await file_downloader.download_files(context)
-                input_files.append(*files)
+                for file in files:
+                    input_files.append(file)
             state.temp.input_files = input_files
 
     async def _run_ai_chain(self, context: TurnContext, state):

--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -751,8 +751,7 @@ class Application(Bot, Generic[StateT]):
             input_files = state.temp.input_files if state.temp.input_files else []
             for file_downloader in self._options.file_downloaders:
                 files = await file_downloader.download_files(context)
-                for file in files:
-                    input_files.append(file)
+                input_files.extend(files)
             state.temp.input_files = input_files
 
     async def _run_ai_chain(self, context: TurnContext, state):


### PR DESCRIPTION
## Linked issues

closes: #1852

## Details

Unpacking doesn't work for array.append. Which means that for non-single files, input_files.append(*files) fails with:
`on_turn_error] unhandled error: list.append() takes exactly one argument (0 given)`

Here we append file-by-file

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [ ] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
