### PR TITLE
[JS] chore: samples support Teams App test tool

### DIFF
--- a/js/samples/01.getting-started/a.echoBot/.gitignore
+++ b/js/samples/01.getting-started/a.echoBot/.gitignore
@@ -112,3 +112,6 @@ env/.env.*.user
 env/.env.local
 appPackage/build
 .deployment
+env/.env.testtool
+.localConfigs.testTool
+devTools/

--- a/js/samples/01.getting-started/a.echoBot/.vscode/launch.json
+++ b/js/samples/01.getting-started/a.echoBot/.vscode/launch.json
@@ -90,6 +90,18 @@
                 "order": 2
             },
             "stopAll": true
+        },
+        {
+            "name": "Debug in Test Tool",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start Teams App (Test Tool)",
+            "presentation": {
+                "group": "local",
+                "order": 1
+            },
+            "stopAll": true
         }
     ]
 }

--- a/js/samples/01.getting-started/a.echoBot/.vscode/tasks.json
+++ b/js/samples/01.getting-started/a.echoBot/.vscode/tasks.json
@@ -100,6 +100,105 @@
                     "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
                 }
             }
+        },
+        {
+            "label": "Start Teams App (Test Tool)",
+            "dependsOn": [
+                "Validate prerequisites (Test Tool)",
+                "Deploy (Test Tool)",
+                "Start application (Test Tool)",
+                "Start Test Tool",
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            // Check all required prerequisites.
+            // See https://aka.ms/teamsfx-tasks/check-prerequisites to know the details and how to customize the args.
+            "label": "Validate prerequisites (Test Tool)",
+            "type": "teamsfx",
+            "command": "debug-check-prerequisites",
+            "args": {
+                "prerequisites": [
+                    "nodejs", // Validate if Node.js is installed.
+                    "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
+                ],
+                "portOccupancy": [
+                    3978, // app service port
+                    9239, // app inspector port for Node.js debugger
+                    56150, // test tool port
+                ]
+            }
+        },
+        {
+            // Build project.
+            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
+            "label": "Deploy (Test Tool)",
+            "type": "teamsfx",
+            "command": "deploy",
+            "args": {
+                "env": "testtool",
+            }
+        },
+        {
+            "label": "Start application (Test Tool)",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:testtool",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}",
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "[nodemon] starting",
+                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                }
+            }
+        },
+        {
+            "label": "Start Test Tool",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:launch-testtool",
+            "isBackground": true,
+            "options": {
+                "env": {
+                  "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin;${env:PATH}"
+                    }
+                }
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Listening on"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "silent"
+            }
         }
     ]
 }

