### PR TITLE
[repo] fix: TeamsSsoPrompt never completes due to timeout

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Teams.AI
             int timeout = _settings.Timeout;
 
             IDictionary<string, object> state = dc.ActiveDialog.State;
-            state[_expiresKey] = DateTime.Now.AddMilliseconds(timeout);
+            state[_expiresKey] = DateTime.UtcNow.AddMilliseconds(timeout);
 
             // Send OAuth card to get SSO token
             await this.SendOAuthCardToObtainTokenAsync(dc.Context, cancellationToken);


### PR DESCRIPTION
## Linked issues

closes: #1744

## Details
**C# fix**
Changed `DateTime.Now` to `DateTime.UtcNow` when used in the `TeamsSSOPrompt`.

**JS fix**
No bug in JS.

**PY**
TeamsSSO auth is not implemented as of now.


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes