### PR TITLE
[PY] fix: Add vscode python settings

### DIFF
--- a/python/packages/ai/.vscode/settings.json
+++ b/python/packages/ai/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "python.analysis.typeCheckingMode": "standard",
+  "python.analysis.enablePytestSupport": false,
+  "python.analysis.enableSyncServer": false,
+  "python.terminal.activateEnvironment": true,
+  "python.terminal.activateEnvInCurrentTerminal": true
+}


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details

This just adds to the `.vscode/settings.json` to hopefully prevent type checking & other issues on different machines