--- a/js/samples/01.getting-started/a.echoBot/README.md
+++ b/js/samples/01.getting-started/a.echoBot/README.md
@@ -11,6 +11,7 @@ This sample shows how to incorporate a basic conversational flow into a Microsof
     -   [Setting up the sample](#setting-up-the-sample)
     -   [Testing the sample](#testing-the-sample)
         -   [Using Teams Toolkit for Visual Studio Code](#using-teams-toolkit-for-visual-studio-code)
+        -   [Using Teams App test tool](#using-teams-app-test-tool)
 
 <!-- /code_chunk_output -->
 
@@ -81,3 +82,15 @@ The simplest way to run this sample in Teams is to use Teams Toolkit for Visual 
 1. In the browser that launches, select the **Add** button to install the app to Teams..
 
 > If you do not have permission to upload custom apps (sideloading), Teams Toolkit will recommend creating and using a Microsoft 365 Developer Program account - a free program to get your own dev environment sandbox that includes Teams.
+
+### Using Teams App test tool
+
+Use **Teams App test tool** (integrated into teams Toolkit) to run this sample.
+
+1. Ensure you have downloaded and installed [Visual Studio Code](https://code.visualstudio.com/docs/setup/setup-overview)
+1. Install the [Teams Toolkit extension](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
+1. Copy this sample into a new folder outside of teams-ai
+1. Select File > Open Folder in VS Code and choose this sample's directory
+1. From the left pane, select **Run and Debug**(Ctrl+Shift+D) and select **Debug in Test Tool** in dropdown list.
+1. Select Debug > Start Debugging or F5 to run the app.
+1. The browser will pop up to open Teams App Test Tool.

--- a/js/samples/01.getting-started/a.echoBot/env/.env.testtool
+++ b/js/samples/01.getting-started/a.echoBot/env/.env.testtool
@@ -1,0 +1,5 @@
+TEAMSFX_ENV=testtool
+
+# Environment variables used by test tool
+TEAMSAPPTESTER_PORT=56150
+TEAMSFX_NOTIFICATION_STORE_FILENAME=.notification.testtoolstore.json

--- a/js/samples/01.getting-started/a.echoBot/package.json
+++ b/js/samples/01.getting-started/a.echoBot/package.json
@@ -31,11 +31,12 @@
         "@types/restify": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "env-cmd": "^10.1.0",
         "eslint": "^8.57.0",
         "nodemon": "~3.0.1",
         "prettier": "^3.3.3",
         "rimraf": "^5.0.10",
-        "typescript": "^5.5.4",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.4"
     }
 }

--- a/js/samples/01.getting-started/a.echoBot/teamsapp.testtool.yml
+++ b/js/samples/01.getting-started/a.echoBot/teamsapp.testtool.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.5
+
+deploy:
+  # Install development tool(s)
+  - uses: devTool/install
+    with:
+      testTool:
+        version: ~0.2.1
+        symlinkDir: ./devTools/teamsapptester
+
+  # Run npm command
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit --workspaces=false
+
+  # Generate runtime environment variables
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./.localConfigs.testTool
+      envs:
+        TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/.gitignore
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/.gitignore
@@ -112,3 +112,6 @@ env/.env.*.user
 env/.env.local
 appPackage/build
 .deployment
+env/.env.testtool
+.localConfigs.testTool
+devTools/

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/.vscode/launch.json
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/.vscode/launch.json
@@ -80,6 +80,18 @@
                 "order": 2
             },
             "stopAll": true
+        },
+        {
+            "name": "Debug in Test Tool",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start Teams App (Test Tool)",
+            "presentation": {
+                "group": "local",
+                "order": 1
+            },
+            "stopAll": true
         }
     ]
 }

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/.vscode/tasks.json
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/.vscode/tasks.json
@@ -100,6 +100,105 @@
                     "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
                 }
             }
