### PR TITLE
[repo] fix: max_tokens bug fix in completions

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Teams.AI.AI.Models
                 IEnumerable<OAIChat.ChatMessage> chatMessages = prompt.Output.Select(chatMessage => chatMessage.ToOpenAIChatMessage());
 
                 ChatCompletionOptions? chatCompletionOptions = ModelReaderWriter.Read<ChatCompletionOptions>(BinaryData.FromString($@"{{
-                    ""max_tokens"": {maxInputTokens},
+                    ""max_tokens"": {promptTemplate.Configuration.Completion.MaxTokens},
                     ""temperature"": {(float)promptTemplate.Configuration.Completion.Temperature},
                     ""top_p"": {(float)promptTemplate.Configuration.Completion.TopP},
                     ""presence_penalty"": {(float)promptTemplate.Configuration.Completion.PresencePenalty},

--- a/python/packages/ai/teams/ai/models/openai_model.py
+++ b/python/packages/ai/teams/ai/models/openai_model.py
@@ -123,7 +123,7 @@ class OpenAIModel(PromptCompletionModel):
         tokenizer: Tokenizer,
         template: PromptTemplate,
     ) -> PromptResponse[str]:
-        max_tokens = template.config.completion.max_input_tokens
+        max_input_tokens = template.config.completion.max_input_tokens
         model = (
             template.config.completion.model
             if template.config.completion.model is not None
@@ -134,7 +134,7 @@ class OpenAIModel(PromptCompletionModel):
             memory=memory,
             functions=functions,
             tokenizer=tokenizer,
-            max_tokens=max_tokens,
+            max_tokens=max_input_tokens,
         )
 
         if res.too_long:
@@ -142,7 +142,7 @@ class OpenAIModel(PromptCompletionModel):
                 status="too_long",
                 error=f"""
                 the generated chat completion prompt had a length of {res.length} tokens
-                which exceeded the max_input_tokens of {max_tokens}
+                which exceeded the max_input_tokens of {max_input_tokens}
                 """,
             )
 
@@ -194,7 +194,7 @@ class OpenAIModel(PromptCompletionModel):
                 frequency_penalty=template.config.completion.frequency_penalty,
                 top_p=template.config.completion.top_p,
                 temperature=template.config.completion.temperature,
-                max_tokens=max_tokens,
+                max_tokens=template.config.completion.max_tokens,
                 extra_body=extra_body,
             )
 

--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -610,7 +610,7 @@ class Application(Bot, Generic[StateT]):
                     return False
 
                 feedback = context.activity.value
-                feedback.reply_to_id=context.activity.reply_to_id
+                feedback.reply_to_id = context.activity.reply_to_id
 
                 await func(context, state, feedback)
                 await context.send_activity(
@@ -819,8 +819,9 @@ class Application(Bot, Generic[StateT]):
         return True
 
     def _contains_non_text_attachments(self, context):
-        non_text_attachments = filter(lambda a: not a.content_type.startswith(
-            "text/html"), context.activity.attachments)
+        non_text_attachments = filter(
+            lambda a: not a.content_type.startswith("text/html"), context.activity.attachments
+        )
         return len(list(non_text_attachments)) > 0
 
     async def _run_after_turn_middleware(self, context: TurnContext, state):


### PR DESCRIPTION
## Linked issues

closes: #1835, #1800

## Details

- `max_input_tokens` was incorrectly passed in as openai's `max_token` (for both C# and Python)

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
