### PR TITLE
[PY] fix: Match against text only if it exists in message selector

### DIFF
--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -251,8 +251,11 @@ class Application(Bot, Generic[StateT]):
                 hits = re.match(select, text)
                 return hits is not None
 
-            i = context.activity.text.find(select)
-            return i > -1
+            if context.activity.text:
+                i = context.activity.text.find(select)
+                return i > -1
+
+            return False
 
         def __call__(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             self._routes.append(Route[StateT](__selector__, func))


### PR DESCRIPTION
## Linked issues

#minor

## Details

When a message extension is inserted into a chat with a bot, a request with type `message` is sent with no `text` field, resulting in the following error:

`AttributeError: 'NoneType' object has no attribute 'find'`

Check for the existence of `text` before calling `find` on it.