+        },
+        {
+            "label": "Start Teams App (Test Tool)",
+            "dependsOn": [
+                "Validate prerequisites (Test Tool)",
+                "Deploy (Test Tool)",
+                "Start application (Test Tool)",
+                "Start Test Tool",
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            // Check all required prerequisites.
+            // See https://aka.ms/teamsfx-tasks/check-prerequisites to know the details and how to customize the args.
+            "label": "Validate prerequisites (Test Tool)",
+            "type": "teamsfx",
+            "command": "debug-check-prerequisites",
+            "args": {
+                "prerequisites": [
+                    "nodejs", // Validate if Node.js is installed.
+                    "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
+                ],
+                "portOccupancy": [
+                    3978, // app service port
+                    9239, // app inspector port for Node.js debugger
+                    56150, // test tool port
+                ]
+            }
+        },
+        {
+            // Build project.
+            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
+            "label": "Deploy (Test Tool)",
+            "type": "teamsfx",
+            "command": "deploy",
+            "args": {
+                "env": "testtool",
+            }
+        },
+        {
+            "label": "Start application (Test Tool)",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:testtool",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}",
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "[nodemon] starting",
+                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                }
+            }
+        },
+        {
+            "label": "Start Test Tool",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:launch-testtool",
+            "isBackground": true,
+            "options": {
+                "env": {
+                  "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin;${env:PATH}"
+                    }
+                }
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Listening on"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "silent"
+            }
         }
     ]
 }

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/README.md
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/README.md
@@ -11,6 +11,7 @@ This sample shows how to incorporate Adaptive Cards into a Microsoft Teams appli
     -   [Setting up the sample](#setting-up-the-sample)
     -   [Testing the sample](#testing-the-sample)
         -   [Using Teams Toolkit for Visual Studio Code](#using-teams-toolkit-for-visual-studio-code)
+        -   [Using Teams App test tool](#using-teams-app-test-tool)
 
 <!-- /code_chunk_output -->
 
@@ -81,3 +82,15 @@ The simplest way to run this sample in Teams is to use Teams Toolkit for Visual 
 1. In the browser that launches, select the **Add** button to install the app to Teams.
 
 > If you do not have permission to upload custom apps (sideloading), Teams Toolkit will recommend creating and using a Microsoft 365 Developer Program account - a free program to get your own dev environment sandbox that includes Teams.
+
+### Using Teams App test tool
+
+Use **Teams App test tool** (integrated into teams Toolkit) to run this sample.
+
+1. Ensure you have downloaded and installed [Visual Studio Code](https://code.visualstudio.com/docs/setup/setup-overview)
+1. Install the [Teams Toolkit extension](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
+1. Copy this sample into a new folder outside of teams-ai
+1. Select File > Open Folder in VS Code and choose this sample's directory
+1. From the left pane, select **Run and Debug**(Ctrl+Shift+D) and select **Debug in Test Tool** in dropdown list.
+1. Select Debug > Start Debugging or F5 to run the app.
+1. The browser will pop up to open Teams App Test Tool.

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/env/.env.testtool
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/env/.env.testtool
@@ -1,0 +1,5 @@
+TEAMSFX_ENV=testtool
+
+# Environment variables used by test tool
+TEAMSAPPTESTER_PORT=56150
+TEAMSFX_NOTIFICATION_STORE_FILENAME=.notification.testtoolstore.json

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
@@ -32,11 +32,12 @@
         "@types/restify": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "env-cmd": "^10.1.0",
         "eslint": "^8.57.0",
         "nodemon": "~3.0.1",
         "prettier": "^3.3.3",
         "rimraf": "^5.0.10",
-        "typescript": "^5.5.4",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.4"
     }
 }

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/teamsapp.testtool.yml
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/teamsapp.testtool.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.5
+
+deploy:
+  # Install development tool(s)
+  - uses: devTool/install
+    with:
+      testTool:
+        version: ~0.2.1
+        symlinkDir: ./devTools/teamsapptester
+
+  # Run npm command
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit --workspaces=false
+
+  # Generate runtime environment variables
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./.localConfigs.testTool
+      envs:
+        TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/.gitignore
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/.gitignore
@@ -112,3 +112,6 @@ env/.env.*.user
 env/.env.local
 appPackage/build
 .deployment
+env/.env.testtool
+.localConfigs.testTool
+devTools/

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/.vscode/launch.json
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/.vscode/launch.json
@@ -90,6 +90,18 @@
                 "order": 2
             },
             "stopAll": true
+        },
+        {
+            "name": "Debug in Test Tool",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start Teams App (Test Tool)",
+            "presentation": {
+                "group": "local",
+                "order": 1
+            },
+            "stopAll": true
         }
     ]
 }

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/.vscode/tasks.json
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/.vscode/tasks.json
@@ -100,6 +100,105 @@
                     "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
                 }
             }
