### PR TITLE
[PY] feat: SSO - auth-sign-in

### DIFF
--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -195,8 +195,9 @@ class Application(Bot, Generic[StateT]):
         self, context: TurnContext, state: StateT, setting_name: str
     ) -> Optional[str]:
         """
-        If the user is signed in, get the access token. If not, triggers the sign in flow for the provided authentication setting name
-        and returns. In this case, the bot should end the turn until the sign in flow is completed.
+        If the user is signed in, get the access token.
+        If not, triggers the sign in flow for the provided authentication setting name and returns.
+        In this case, the bot should end the turn until the sign in flow is completed.
         """
         if self._auth is None:
             raise ApplicationError("Authentication manager is not configured.")

--- a/python/packages/ai/tests/test_app.py
+++ b/python/packages/ai/tests/test_app.py
@@ -26,6 +26,20 @@ class TestApp(IsolatedAsyncioTestCase):
         yield
 
     @pytest.mark.asyncio
+    async def test_get_token_or_sign_in_user_token_exists(self):
+        context = mock.MagicMock(spec=TurnContext)
+        state = mock.MagicMock()
+        state.temp.auth_tokens = {"test_setting": "test_token"}
+
+        self.app._auth = mock.MagicMock()
+        self.app._auth.sign_in = mock.AsyncMock(return_value=mock.Mock(status="complete"))
+
+        result = await self.app.get_token_or_sign_in_user(context, state, "test_setting")
+
+        self.app._auth.sign_in.assert_called_once_with(context, state, key="test_setting")
+        self.assertEqual(result, "test_token")
+
+    @pytest.mark.asyncio
     async def test_activity(self):
         on_event = mock.AsyncMock()
         self.app.activity("event")(on_event)

--- a/python/packages/ai/tests/test_app.py
+++ b/python/packages/ai/tests/test_app.py
@@ -11,7 +11,7 @@ import pytest
 from botbuilder.core import TurnContext
 from botbuilder.schema import Activity, ChannelAccount, ConversationAccount
 
-from teams import Application
+from teams import Application, ApplicationError
 from teams.feedback_loop_data import FeedbackLoopActionValue, FeedbackLoopData
 from teams.message_reaction_types import MessageReactionTypes
 from tests.utils import SimpleAdapter
@@ -38,6 +38,52 @@ class TestApp(IsolatedAsyncioTestCase):
 
         self.app._auth.sign_in.assert_called_once_with(context, state, key="test_setting")
         self.assertEqual(result, "test_token")
+    
+    @pytest.mark.asyncio
+    async def test_get_token_or_sign_in_user_no_token_sign_in_flow(self):
+        context = mock.MagicMock(spec=TurnContext)
+        state = mock.MagicMock()
+        state.temp.auth_tokens = {}
+
+        self.app._auth = mock.MagicMock()
+        self.app._auth.sign_in = mock.AsyncMock(return_value=mock.Mock(status="pending"))
+        self.app._authenticate_user = mock.AsyncMock(return_value=False)
+
+        result = await self.app.get_token_or_sign_in_user(context, state, "test_setting")
+
+        self.app._auth.sign_in.assert_called_once_with(context, state, key="test_setting")
+        self.app._authenticate_user.assert_called_once_with(context, state)
+        self.assertIsNone(result)
+
+    @pytest.mark.asyncio
+    async def test_get_token_or_sign_in_user_successful_authentication(self):
+        context = mock.MagicMock(spec=TurnContext)
+        state = mock.MagicMock()
+        state.temp.auth_tokens = {}
+
+        self.app._auth = mock.MagicMock()
+        self.app._auth.sign_in = mock.AsyncMock(return_value=mock.Mock(status="pending"))
+        self.app._authenticate_user = mock.AsyncMock(return_value=True)
+        state.temp.auth_tokens = {"test_setting": "new_token"}
+
+        result = await self.app.get_token_or_sign_in_user(context, state, "test_setting")
+
+        self.app._auth.sign_in.assert_called_once_with(context, state, key="test_setting")
+        self.app._authenticate_user.assert_called_once_with(context, state)
+        self.assertEqual(result, "new_token")
+    
+    @pytest.mark.asyncio
+    async def test_get_token_or_sign_in_user_no_auth_manager(self):
+        context = mock.MagicMock(spec=TurnContext)
+        state = mock.MagicMock()
+
+        self.app._auth = None
+
+        with self.assertRaises(ApplicationError) as context_manager:
+            await self.app.get_token_or_sign_in_user(context, state, "test_setting")
+
+        self.assertEqual(str(context_manager.exception), "Authentication manager is not configured.")
+
 
     @pytest.mark.asyncio
     async def test_activity(self):

--- a/python/packages/ai/tests/test_app.py
+++ b/python/packages/ai/tests/test_app.py
@@ -38,7 +38,7 @@ class TestApp(IsolatedAsyncioTestCase):
 
         self.app._auth.sign_in.assert_called_once_with(context, state, key="test_setting")
         self.assertEqual(result, "test_token")
-    
+
     @pytest.mark.asyncio
     async def test_get_token_or_sign_in_user_no_token_sign_in_flow(self):
         context = mock.MagicMock(spec=TurnContext)
@@ -71,7 +71,7 @@ class TestApp(IsolatedAsyncioTestCase):
         self.app._auth.sign_in.assert_called_once_with(context, state, key="test_setting")
         self.app._authenticate_user.assert_called_once_with(context, state)
         self.assertEqual(result, "new_token")
-    
+
     @pytest.mark.asyncio
     async def test_get_token_or_sign_in_user_no_auth_manager(self):
         context = mock.MagicMock(spec=TurnContext)
@@ -82,8 +82,9 @@ class TestApp(IsolatedAsyncioTestCase):
         with self.assertRaises(ApplicationError) as context_manager:
             await self.app.get_token_or_sign_in_user(context, state, "test_setting")
 
-        self.assertEqual(str(context_manager.exception), "Authentication manager is not configured.")
-
+        self.assertEqual(
+            str(context_manager.exception), "Authentication manager is not configured."
+        )
 
     @pytest.mark.asyncio
     async def test_activity(self):


### PR DESCRIPTION
## Linked issues

closes: #1318

## Details
Added the get_token_or_sign_in_user() method. It is the interaction entrypoint for the sso authentication.

It is modeled after the JS version of this functionality. 

If the user is signed in, get the access token.
If not, triggers the sign in flow for the provided authentication setting name and returns.
In this case, the bot should end the turn until the sign in flow is completed.

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