+        },
+        {
+            "label": "Start Teams App (Test Tool)",
+            "dependsOn": [
+                "Validate prerequisites (Test Tool)",
+                "Deploy (Test Tool)",
+                "Start application (Test Tool)",
+                "Start Test Tool",
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            // Check all required prerequisites.
+            // See https://aka.ms/teamsfx-tasks/check-prerequisites to know the details and how to customize the args.
+            "label": "Validate prerequisites (Test Tool)",
+            "type": "teamsfx",
+            "command": "debug-check-prerequisites",
+            "args": {
+                "prerequisites": [
+                    "nodejs", // Validate if Node.js is installed.
+                    "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
+                ],
+                "portOccupancy": [
+                    3978, // app service port
+                    9239, // app inspector port for Node.js debugger
+                    56150, // test tool port
+                ]
+            }
+        },
+        {
+            // Build project.
+            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
+            "label": "Deploy (Test Tool)",
+            "type": "teamsfx",
+            "command": "deploy",
+            "args": {
+                "env": "testtool",
+            }
+        },
+        {
+            "label": "Start application (Test Tool)",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:testtool",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}",
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "[nodemon] starting",
+                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                }
+            }
+        },
+        {
+            "label": "Start Test Tool",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:launch-testtool",
+            "isBackground": true,
+            "options": {
+                "env": {
+                  "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin;${env:PATH}"
+                    }
+                }
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Listening on"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "silent"
+            }
         }
     ]
 }

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/README.md
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/README.md
@@ -11,6 +11,7 @@ LightBot: Your Enlightened Assistant. This example showcases how the LightBot un
     -   [Setting up the sample](#setting-up-the-sample)
     -   [Testing the sample](#testing-the-sample)
         -   [Using Teams Toolkit for Visual Studio Code](#using-teams-toolkit-for-visual-studio-code)
+        -   [Using Teams App Test Tool](#using-teams-app-test-tool)
 
 <!-- /code_chunk_output -->
 
@@ -118,3 +119,29 @@ If you are using Azure OpenAI then follow these steps:
 1. In the browser that launches, select the **Add** button to install the app to Teams.
 
 > If you do not have permission to upload custom apps (sideloading), Teams Toolkit will recommend creating and using a Microsoft 365 Developer Program account - a free program to get your own dev environment sandbox that includes Teams.
+
+### Using Teams App test tool
+
+If you are using Azure OpenAI then follow these steps:
+
+- Comment the `SECRET_OPENAI_KEY` variable in the `./env/.env.testtool` file.
+- Add your Azure OpenAI key and endpoint values to the `SECRET_AZURE_OPENAI_KEY` and `SECRET_AZURE_OPENAI_ENDPOINT` variables
+- Open the `teamsapp.testtool.yml` file and modify the last step to use Azure OpenAI variables instead:
+
+```yml
+- uses: file/createOrUpdateEnvironmentFile
+  with:
+    target: ./.localConfigs.testTool
+    envs:
+      TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}
+      # OPENAI_KEY: ${{SECRET_OPENAI_KEY}}
+      AZURE_OPENAI_KEY: ${{SECRET_AZURE_OPENAI_KEY}}
+      AZURE_OPENAI_ENDPOINT: ${{SECRET_AZURE_OPENAI_ENDPOINT}}
+```
+1. Ensure you have downloaded and installed [Visual Studio Code](https://code.visualstudio.com/docs/setup/setup-overview)
+1. Install the [Teams Toolkit extension](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
+1. Copy this sample into a new folder outside of teams-ai
+1. Select File > Open Folder in VS Code and choose this sample's directory
+1. From the left pane, select **Run and Debug**(Ctrl+Shift+D) and select **Debug in Test Tool** in dropdown list.
+1. Select Debug > Start Debugging or F5 to run the app.
+1. The browser will pop up to open Teams App Test Tool.

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/env/.env.testtool
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/env/.env.testtool
@@ -1,0 +1,9 @@
+TEAMSFX_ENV=testtool
+
+# Environment variables used by test tool
+TEAMSAPPTESTER_PORT=56150
+TEAMSFX_NOTIFICATION_STORE_FILENAME=.notification.testtoolstore.json
+
+SECRET_OPENAI_KEY=
+#SECRET_AZURE_OPENAI_KEY=
+#SECRET_AZURE_OPENAI_ENDPOINT=

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
@@ -12,15 +12,17 @@
         "start": "tsc --build && node ./lib/index.js",
         "test": "echo \"Error: no test specified\" && exit 1",
         "watch": "nodemon --watch ./src -e ts --exec \"yarn start\"",
-        "dev:teamsfx": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts"
+        "dev:teamsfx": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts",
+        "dev:teamsfx:testtool": "env-cmd --silent -f .localConfigs.testTool npm run dev:teamsfx",
+        "dev:teamsfx:launch-testtool": "env-cmd --silent -f env/.env.testtool teamsapptester start"
     },
     "repository": {
         "type": "git",
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "botbuilder": "^4.22.3",
         "@microsoft/teams-ai": "~1.3.1",
+        "botbuilder": "^4.22.3",
         "dotenv": "^16.4.5",
         "openai": "4.28.4",
         "replace": "~1.2.0",
@@ -31,12 +33,13 @@
         "@types/restify": "8.5.12",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "env-cmd": "^10.1.0",
         "eslint": "^8.57.0",
         "nodemon": "~1.19.4",
         "prettier": "^3.3.3",
         "rimraf": "^5.0.10",
-        "typescript": "^5.5.4",
         "shx": "^0.3.4",
-        "ts-node": "^10.9.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.4"
     }
 }

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/teamsapp.testtool.yml
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/teamsapp.testtool.yml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.5
+
+deploy:
+  # Install development tool(s)
+  - uses: devTool/install
+    with:
+      testTool:
+        version: ~0.2.1
+        symlinkDir: ./devTools/teamsapptester
+
+  # Run npm command
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit --workspaces=false
+
+  # Generate runtime environment variables
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./.localConfigs.testTool
+      envs:
+        TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}
+        OPENAI_KEY: ${{SECRET_OPENAI_KEY}}
+        # AZURE_OPENAI_KEY: ${{SECRET_AZURE_OPENAI_KEY}}
+        # AZURE_OPENAI_ENDPOINT: ${{SECRET_AZURE_OPENAI_ENDPOINT}}
+        

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/.gitignore
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/.gitignore
@@ -112,3 +112,6 @@ env/.env.*.user
 env/.env.local
 appPackage/build
 .deployment
+env/.env.testtool
+.localConfigs.testTool
+devTools/

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/.vscode/launch.json
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/.vscode/launch.json
@@ -90,6 +90,18 @@
                 "order": 2
             },
             "stopAll": true
+        },
+        {
+            "name": "Debug in Test Tool",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start Teams App (Test Tool)",
+            "presentation": {
+                "group": "local",
+                "order": 1
+            },
+            "stopAll": true
         }
     ]
 }

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/.vscode/tasks.json
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/.vscode/tasks.json
@@ -100,6 +100,105 @@
                     "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
                 }
             }
+        },
+        {
+            "label": "Start Teams App (Test Tool)",
+            "dependsOn": [
+                "Validate prerequisites (Test Tool)",
+                "Deploy (Test Tool)",
+                "Start application (Test Tool)",
+                "Start Test Tool",
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            // Check all required prerequisites.
+            // See https://aka.ms/teamsfx-tasks/check-prerequisites to know the details and how to customize the args.
+            "label": "Validate prerequisites (Test Tool)",
+            "type": "teamsfx",
+            "command": "debug-check-prerequisites",
+            "args": {
+                "prerequisites": [
+                    "nodejs", // Validate if Node.js is installed.
+                    "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
+                ],
+                "portOccupancy": [
+                    3978, // app service port
+                    9239, // app inspector port for Node.js debugger
+                    56150, // test tool port
+                ]
+            }
+        },
+        {
+            // Build project.
+            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
+            "label": "Deploy (Test Tool)",
+            "type": "teamsfx",
+            "command": "deploy",
+            "args": {
+                "env": "testtool",
+            }
+        },
+        {
+            "label": "Start application (Test Tool)",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:testtool",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}",
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "[nodemon] starting",
+                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                }
+            }
+        },
+        {
+            "label": "Start Test Tool",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:launch-testtool",
+            "isBackground": true,
+            "options": {
+                "env": {
+                  "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin;${env:PATH}"
+                    }
+                }
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Listening on"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "silent"
+            }
         }
     ]
 }

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/README.md
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/README.md
@@ -11,6 +11,7 @@ ListBot: Your Ultimate List Management Companion. Powered by advanced AI capabil
     -   [Setting up the sample](#setting-up-the-sample)
     -   [Testing the sample](#testing-the-sample)
         -   [Using Teams Toolkit for Visual Studio Code](#using-teams-toolkit-for-visual-studio-code)
+        -   [Using Teams App Test Tool](#using-teams-app-test-tool)
 
 <!-- /code_chunk_output -->
 
@@ -196,3 +197,29 @@ If you are using Azure OpenAI then follow these steps:
 1. In the browser that launches, select the **Add** button to install the app to Teams.
 
 > If you do not have permission to upload custom apps (sideloading), Teams Toolkit will recommend creating and using a Microsoft 365 Developer Program account - a free program to get your own dev environment sandbox that includes Teams.
+
+### Using Teams App test tool
+
+If you are using Azure OpenAI then follow these steps:
+
+- Comment the `SECRET_OPENAI_KEY` variable in the `./env/.env.testtool` file.
+- Add your Azure OpenAI key and endpoint values to the `SECRET_AZURE_OPENAI_KEY` and `SECRET_AZURE_OPENAI_ENDPOINT` variables
+- Open the `teamsapp.testtool.yml` file and modify the last step to use Azure OpenAI variables instead:
+
+```yml
+- uses: file/createOrUpdateEnvironmentFile
+  with:
+    target: ./.localConfigs.testTool
+    envs:
+      TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}
+      # OPENAI_KEY: ${{SECRET_OPENAI_KEY}}
+      AZURE_OPENAI_KEY: ${{SECRET_AZURE_OPENAI_KEY}}
+      AZURE_OPENAI_ENDPOINT: ${{SECRET_AZURE_OPENAI_ENDPOINT}}
+```
+1. Ensure you have downloaded and installed [Visual Studio Code](https://code.visualstudio.com/docs/setup/setup-overview)
+1. Install the [Teams Toolkit extension](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
+1. Copy this sample into a new folder outside of teams-ai
+1. Select File > Open Folder in VS Code and choose this sample's directory
+1. From the left pane, select **Run and Debug**(Ctrl+Shift+D) and select **Debug in Test Tool** in dropdown list.
+1. Select Debug > Start Debugging or F5 to run the app.
+1. The browser will pop up to open Teams App Test Tool.

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/env/.env.testtool
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/env/.env.testtool
@@ -1,0 +1,9 @@
+TEAMSFX_ENV=testtool
+
+# Environment variables used by test tool
+TEAMSAPPTESTER_PORT=56150
+TEAMSFX_NOTIFICATION_STORE_FILENAME=.notification.testtoolstore.json
+
+SECRET_OPENAI_KEY=
+#SECRET_AZURE_OPENAI_KEY=
+#SECRET_AZURE_OPENAI_ENDPOINT=

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
@@ -12,7 +12,9 @@
         "start": "tsc --build && node ./lib/index.js",
         "test": "echo \"Error: no test specified\" && exit 1",
         "watch": "nodemon --watch ./src -e ts --exec \"yarn start\"",
-        "dev:teamsfx": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts"
+        "dev:teamsfx": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts",
+        "dev:teamsfx:testtool": "env-cmd --silent -f .localConfigs.testTool npm run dev:teamsfx",
+        "dev:teamsfx:launch-testtool": "env-cmd --silent -f env/.env.testtool teamsapptester start"
     },
     "repository": {
         "type": "git",
@@ -27,11 +29,12 @@
         "restify": "~11.1.0"
     },
     "devDependencies": {
-        "@types/node": "^20.16.1",
         "@types/jsonwebtoken": "^9.0.4",
+        "@types/node": "^20.16.1",
         "@types/restify": "8.5.12",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "env-cmd": "^10.1.0",
         "eslint": "^8.57.0",
         "nodemon": "~1.19.4",
         "prettier": "^3.3.3",

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/teamsapp.testtool.yml
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/teamsapp.testtool.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.5
+
+deploy:
+  # Install development tool(s)
+  - uses: devTool/install
+    with:
+      testTool:
+        version: ~0.2.1
+        symlinkDir: ./devTools/teamsapptester
+
+  # Run npm command
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit --workspaces=false
+
+  # Generate runtime environment variables
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./.localConfigs.testTool
+      envs:
+        TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}
+        OPENAI_KEY: ${{SECRET_OPENAI_KEY}}
+        # AZURE_OPENAI_KEY: ${{SECRET_AZURE_OPENAI_KEY}}
+        # AZURE_OPENAI_ENDPOINT: ${{SECRET_AZURE_OPENAI_ENDPOINT}}

--- a/js/samples/04.ai-apps/a.teamsChefBot/.gitignore
+++ b/js/samples/04.ai-apps/a.teamsChefBot/.gitignore
@@ -112,3 +112,6 @@ env/.env.*.user
 env/.env.local
 appPackage/build
 .deployment
+env/.env.testtool
+.localConfigs.testTool
+devTools/

--- a/js/samples/04.ai-apps/a.teamsChefBot/.vscode/launch.json
+++ b/js/samples/04.ai-apps/a.teamsChefBot/.vscode/launch.json
@@ -90,6 +90,18 @@
                 "order": 2
             },
             "stopAll": true
+        },
+        {
+            "name": "Debug in Test Tool",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start Teams App (Test Tool)",
+            "presentation": {
+                "group": "local",
+                "order": 1
+            },
+            "stopAll": true
         }
     ]
 }

--- a/js/samples/04.ai-apps/a.teamsChefBot/.vscode/tasks.json
+++ b/js/samples/04.ai-apps/a.teamsChefBot/.vscode/tasks.json
@@ -100,6 +100,105 @@
                     "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
                 }
             }
+        },
+        {
+            "label": "Start Teams App (Test Tool)",
+            "dependsOn": [
+                "Validate prerequisites (Test Tool)",
+                "Deploy (Test Tool)",
+                "Start application (Test Tool)",
+                "Start Test Tool",
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            // Check all required prerequisites.
+            // See https://aka.ms/teamsfx-tasks/check-prerequisites to know the details and how to customize the args.
+            "label": "Validate prerequisites (Test Tool)",
+            "type": "teamsfx",
+            "command": "debug-check-prerequisites",
+            "args": {
+                "prerequisites": [
+                    "nodejs", // Validate if Node.js is installed.
+                    "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
+                ],
+                "portOccupancy": [
+                    3978, // app service port
+                    9239, // app inspector port for Node.js debugger
+                    56150, // test tool port
+                ]
+            }
+        },
+        {
+            // Build project.
+            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
+            "label": "Deploy (Test Tool)",
+            "type": "teamsfx",
+            "command": "deploy",
+            "args": {
+                "env": "testtool",
+            }
+        },
+        {
+            "label": "Start application (Test Tool)",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:testtool",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}",
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "[nodemon] starting",
+                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                }
+            }
+        },
+        {
+            "label": "Start Test Tool",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:launch-testtool",
+            "isBackground": true,
+            "options": {
+                "env": {
+                  "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin;${env:PATH}"
+                    }
+                }
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Listening on"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "silent"
+            }
         }
     ]
 }

--- a/js/samples/04.ai-apps/a.teamsChefBot/README.md
+++ b/js/samples/04.ai-apps/a.teamsChefBot/README.md
@@ -11,6 +11,7 @@ This is a conversational bot for Microsoft Teams that thinks it's a Chef to help
     -   [Setting up the sample](#setting-up-the-sample)
     -   [Testing the sample](#testing-the-sample)
         -   [Using Teams Toolkit for Visual Studio Code](#using-teams-toolkit-for-visual-studio-code)
+        -   [Using Teams App test tool](#using-teams-app-test-tool)
 
 <!-- /code_chunk_output -->
 
@@ -96,3 +97,29 @@ The simplest way to run this sample in Teams is to use Teams Toolkit for Visual 
 1. In the browser that launches, select the **Add** button to install the app to Teams.
 
 > If you do not have permission to upload custom apps (sideloading), Teams Toolkit will recommend creating and using a Microsoft 365 Developer Program account - a free program to get your own dev environment sandbox that includes Teams.
+
+### Using Teams App test tool
+
+If you are using Azure OpenAI then follow these steps:
+
+- Comment the `SECRET_OPENAI_KEY` variable in the `./env/.env.testtool` file.
+- Add your Azure OpenAI key and endpoint values to the `SECRET_AZURE_OPENAI_KEY` and `SECRET_AZURE_OPENAI_ENDPOINT` variables
+- Open the `teamsapp.testtool.yml` file and modify the last step to use Azure OpenAI variables instead:
+
+```yml
+- uses: file/createOrUpdateEnvironmentFile
+  with:
+    target: ./.localConfigs.testTool
+    envs:
+      TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}
+      # OPENAI_KEY: ${{SECRET_OPENAI_KEY}}
+      AZURE_OPENAI_KEY: ${{SECRET_AZURE_OPENAI_KEY}}
+      AZURE_OPENAI_ENDPOINT: ${{SECRET_AZURE_OPENAI_ENDPOINT}}
+```
+1. Ensure you have downloaded and installed [Visual Studio Code](https://code.visualstudio.com/docs/setup/setup-overview)
+1. Install the [Teams Toolkit extension](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
+1. Copy this sample into a new folder outside of teams-ai
+1. Select File > Open Folder in VS Code and choose this sample's directory
+1. From the left pane, select **Run and Debug**(Ctrl+Shift+D) and select **Debug in Test Tool** in dropdown list.
+1. Select Debug > Start Debugging or F5 to run the app.
+1. The browser will pop up to open Teams App Test Tool.

--- a/js/samples/04.ai-apps/a.teamsChefBot/env/.env.testtool
+++ b/js/samples/04.ai-apps/a.teamsChefBot/env/.env.testtool
@@ -1,0 +1,9 @@
+TEAMSFX_ENV=testtool
+
+# Environment variables used by test tool
+TEAMSAPPTESTER_PORT=56150
+TEAMSFX_NOTIFICATION_STORE_FILENAME=.notification.testtoolstore.json
+
+SECRET_OPENAI_KEY=
+#SECRET_AZURE_OPENAI_KEY=
+#SECRET_AZURE_OPENAI_ENDPOINT=

--- a/js/samples/04.ai-apps/a.teamsChefBot/package.json
+++ b/js/samples/04.ai-apps/a.teamsChefBot/package.json
@@ -21,8 +21,8 @@
     },
     "dependencies": {
         "@microsoft/teams-ai": "~1.3.1",
-        "@microsoft/teamsfx": "^2.3.2",
         "@microsoft/teams-js": "^2.26.0",
+        "@microsoft/teamsfx": "^2.3.2",
         "botbuilder": "^4.22.3",
         "dotenv": "^16.4.5",
         "openai": "4.28.4",
@@ -36,6 +36,7 @@
         "@types/restify": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "env-cmd": "^10.1.0",
         "eslint": "^8.57.0",
         "nodemon": "~3.0.1",
         "prettier": "^3.3.3",

--- a/js/samples/04.ai-apps/a.teamsChefBot/teamsapp.testtool.yml
+++ b/js/samples/04.ai-apps/a.teamsChefBot/teamsapp.testtool.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.5
+
+deploy:
+  # Install development tool(s)
+  - uses: devTool/install
+    with:
+      testTool:
+        version: ~0.2.1
+        symlinkDir: ./devTools/teamsapptester
+
+  # Run npm command
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit --workspaces=false
+
+  # Generate runtime environment variables
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./.localConfigs.testTool
+      envs:
+        TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}
+        OPENAI_KEY: ${{SECRET_OPENAI_KEY}}
+        # AZURE_OPENAI_KEY: ${{SECRET_AZURE_OPENAI_KEY}}
+        # AZURE_OPENAI_ENDPOINT: ${{SECRET_AZURE_OPENAI_ENDPOINT}}


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details

Add configurations of Teams App test tool for `Echo Bot`, `Type Ahead Bot`, `Teams Chef`, `List Bot` and `Light Bot`.

#### Change details

For each sample:

- Add Debug in Test Tool launch compounds and related tasks
- Add file of .env.testtool and teamsapp.testtool.yml
- Add package env-cmd
- Add section of Using Teams App test tool in READMD.md
- Update .gitignore

**code snippets**:

**screenshots**:

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes