### PR TITLE
Test migration to MCS SDK (DO NOT MERGE)

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.AI.Action;
 using Microsoft.Teams.AI.AI.Moderator;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AITests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.AI.Action;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionCollectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionCollectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Action;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionCollectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionCollectionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Action;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionHandlerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionHandlerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Teams.AI.Tests.TestUtils;
 using Microsoft.Copilot.Protocols.Primitives;
 using Moq;
 using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.AITests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionHandlerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionHandlerTests.cs
@@ -5,9 +5,9 @@ using Microsoft.Teams.AI.AI.Moderator;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Moq;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 
 namespace Microsoft.Teams.AI.Tests.AITests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionPlannerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionPlannerTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.AI.Augmentations;
 using Microsoft.Teams.AI.AI.Models;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionPlannerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ActionPlannerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.AI.Augmentations;
 using Microsoft.Teams.AI.AI.Models;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AssistantsPlannerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AssistantsPlannerTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using System.Reflection;
 using Microsoft.Teams.AI.AI.Planners;
 using OpenAI.Assistants;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.AITests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AssistantsPlannerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AssistantsPlannerTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.AI.Planners.Experimental;
 using Microsoft.Teams.AI.Exceptions;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/MonologueAugmentationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/MonologueAugmentationTests.cs
@@ -1,5 +1,5 @@
 ﻿using Json.Schema;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Augmentations;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Planners;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/MonologueAugmentationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/MonologueAugmentationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Json.Schema;
 using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Augmentations;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Planners;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/SequenceAugmentationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/SequenceAugmentationTests.cs
@@ -1,5 +1,5 @@
 ﻿using Json.Schema;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Augmentations;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Planners;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/SequenceAugmentationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Augmentations/SequenceAugmentationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Json.Schema;
 using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Augmentations;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Planners;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AzureContentSafetyModeratorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AzureContentSafetyModeratorTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Copilot.BotBuilder;
 using Azure.AI.ContentSafety;
 using Azure;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Adapter;
 
 #pragma warning disable CS8604 // Possible null reference argument.
 namespace Microsoft.Teams.AI.Tests.AITests

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AzureContentSafetyModeratorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/AzureContentSafetyModeratorTests.cs
@@ -2,11 +2,11 @@
 using Microsoft.Teams.AI.AI.Moderator;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.AI.Prompts;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Moq;
 using System.Reflection;
 using Microsoft.Teams.AI.Tests.TestUtils;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Azure.AI.ContentSafety;
 using Azure;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/DefaultActionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/DefaultActionsTests.cs
@@ -5,10 +5,10 @@ using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Moderator;
 
 namespace Microsoft.Teams.AI.Tests.AITests

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/DefaultActionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/DefaultActionsTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Moderator;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.AITests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Clients;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/LLMClientTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Clients;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/OpenAIModelTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/OpenAIModelTests.cs
@@ -15,6 +15,7 @@ using System.Reflection;
 using ChatMessage = Microsoft.Teams.AI.AI.Models.ChatMessage;
 using ChatRole = Microsoft.Teams.AI.AI.Models.ChatRole;
 using Azure.Identity;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.AITests.Models
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/OpenAIModelTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/OpenAIModelTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIModeratorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/OpenAIModeratorTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Teams.AI.AI.Moderator;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.Exceptions;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Moq;
 using System.Reflection;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/PromptManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/PromptManagerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/PromptManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/PromptManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/ConversationHistorySectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/ConversationHistorySectionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Moq;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/ConversationHistorySectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/ConversationHistorySectionTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/DataSourceSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/DataSourceSectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.DataSources;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/DataSourceSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/DataSourceSectionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.DataSources;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionCallMessageSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionCallMessageSectionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionCallMessageSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionCallMessageSectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionResponseMessageSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionResponseMessageSectionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionResponseMessageSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/FunctionResponseMessageSectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/GroupSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/GroupSectionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Moq;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/GroupSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/GroupSectionTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/PromptSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/PromptSectionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Moq;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/PromptSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/PromptSectionTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TemplateSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TemplateSectionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Moq;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TemplateSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TemplateSectionTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TextSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TextSectionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Moq;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TextSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/TextSectionTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/UserInputMessageSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/UserInputMessageSectionTests.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Teams.AI.Application;
 using static System.Net.Mime.MediaTypeNames;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.AITests.PromptsTests.SectionsTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/UserInputMessageSectionTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/PromptsTests/SectionsTests/UserInputMessageSectionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Prompts;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/ActionResponseValidatorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/ActionResponseValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Json.Schema;
 using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/ActionResponseValidatorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/ActionResponseValidatorTests.cs
@@ -1,5 +1,5 @@
 ﻿using Json.Schema;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/DefaultResponseValidatorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/DefaultResponseValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.AI.Validators;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/DefaultResponseValidatorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/DefaultResponseValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.AI.Validators;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/JsonResponseValidatorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/JsonResponseValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Json.Schema;
 using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/JsonResponseValidatorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/ValidatorsTests/JsonResponseValidatorTests.cs
@@ -1,5 +1,5 @@
 ﻿using Json.Schema;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/AdaptiveCardsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/AdaptiveCardsTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/AdaptiveCardsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/AdaptiveCardsTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
@@ -15,8 +16,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnActionExecute_Verb()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -74,8 +75,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnActionExecute_Verb_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -289,8 +290,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnSearch_Dataset()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -361,8 +362,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnSearch_Dataset_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationBuilderTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationBuilderTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
@@ -55,7 +55,7 @@ namespace Microsoft.Teams.AI.Tests.Application
                 Moderator = new TestModerator()
             };
             AuthenticationOptions<TurnState> authOptions = new();
-            authOptions.AddAuthentication("graph", new OAuthSettings() { ConnectionName = "graph-connection" });
+            authOptions.AddAuthentication("graph", new OAuthSettings());
 
             // Act
             var app = new ApplicationBuilder<TurnState>()

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Connector;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Connector;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Moq;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationRouteTests.cs
@@ -1,13 +1,14 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Connector;
 using Microsoft.Copilot.Protocols.Primitives;
-using Microsoft.Copilot.Teams.Primitives
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Moq;
 using Newtonsoft.Json.Linq;
 using System.Text.RegularExpressions;
-using Activity = Microsoft.Bot.Schema.Activity;
+using Activity = Microsoft.Copilot.Protocols.Primitives.Activity;
 
 namespace Microsoft.Teams.AI.Tests.Application
 {
@@ -1866,8 +1867,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async Task Test_OnConfigFetch()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1885,7 +1886,7 @@ namespace Microsoft.Teams.AI.Tests.Application
             {
                 Type = ActivityTypes.Invoke,
                 Name = "config/fetch",
-                ChannelId = Channels.Outlook,
+                ChannelId = "outlook",
                 Recipient = new() { Id = "recipientId" },
                 Conversation = new() { Id = "conversationId" },
                 From = new() { Id = "fromId" },
@@ -1950,8 +1951,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async Task Test_OnConfigSubmit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1974,7 +1975,7 @@ namespace Microsoft.Teams.AI.Tests.Application
             {
                 Type = ActivityTypes.Invoke,
                 Name = "config/submit",
-                ChannelId = Channels.Outlook,
+                ChannelId = "outlook",
                 Value = JObject.FromObject(data),
                 Recipient = new() { Id = "recipientId" },
                 Conversation = new() { Id = "conversationId" },
@@ -2042,8 +2043,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async Task Test_OnFileConsentAccept()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -2123,8 +2124,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async Task Test_OnFileConsentDecline()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -2204,8 +2205,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async Task Test_OnO365ConnectorCardAction()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -2278,8 +2279,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async Task Test_OnHandoff()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.Exceptions;
@@ -65,7 +65,7 @@ namespace Microsoft.Teams.AI.Tests.Application
             {
                 AutoSignIn = (context, cancellationToken) => Task.FromResult(false)
             };
-            authenticationOptions.AddAuthentication("graph", new OAuthSettings() { ConnectionName = "graph-connection" });
+            authenticationOptions.AddAuthentication("graph", new OAuthSettings());
             ApplicationOptions<TurnState> applicationOptions = new()
             {
                 RemoveRecipientMention = removeRecipientMention,

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/ApplicationTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.AI;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthUtilitiesTest.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthUtilitiesTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthUtilitiesTest.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthUtilitiesTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/AuthenticationManagerTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/BotAuthenticationBaseTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/OAuthBotAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/OAuthBotAuthenticationTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Newtonsoft.Json.Linq;
@@ -122,7 +122,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", SETTING_NAME);
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.VerifyStateRouteSelector(turnContext, default);
@@ -143,7 +143,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", SETTING_NAME);
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.VerifyStateRouteSelector(turnContext, default);
@@ -164,7 +164,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", SETTING_NAME);
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.VerifyStateRouteSelector(turnContext, default);
@@ -185,7 +185,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", "NOT SETTING_NAME");
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.VerifyStateRouteSelector(turnContext, default);
@@ -206,7 +206,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", SETTING_NAME);
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.TokenExchangeRouteSelector(turnContext, default);
@@ -227,7 +227,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", SETTING_NAME);
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.TokenExchangeRouteSelector(turnContext, default);
@@ -248,7 +248,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", SETTING_NAME);
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.TokenExchangeRouteSelector(turnContext, default);
@@ -269,7 +269,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
             ((JObject)turnContext.Activity.Value).Add("settingName", "NOT SETTING_NAME");
 
             var app = new TestApplication(new() { Adapter = testAdapter });
-            var botAuth = new TestOAuthBotAuthentication(app, new() { ConnectionName = "connectionName" }, SETTING_NAME);
+            var botAuth = new TestOAuthBotAuthentication(app, new(), SETTING_NAME);
 
             // Act
             var result = await botAuth.TokenExchangeRouteSelector(turnContext, default);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoBotAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoBotAuthenticationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoBotAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoBotAuthenticationTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoPromptTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoPromptTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
                 })
                 .AssertReply(a =>
                 {
-                    Assert.Equal(ActivityTypesEx.InvokeResponse, a.Type);
+                    Assert.Equal(ActivityTypes.InvokeResponse, a.Type);
                     var response = ((Activity)a).Value as InvokeResponse;
                     Assert.NotNull(response);
                     Assert.Equal(200, response!.Status);
@@ -154,7 +154,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
                 })
                 .AssertReply(a =>
                 {
-                    Assert.Equal(ActivityTypesEx.InvokeResponse, a.Type);
+                    Assert.Equal(ActivityTypes.InvokeResponse, a.Type);
                     var response = ((Activity)a).Value as InvokeResponse;
                     Assert.NotNull(response);
                     Assert.Equal(412, response!.Status);
@@ -205,7 +205,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.Bot
                 })
                 .AssertReply(a =>
                 {
-                    Assert.Equal(ActivityTypesEx.InvokeResponse, a.Type);
+                    Assert.Equal(ActivityTypes.InvokeResponse, a.Type);
                     var response = ((Activity)a).Value as InvokeResponse;
                     Assert.NotNull(response);
                     Assert.Equal(200, response!.Status);

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoPromptTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/Bot/TeamsSsoPromptTests.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Moq;
-using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Connector;
+using Microsoft.Copilot.BotBuilder.Adapters;
+using Microsoft.Copilot.Protocols.Connector;
 using System.Text.Json;
 using Newtonsoft.Json.Linq;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
@@ -1,9 +1,10 @@
 ﻿
 using Microsoft.Copilot.BotBuilder;
 using Microsoft.Copilot.Protocols.Primitives;
-using Microsoft.Copilot.Teams.Primitives
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Microsoft.Teams.AI.Exceptions;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
 {
@@ -85,8 +86,8 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         {
             // arrange
             var meAuth = new MockedMessageExtensionsAuthentication();
-            Activity[]? activities = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activities = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activities = arg;
             }
@@ -108,7 +109,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
             Assert.NotNull(activities);
             var sentActivity = activities.FirstOrDefault();
             Assert.NotNull(sentActivity);
-            Assert.Equal(ActivityTypesEx.InvokeResponse, sentActivity.Type);
+            Assert.Equal(ActivityTypes.InvokeResponse, sentActivity.Type);
             Assert.Equal(412, ((InvokeResponse)sentActivity.Value).Status);
         }
 
@@ -132,8 +133,8 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
         {
             // arrange
             var meAuth = new MockedMessageExtensionsAuthentication();
-            Activity[]? activities = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activities = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activities = arg;
             }
@@ -149,7 +150,7 @@ namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
             Assert.NotNull(activities);
             var sentActivity = activities.FirstOrDefault();
             Assert.NotNull(sentActivity);
-            Assert.Equal(ActivityTypesEx.InvokeResponse, sentActivity.Type);
+            Assert.Equal(ActivityTypes.InvokeResponse, sentActivity.Type);
             var invokeResponse = sentActivity.Value as InvokeResponse;
             Assert.NotNull(invokeResponse);
             var meResponse = invokeResponse.Body as MessagingExtensionResponse;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBaseTests.cs
@@ -1,7 +1,7 @@
 ﻿
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Microsoft.Teams.AI.Exceptions;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/OAuthMessageExtensionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/OAuthMessageExtensionsTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Tests.TestUtils;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/OAuthMessageExtensionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/OAuthMessageExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Tests.TestUtils;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthenticationTests.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Identity.Client;
 using Moq;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Newtonsoft.Json.Linq;
 using Microsoft.Teams.AI.Exceptions;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthenticationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Newtonsoft.Json.Linq;
 using Microsoft.Teams.AI.Exceptions;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication.MessageExtensions
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/MockedAuthentication.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/OAuthAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/OAuthAuthenticationTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TeamsSsoAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TeamsSsoAuthenticationTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Moq;
 using Newtonsoft.Json.Linq;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TeamsSsoAuthenticationTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TeamsSsoAuthenticationTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Exceptions;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TestAuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/Authentication/TestAuthenticationManager.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.Tests.Application.Authentication

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MeetingsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MeetingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Connector;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MeetingsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MeetingsTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Connector;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Connector;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MessageExtensionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MessageExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
-using Microsoft.Copilot.Teams.Primitives
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
@@ -16,8 +17,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnSubmitAction_CommandId()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -75,8 +76,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnSubmitAction_CommandId_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -163,8 +164,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnBotMessagePreviewEdit_CommandId()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -227,8 +228,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnBotMessagePreviewEdit_CommandId_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -319,8 +320,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnBotMessagePreviewSend_CommandId()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -381,8 +382,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnBotMessagePreviewSend_CommandId_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -471,8 +472,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnFetchTask_CommandId()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -522,8 +523,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnFetchTask_CommandId_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -602,8 +603,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnQuery_CommandId()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -669,8 +670,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnQuery_CommandId_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -762,8 +763,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_SelectItem()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -813,8 +814,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_SelectItem_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -861,8 +862,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnQueryLink()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -916,8 +917,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnQueryLink_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -955,8 +956,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnAnonymousQueryLink()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1010,8 +1011,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnAnonymousQueryLink_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1049,8 +1050,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnQueryUrlSetting()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1098,8 +1099,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnQueryUrlSetting_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1136,8 +1137,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnConfigureSettings()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1187,8 +1188,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnConfigureSettings_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1224,8 +1225,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnCardButtonClicked()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -1268,8 +1269,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnCardButtonClicked_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MessageExtensionsTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/MessageExtensionsTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TaskModulesTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TaskModulesTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
-using Microsoft.Copilot.Teams.Primitives
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
@@ -15,8 +16,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnFetch_Verb()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -73,8 +74,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnFetch_Verb_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -160,8 +161,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnSubmit_Verb()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }
@@ -218,8 +219,8 @@ namespace Microsoft.Teams.AI.Tests.Application
         public async void Test_OnSubmit_Verb_NotHit()
         {
             // Arrange
-            Activity[]? activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
+            IActivity[]? activitiesToSend = null;
+            void CaptureSend(IActivity[] arg)
             {
                 activitiesToSend = arg;
             }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TaskModulesTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TaskModulesTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TeamsAdapterTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Application/TeamsAdapterTests.cs
@@ -11,17 +11,25 @@ namespace Microsoft.Teams.AI.Tests.Application
         {
             string version = Assembly.GetAssembly(typeof(TeamsAdapter))?.GetName().Version?.ToString() ?? "";
             ProductInfoHeaderValue productInfo = new("teamsai-dotnet", version);
+
+            Assert.False(true);
+
+            /*
             TeamsAdapter adapter = new();
             Assert.NotNull(adapter.HttpClientFactory);
 
             HttpClient client = adapter.HttpClientFactory.CreateClient();
             Assert.NotNull(client);
             Assert.True(client.DefaultRequestHeaders.UserAgent.Contains(productInfo));
+            */
         }
 
         [Fact]
         public void Test_TeamsAdapter_NoDuplicateDefaultHeaders()
         {
+            Assert.False(true);
+
+            /*
             string version = Assembly.GetAssembly(typeof(TeamsAdapter))?.GetName().Version?.ToString() ?? "";
             ProductInfoHeaderValue productInfo = new("teamsai-dotnet", version);
             ConfigurationBuilder config = new();
@@ -32,6 +40,7 @@ namespace Microsoft.Teams.AI.Tests.Application
             Assert.NotNull(client);
             Assert.True(client.DefaultRequestHeaders.UserAgent.Contains(productInfo));
             Assert.True(client.DefaultRequestHeaders.UserAgent.Count == 1);
+            */
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/AzureContentSafetyModeratorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/AzureContentSafetyModeratorTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.IntegrationTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/AzureContentSafetyModeratorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/AzureContentSafetyModeratorTests.cs
@@ -4,9 +4,9 @@ using Microsoft.Teams.AI.AI;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using System.Reflection;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 
 namespace Microsoft.Teams.AI.Tests.IntegrationTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModelTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModelTests.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Moq;
 using System.Reflection;
 using Xunit.Abstractions;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModelTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModelTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Extensions.Logging;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.IntegrationTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModeratorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModeratorTests.cs
@@ -5,9 +5,9 @@ using Microsoft.Extensions.Configuration;
 using Moq;
 using System.Reflection;
 using Xunit.Abstractions;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Microsoft.Extensions.Logging;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModeratorTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/IntegrationTests/OpenAIModeratorTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Teams.AI.State;
 using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.Tests.TestUtils;
 using Microsoft.Extensions.Logging;
+using Microsoft.Copilot.Protocols.Adapter;
 
 namespace Microsoft.Teams.AI.Tests.IntegrationTests
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Microsoft.Teams.AI.Tests.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Microsoft.Teams.AI.Tests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.2" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="OpenAI" Version="2.0.0-beta.7" />
@@ -32,6 +31,36 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TeamsAI\Microsoft.Teams.AI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Copilot.BotBuilder">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplBotBuilder\netstandard2.0\Microsoft.Copilot.BotBuilder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.BotBuilder.Dialogs">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplBotBuilderDialogs\netstandard2.0\Microsoft.Copilot.BotBuilder.Dialogs.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Authentication">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplAuth\netstandard2.0\Microsoft.Copilot.Authentication.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Authentication.Msal">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplAuth.Msal\netstandard2.0\Microsoft.Copilot.Authentication.Msal.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Hosting.AspNetCore">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplHostingAspNet\netstandard2.0\Microsoft.Copilot.Hosting.AspNetCore.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Protocols.Adapter">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplAdapter\netstandard2.0\Microsoft.Copilot.Protocols.Adapter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Protocols.Primitives">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplProtoPrimitives\netstandard2.0\Microsoft.Copilot.Protocols.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Protocols.Connector">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplConnector\netstandard2.0\Microsoft.Copilot.Protocols.Connector.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Teams">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplTeams\netstandard2.0\Microsoft.Copilot.Teams.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateTests.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Tests.TestUtils;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 using Moq;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Record = Microsoft.Teams.AI.State.Record;
 using System.Reflection;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/StateTests/TurnStateTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Teams.AI.Tests.StateTests
             // Arrange
             var state = new TurnState();
             var turnContext = TurnStateConfig.CreateConfiguredTurnContext();
-            Activity activity = turnContext.Activity;
+            IActivity activity = turnContext.Activity;
             string channelId = activity.ChannelId;
             string botId = activity.Recipient.Id;
             string conversationId = activity.Conversation.Id;
@@ -75,7 +75,7 @@ namespace Microsoft.Teams.AI.Tests.StateTests
             // Arrange
             var state = new TurnState();
             var turnContext = TurnStateConfig.CreateConfiguredTurnContext();
-            Activity activity = turnContext.Activity;
+            IActivity activity = turnContext.Activity;
             string channelId = activity.ChannelId;
             string botId = activity.Recipient.Id;
             string conversationId = activity.Conversation.Id;
@@ -112,7 +112,7 @@ namespace Microsoft.Teams.AI.Tests.StateTests
             // Arrange
             var state = new CustomTurnState();
             var turnContext = TurnStateConfig.CreateConfiguredTurnContext();
-            Activity activity = turnContext.Activity;
+            IActivity activity = turnContext.Activity;
             string channelId = activity.ChannelId;
             string botId = activity.Recipient.Id;
             string conversationId = activity.Conversation.Id;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/CustomTurnState.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/CustomTurnState.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.State;
 using Record = Microsoft.Teams.AI.State.Record;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/CustomTurnState.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/CustomTurnState.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Record = Microsoft.Teams.AI.State.Record;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/NotImplementedAdapter.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/NotImplementedAdapter.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.TestUtils
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/NotImplementedAdapter.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/NotImplementedAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.TestUtils
@@ -10,12 +11,12 @@ namespace Microsoft.Teams.AI.Tests.TestUtils
             throw new NotImplementedException();
         }
 
-        public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
+        public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
+        public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, IActivity activity, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/SimpleAdapter.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/SimpleAdapter.cs
@@ -2,32 +2,33 @@
 // Licensed under the MIT License.
 
 using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.TestUtils
 {
     public class SimpleAdapter : TeamsAdapter
     {
-        private readonly Action<Activity[]>? _callOnSend;
-        private readonly Action<Activity>? _callOnUpdate;
+        private readonly Action<IActivity[]>? _callOnSend;
+        private readonly Action<IActivity>? _callOnUpdate;
         private readonly Action<ConversationReference>? _callOnDelete;
 
-        public SimpleAdapter() : base()
+        public SimpleAdapter() : base(null)
         {
 
         }
 
-        public SimpleAdapter(Action<Activity[]> callOnSend) : base()
+        public SimpleAdapter(Action<IActivity[]> callOnSend) : base(null)
         {
             _callOnSend = callOnSend;
         }
 
-        public SimpleAdapter(Action<Activity> callOnUpdate) : base()
+        public SimpleAdapter(Action<IActivity> callOnUpdate) : base(null)
         {
             _callOnUpdate = callOnUpdate;
         }
 
-        public SimpleAdapter(Action<ConversationReference> callOnDelete) : base()
+        public SimpleAdapter(Action<ConversationReference> callOnDelete) : base(null)
         {
             _callOnDelete = callOnDelete;
         }
@@ -39,7 +40,7 @@ namespace Microsoft.Teams.AI.Tests.TestUtils
             return Task.CompletedTask;
         }
 
-        public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
+        public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken)
         {
             Assert.NotNull(activities); // SimpleAdapter.deleteActivity: missing reference
             Assert.True(activities.Count() > 0, "SimpleAdapter.sendActivities: empty activities array.");
@@ -50,7 +51,7 @@ namespace Microsoft.Teams.AI.Tests.TestUtils
             return Task.FromResult(responses.ToArray());
         }
 
-        public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
+        public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, IActivity activity, CancellationToken cancellationToken)
         {
             Assert.NotNull(activity); //SimpleAdapter.updateActivity: missing activity
             _callOnUpdate?.Invoke(activity);
@@ -59,7 +60,7 @@ namespace Microsoft.Teams.AI.Tests.TestUtils
 #pragma warning restore CA1062 // Validate arguments of public methods
         }
 
-        public async Task ProcessRequest(Activity activity, BotCallbackHandler callback, CancellationToken cancellationToken)
+        public async Task ProcessRequest(IActivity activity, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             using (var ctx = new TurnContext(this, activity))
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/SimpleAdapter.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/SimpleAdapter.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.TestUtils
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestActionHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestActionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Action;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestActionHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestActionHandler.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Action;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestInvokeAdapter.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestInvokeAdapter.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.TestUtils
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestInvokeAdapter.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestInvokeAdapter.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Teams.AI.Tests.TestUtils
     {
         public IActivity? Activity { get; private set; }
 
-        public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
+        public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken)
         {
-            Activity = activities.FirstOrDefault(activity => activity.Type == ActivityTypesEx.InvokeResponse);
+            Activity = activities.FirstOrDefault(activity => activity.Type == ActivityTypes.InvokeResponse);
             return Task.FromResult(new ResourceResponse[0]);
         }
     }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestModerator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestModerator.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Moderator;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.AI.Planners;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestModerator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestModerator.cs
@@ -3,6 +3,7 @@ using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Moderator;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.AI.Planners;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.Tests.TestUtils
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPlanner.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TestPlanner.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TurnStateConfig.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TurnStateConfig.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Moq;
 using Record = Microsoft.Teams.AI.State.Record;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TurnStateConfig.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TestUtils/TurnStateConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Moq;
@@ -17,7 +18,7 @@ namespace Microsoft.Teams.AI.Tests.TestUtils
 
             // Arrange
             var state = new TurnState();
-            Activity activity = turnContext.Activity;
+            IActivity activity = turnContext.Activity;
             string channelId = activity.ChannelId;
             string botId = activity.Recipient.Id;
             string conversationId = activity.Conversation.Id;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TypingTimerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TypingTimerTests.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Moq;
 
 namespace Microsoft.Teams.AI.Tests

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TypingTimerTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/TypingTimerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
 using Microsoft.Copilot.Protocols.Primitives;
 using Moq;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AI.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AI.cs
@@ -5,7 +5,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Teams.AI.AI.Moderator;
 using Microsoft.Teams.AI.Utilities;
 using Microsoft.Teams.AI.State;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/AIEntity.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/AIEntity.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.Protocols.Primitives;
 using Newtonsoft.Json;
 
 namespace Microsoft.Teams.AI.AI.Action

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.AI.Action

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionTurnContextAttribute.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/ActionTurnContextAttribute.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Action
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
@@ -2,12 +2,12 @@
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Utilities;
-using Microsoft.Bot.Connector;
+using Microsoft.Copilot.Protocols.Connector;
 using Microsoft.Extensions.Logging;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Action
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/IActionHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/IActionHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.AI.Action

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/DefaultAugmentation.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/DefaultAugmentation.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.AI.Prompts;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/IAugmentation.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/IAugmentation.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Prompts.Sections;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/MonologueAugmentation.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/MonologueAugmentation.cs
@@ -1,6 +1,7 @@
 ﻿using Json.More;
 using Json.Schema;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.AI.Prompts;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/SequenceAugmentation.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Augmentations/SequenceAugmentation.cs
@@ -1,5 +1,6 @@
 ﻿using Json.More;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.AI.Prompts;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Clients/LLMClient.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.AI.AI.Models;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/DataSources/IDataSource.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/DataSources/IDataSource.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/DataSources/TextDataSource.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/DataSources/TextDataSource.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts.Sections;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/IPromptCompletionModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/IPromptCompletionModel.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Models
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.AI.AI.Prompts;
@@ -18,6 +18,7 @@ using System.ClientModel;
 using ServiceVersion = Azure.AI.OpenAI.AzureOpenAIClientOptions.ServiceVersion;
 using Azure.AI.OpenAI.Chat;
 using OpenAI.Chat;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Models
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/AzureContentSafetyModerator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/AzureContentSafetyModerator.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.State;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Azure.AI.ContentSafety;
 using Azure;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Moderator
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/DefaultModerator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/DefaultModerator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/IModerator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/IModerator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Teams.AI.AI.Planners;
 using Microsoft.Teams.AI.State;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Moderator
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/OpenAIModerator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Moderator/OpenAIModerator.cs
@@ -2,8 +2,9 @@
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Teams.AI.State;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.OpenAI;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Moderator
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/ActionPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/ActionPlanner.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Extensions.Logging;
 using Microsoft.Teams.AI.AI.Clients;
 using Microsoft.Teams.AI.AI.Models;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/ActionPlannerOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/ActionPlannerOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/AssistantsPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/AssistantsPlanner.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.AI.OpenAI;
 using Azure.Core;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Teams.AI.AI.Models;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/IPlanner.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Planners/IPlanner.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.AI.Planners

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/IPromptFunctions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/IPromptFunctions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/PromptManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/PromptManager.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Augmentations;
 using Microsoft.Teams.AI.AI.DataSources;
 using Microsoft.Teams.AI.AI.Models;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/ActionAugmentationSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/ActionAugmentationSection.cs
@@ -1,5 +1,6 @@
 ﻿using Json.More;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/ConversationHistorySection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/ConversationHistorySection.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/DataSourceSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/DataSourceSection.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.DataSources;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/FunctionCallMessageSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/FunctionCallMessageSection.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using System.Text.Json;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/FunctionResponseMessageSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/FunctionResponseMessageSection.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/GroupSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/GroupSection.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/LayoutSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/LayoutSection.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/PromptSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/PromptSection.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using System.Text.Json;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/TemplateSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/TemplateSection.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.State;
 using System.Text.Json;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/TextSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/TextSection.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Teams.AI.AI.Models;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/UserInputMessageSection.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Prompts/Sections/UserInputMessageSection.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Application;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.AI.Prompts.Sections
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/ActionResponseValidator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/ActionResponseValidator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Models;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/DefaultResponseValidator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/DefaultResponseValidator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/IPromptResponseValidator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/IPromptResponseValidator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/JSONResponseValidator.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Validators/JSONResponseValidator.cs
@@ -1,7 +1,8 @@
 ﻿using System.Text.Json;
 using Json.More;
 using Json.Schema;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.AI.Prompts;
 using Microsoft.Teams.AI.AI.Tokenizers;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ActivityUtilities.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ActivityUtilities.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Connector;
+using Microsoft.Copilot.Protocols.Primitives;
 using Newtonsoft.Json.Linq;
 using System.Net;
 
@@ -7,34 +8,21 @@ namespace Microsoft.Teams.AI
 {
     internal static class ActivityUtilities
     {
-        public static T? GetTypedValue<T>(Activity activity)
+        public static T? GetTypedValue<T>(IActivity activity)
         {
             if (activity?.Value == null)
             {
                 return default;
             }
-            JObject? obj = activity.Value as JObject;
-            if (obj == null)
-            {
-                return default;
-            }
-            T? invokeValue;
-            try
-            {
-                invokeValue = obj.ToObject<T>();
-            }
-            catch
-            {
-                return default;
-            }
-            return invokeValue;
+
+            return SerializationExtensions.ToObject<T>(activity.Value);
         }
 
         public static Activity CreateInvokeResponseActivity(object? body = default)
         {
             Activity activity = new()
             {
-                Type = ActivityTypesEx.InvokeResponse,
+                Type = ActivityTypes.InvokeResponse,
                 Value = new InvokeResponse { Status = (int)HttpStatusCode.OK, Body = body }
             };
             return activity;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCardInvokeResponseFactory.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCardInvokeResponseFactory.cs
@@ -1,5 +1,5 @@
 ﻿using AdaptiveCards;
-using Microsoft.Bot.Schema;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCards.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCards.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
+using Microsoft.Copilot.Protocols.Connector;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Utilities;
@@ -340,8 +342,11 @@ namespace Microsoft.Teams.AI
                     throw new TeamsAIException($"Unexpected AdaptiveCards.OnSearch() triggered for activity type: {turnContext.Activity.Type}");
                 }
 
+                // Would probably be better to have a type to convert to.
+                IDictionary<string, System.Text.Json.JsonElement> queryElements = SerializationExtensions.ToJsonElements(searchInvokeValue.QueryOptions);
+
                 AdaptiveCardsSearchParams adaptiveCardsSearchParams = new(searchInvokeValue.QueryText, searchInvokeValue.Dataset ?? string.Empty);
-                Query<AdaptiveCardsSearchParams> query = new(searchInvokeValue.QueryOptions.Top, searchInvokeValue.QueryOptions.Skip, adaptiveCardsSearchParams);
+                Query<AdaptiveCardsSearchParams> query = new(int.Parse(queryElements["top"].ToString()), int.Parse(queryElements["skip"].ToString()), adaptiveCardsSearchParams);
                 IList<AdaptiveCardsSearchResult> results = await handler(turnContext, turnState, query, cancellationToken);
 
                 // Check to see if an invoke response has already been added

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCardsHandlers.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/AdaptiveCards/AdaptiveCardsHandlers.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Newtonsoft.Json;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Application.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Hosting.AspNetCore;
+using Microsoft.Copilot.Protocols.Adapter;
+using Microsoft.Copilot.Protocols.Connector;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.Application;
 using Microsoft.Teams.AI.Exceptions;
@@ -33,7 +34,7 @@ namespace Microsoft.Teams.AI
         private static readonly string CONFIG_SUBMIT_INVOKE_NAME = "config/submit";
 
         private readonly AI<TState>? _ai;
-        private readonly BotAdapter? _adapter;
+        private readonly IBotAdapter? _adapter;
         private readonly AuthenticationManager<TState>? _authentication;
 
         private readonly int _typingTimerDelay = 1000;
@@ -163,7 +164,7 @@ namespace Microsoft.Teams.AI
         /// <summary>
         /// Fluent interface for accessing the bot adapter used to configure the application.
         /// </summary>
-        public BotAdapter Adapter
+        public IBotAdapter Adapter
         {
             get
             {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ApplicationBuilder.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ApplicationBuilder.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.State;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Authentication;
 
 namespace Microsoft.Teams.AI
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ApplicationOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ApplicationOptions.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Teams.AI.AI;
 using Microsoft.Teams.AI.State;
 using Microsoft.Extensions.Logging;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.Application;
+using Microsoft.Copilot.Protocols.Adapter;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI
 {
@@ -17,7 +19,7 @@ namespace Microsoft.Teams.AI
         /// Optional. Teams Bot adapter being used.
         /// </summary>
         /// <remarks>
-        /// If using the <see cref="ApplicationOptions{TState}.LongRunningMessages"/> option, calling the <see cref="CloudAdapterBase.ContinueConversationAsync(string, Bot.Schema.Activity, BotCallbackHandler, CancellationToken)"/> method, or configuring user authentication, this property is required.
+        /// If using the <see cref="ApplicationOptions{TState}.LongRunningMessages"/> option, calling the <see cref="CloudAdapterBase.ContinueConversationAsync(string, IActivity, BotCallbackHandler, CancellationToken)"/> method, or configuring user authentication, this property is required.
         /// </remarks>
         public TeamsAdapter? Adapter { get; set; }
 
@@ -25,7 +27,7 @@ namespace Microsoft.Teams.AI
         /// Optional. Application ID of the bot.
         /// </summary>
         /// <remarks>
-        /// If using the <see cref="ApplicationOptions{TState}.LongRunningMessages"/> option, calling the <see cref="CloudAdapterBase.ContinueConversationAsync(string, Bot.Schema.Activity, BotCallbackHandler, CancellationToken)"/> method, or configuring user authentication, this property is required.
+        /// If using the <see cref="ApplicationOptions{TState}.LongRunningMessages"/> option, calling the <see cref="CloudAdapterBase.ContinueConversationAsync(string, IActivity, BotCallbackHandler, CancellationToken)"/> method, or configuring user authentication, this property is required.
         /// </remarks>
         public string? BotAppId { get; set; }
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AdaptiveCards/AdaptiveCardsAuthenticationBase.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationManager.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/AuthenticationOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/BotAuthenticationBase.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Newtonsoft.Json.Linq;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/FilteredTeamsSSOTokenExchangeMiddleware.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/FilteredTeamsSSOTokenExchangeMiddleware.cs
@@ -1,49 +1,39 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Teams;
-using Microsoft.Bot.Connector;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Teams;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Newtonsoft.Json.Linq;
+using Microsoft.Copilot.Teams.Adapter;
 
 namespace Microsoft.Teams.AI.Application.Authentication.Bot
 {
-    internal class FilteredTeamsSSOTokenExchangeMiddleware : IMiddleware
+    internal class FilteredTeamsSSOTokenExchangeMiddleware : TeamsSSOTokenExchangeMiddleware
     {
         private string _oauthConnectionName;
-        private TeamsSSOTokenExchangeMiddleware tokenExchangeMiddleware;
 
-        public FilteredTeamsSSOTokenExchangeMiddleware(IStorage storage, string oauthConnectionName)
+        public FilteredTeamsSSOTokenExchangeMiddleware(IStorage storage, string oauthConnectionName) : base(storage, oauthConnectionName)
         {
-            this.tokenExchangeMiddleware = new TeamsSSOTokenExchangeMiddleware(storage, oauthConnectionName);
             this._oauthConnectionName = oauthConnectionName;
         }
 
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
-        {
-            if (string.Equals(Channels.Msteams, turnContext.Activity.ChannelId, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(SignInConstants.TokenExchangeOperationName, turnContext.Activity.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                string? connectionName = _GetConnectionName(turnContext);
-
-                // If connection name matches then continue to the Teams SSO Token Exchange Middleware.
-                if (connectionName == this._oauthConnectionName)
-                {
-                    await tokenExchangeMiddleware.OnTurnAsync(turnContext, next, cancellationToken).ConfigureAwait(false);
-                    return;
-                }
-            }
-
-            await next(cancellationToken).ConfigureAwait(false);
-        }
-
-        private string? _GetConnectionName(ITurnContext turnContext)
+        public new async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
         {
             JObject? obj = turnContext.Activity.Value as JObject;
             if (obj == null)
             {
                 throw new TeamsAIException("Excepted `turnContext.Activity.Value` to have `connectionName` property");
             };
-            return obj.Value<string>("connectionName");
+            string? connectionName = obj.Value<string>("connectionName");
+
+            // If connection name matches then continue to the Teams SSO Token Exchange Middleware.
+            if (connectionName == this._oauthConnectionName)
+            {
+                await base.OnTurnAsync(turnContext, next, cancellationToken);
+            }
+            else
+            {
+                await next(cancellationToken);
+            }
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/OAuthBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/OAuthBotAuthentication.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Application.Authentication.Bot;
 using Microsoft.Teams.AI.State;
 
@@ -30,10 +30,7 @@ namespace Microsoft.Teams.AI
             this._oauthPrompt = new OAuthPrompt("OAuthPrompt", this._oauthSettings);
 
             // Handles deduplication of token exchange event when using SSO with Bot Authentication
-            if (!IsTokenExchangeMiddlewareRegistered(app))
-            {
-                app.Adapter.Use(new FilteredTeamsSSOTokenExchangeMiddleware(storage ?? new MemoryStorage(), oauthSettings.ConnectionName));
-            }
+            app.Adapter.Use(new FilteredTeamsSSOTokenExchangeMiddleware(storage ?? new MemoryStorage(), settingName));
         }
 
         /// <summary>
@@ -118,14 +115,9 @@ namespace Microsoft.Teams.AI
             };
         }
 
-        protected virtual async Task<SignInResource> GetSignInResourceAsync(ITurnContext context, string connectionName, CancellationToken cancellationToken = default)
+        protected async virtual Task<SignInResource> GetSignInResourceAsync(ITurnContext context, string connectionName, CancellationToken cancellationToken = default)
         {
             return await UserTokenClientWrapper.GetSignInResourceAsync(context, this._oauthSettings.ConnectionName, cancellationToken);
-        }
-
-        private bool IsTokenExchangeMiddlewareRegistered(Application<TState> app)
-        {
-            return app.Adapter.MiddlewareSet.Where(middleWare => middleWare as FilteredTeamsSSOTokenExchangeMiddleware is not null).Count() > 0;
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoBotAuthentication.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Exceptions;
 using Newtonsoft.Json.Linq;
@@ -145,7 +145,7 @@ namespace Microsoft.Teams.AI
                 throw new AuthException("Invalid context, can not get storage key!");
             }
 
-            Activity activity = context.Activity;
+            IActivity activity = context.Activity;
             string channelId = activity.ChannelId;
             string conversationId = activity.Conversation.Id;
             if (activity.Type != ActivityTypes.Invoke || activity.Name != SignInConstants.TokenExchangeOperationName)

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/Bot/TeamsSsoPrompt.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Primitives;
 using System.Net;
 using Newtonsoft.Json.Linq;
 using Microsoft.Identity.Client;
@@ -146,7 +146,7 @@ namespace Microsoft.Teams.AI
             SignInResource signInResource = GetSignInResource();
 
             // Ensure prompt initialized
-            IMessageActivity prompt = Activity.CreateMessageActivity();
+            IActivity prompt = Activity.CreateMessageActivity();
             prompt.Attachments = new List<Attachment>();
             prompt.Attachments.Add(new Attachment
             {
@@ -200,7 +200,7 @@ namespace Microsoft.Teams.AI
             await turnContext.SendActivityAsync(
                 new Activity
                 {
-                    Type = ActivityTypesEx.InvokeResponse,
+                    Type = ActivityTypes.InvokeResponse,
                     Value = new InvokeResponse
                     {
                         Status = (int)statusCode,

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/IAuthentication.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/MessageExtensionsAuthenticationBase.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams;
+using Microsoft.Copilot.Teams.Primitives;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.AI
@@ -45,7 +46,7 @@ namespace Microsoft.Teams.AI
                     // Token exchange failed, asks user to sign in and consent.
                     Activity activity = new()
                     {
-                        Type = ActivityTypesEx.InvokeResponse,
+                        Type = ActivityTypes.InvokeResponse,
                         Value = new InvokeResponse
                         {
                             Status = 412

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/OAuthMessageExtensionsAuthentication.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/MessageExtensions/TeamsSsoMessageExtensionsAuthentication.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.Exceptions;
 using Newtonsoft.Json.Linq;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthAuthentication.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using System.Runtime.CompilerServices;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthSettings.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/OAuthSettings.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Bot.Builder.Dialogs;
+﻿using Microsoft.Copilot.BotBuilder.Dialogs;
 
 namespace Microsoft.Teams.AI
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TeamsSsoAuthentication.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Identity.Client;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/TurnStateProperty.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Exceptions;
-using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Copilot.BotBuilder.Dialogs;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/UserTokenClientWrapper.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Authentication/UserTokenClientWrapper.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 
 namespace Microsoft.Teams.AI
@@ -9,31 +8,31 @@ namespace Microsoft.Teams.AI
     {
         public static async Task<SignInResource> GetSignInResourceAsync(ITurnContext context, string connectionName, CancellationToken cancellationToken = default)
         {
-            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            IUserTokenClient userTokenClient = GetUserTokenClient(context);
             return await userTokenClient.GetSignInResourceAsync(connectionName, context.Activity, "", cancellationToken);
         }
 
         public static async Task<TokenResponse> GetUserTokenAsync(ITurnContext context, string connectionName, string magicCode, CancellationToken cancellationToken = default)
         {
-            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            IUserTokenClient userTokenClient = GetUserTokenClient(context);
             return await userTokenClient.GetUserTokenAsync(context.Activity.From.Id, connectionName, context.Activity.ChannelId, magicCode, cancellationToken);
         }
 
         public static async Task<TokenResponse> ExchangeTokenAsync(ITurnContext context, string connectionName, TokenExchangeRequest tokenExchangeRequest, CancellationToken cancellationToken = default)
         {
-            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            IUserTokenClient userTokenClient = GetUserTokenClient(context);
             return await userTokenClient.ExchangeTokenAsync(context.Activity.From.Id, connectionName, context.Activity.ChannelId, tokenExchangeRequest, cancellationToken);
         }
 
         public static async Task SignoutUserAsync(ITurnContext context, string connectionName, CancellationToken cancellationToken = default)
         {
-            UserTokenClient userTokenClient = GetUserTokenClient(context);
+            IUserTokenClient userTokenClient = GetUserTokenClient(context);
             await userTokenClient.SignOutUserAsync(context.Activity.From.Id, connectionName, context.Activity.ChannelId, cancellationToken);
         }
 
-        private static UserTokenClient GetUserTokenClient(ITurnContext context)
+        private static IUserTokenClient GetUserTokenClient(ITurnContext context)
         {
-            UserTokenClient userTokenClient = context.TurnState.Get<UserTokenClient>();
+            IUserTokenClient userTokenClient = context.TurnState.Get<IUserTokenClient>();
             if (userTokenClient == null)
             {
                 throw new TeamsAIException("OAuth Connection is not supported by the current adapter");

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ConfigHandlerAsync.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ConfigHandlerAsync.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/FeedbackLoopHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/FeedbackLoopHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.Application

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/FileConsentCardHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/FileConsentCardHandler.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/HandoffHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/HandoffHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.Application

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/IInputFileDownloader.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/IInputFileDownloader.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI.Application

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/Meetings.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/Meetings.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Connector;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.Protocols.Connector;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Utilities;
 

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/MeetingsHandlers.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Meetings/MeetingsHandlers.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/MessageExtensions/MessageExtensions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/MessageExtensions/MessageExtensions.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Utilities;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/MessageExtensions/MessageExtensionsHandlers.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/MessageExtensions/MessageExtensionsHandlers.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/O365ConnectorCardActionHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/O365ConnectorCardActionHandler.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ReadReceiptHandler.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/ReadReceiptHandler.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Route/Route.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/Route/Route.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TaskModules/TaskModules.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TaskModules/TaskModules.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Adapter;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.State;
 using Microsoft.Teams.AI.Utilities;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TaskModules/TaskModulesHandlers.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TaskModules/TaskModulesHandlers.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema.Teams;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.Teams.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TeamsAdapter.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TeamsAdapter.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.AspNetCore.Http;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Hosting.AspNetCore;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Security.Claims;
 
 // Note: this class should never modify the way `CloudAdapter` is intended to work.
 
@@ -17,78 +18,28 @@ namespace Microsoft.Teams.AI
     public class TeamsAdapter : CloudAdapter
     {
         /// <summary>
-        /// The Http Client Factory
-        /// </summary>
-        public IHttpClientFactory HttpClientFactory { get; }
-
-        /// <summary>
-        /// The Configuration
-        /// </summary>
-        internal IConfiguration? Configuration { get; }
-
-        /// <summary>
-        /// The Service Client Credentials Factory
-        /// </summary>
-        internal ServiceClientCredentialsFactory? CredentialsFactory { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamsAdapter"/> class. (Public cloud. No auth. For testing.)
-        /// </summary>
-        public TeamsAdapter() : base()
-        {
-            HttpClientFactory = new TeamsHttpClientFactory();
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TeamsAdapter"/> class.
         /// </summary>
-        /// <param name="configuration">The <see cref="IConfiguration"/> instance.</param>
-        /// <param name="httpClientFactory">The <see cref="IHttpClientFactory"/> this adapter should use.</param>
+        /// <param name="channelServiceClientFactory">The IChannelServiceClientFactory instance.</param>
         /// <param name="logger">The <see cref="ILogger"/> implementation this adapter should use.</param>
         public TeamsAdapter(
-            IConfiguration configuration,
-            IHttpClientFactory? httpClientFactory = null,
+            IChannelServiceClientFactory channelServiceClientFactory,
             ILogger? logger = null) : base(
-                configuration,
-                new TeamsHttpClientFactory(httpClientFactory),
+                channelServiceClientFactory,
                 logger)
         {
-            HttpClientFactory = new TeamsHttpClientFactory(httpClientFactory);
-            Configuration = configuration;
-            CredentialsFactory = new ConfigurationServiceClientCredentialFactory(configuration);
+            //HttpClientFactory = new TeamsHttpClientFactory(httpClientFactory);
+            //Configuration = configuration;
+            //CredentialsFactory = new ConfigurationServiceClientCredentialFactory(configuration);
         }
 
         /// <inheritdoc />
-        public new async Task ProcessAsync(HttpRequest httpRequest, HttpResponse httpResponse, IBot bot, CancellationToken cancellationToken = default)
+        public new async Task ProcessAsync(ClaimsIdentity claimsIdentity, HttpRequest httpRequest, HttpResponse httpResponse, IBot bot, CancellationToken cancellationToken = default)
         {
-            string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            ProductInfoHeaderValue productInfo = new("teamsai-dotnet", version);
-            httpResponse.Headers.Add("User-Agent", productInfo.ToString());
-            await base.ProcessAsync(httpRequest, httpResponse, bot, cancellationToken);
-        }
-    }
-
-    internal class TeamsHttpClientFactory : IHttpClientFactory
-    {
-        private readonly IHttpClientFactory? _parent;
-
-        public TeamsHttpClientFactory(IHttpClientFactory? parent = null)
-        {
-            _parent = parent;
-        }
-
-        public HttpClient CreateClient(string name)
-        {
-            HttpClient client = _parent != null ? _parent.CreateClient(name) : new();
-            string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            ProductInfoHeaderValue productInfo = new("teamsai-dotnet", version);
-
-            if (!client.DefaultRequestHeaders.UserAgent.Contains(productInfo))
-            {
-                client.DefaultRequestHeaders.UserAgent.Add(productInfo);
-            }
-
-            return client;
+            //string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            //ProductInfoHeaderValue productInfo = new("teamsai-dotnet", version);
+            //httpResponse.Headers.Add("User-Agent", productInfo.ToString());
+            await base.ProcessAsync(claimsIdentity, httpRequest, httpResponse, bot, cancellationToken);
         }
     }
 }

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TurnEventHandlerAsync.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/TurnEventHandlerAsync.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.State;
 
 namespace Microsoft.Teams.AI

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
@@ -40,18 +40,56 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.2" />
     <PackageReference Include="JsonSchema.Net" Version="5.5.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.62.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24271.1" />
     <PackageReference Include="OpenAI" Version="2.0.0-beta.7" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
+
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.LoggingExtensions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Azure.Core" Version="1.42.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0"/>
+
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Copilot.BotBuilder">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplBotBuilder\netstandard2.0\Microsoft.Copilot.BotBuilder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.BotBuilder.Dialogs">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplBotBuilderDialogs\netstandard2.0\Microsoft.Copilot.BotBuilder.Dialogs.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Authentication">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplAuth\netstandard2.0\Microsoft.Copilot.Authentication.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Authentication.Msal">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplAuth.Msal\netstandard2.0\Microsoft.Copilot.Authentication.Msal.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Hosting.AspNetCore">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplHostingAspNet\netstandard2.0\Microsoft.Copilot.Hosting.AspNetCore.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Protocols.Adapter">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplAdapter\netstandard2.0\Microsoft.Copilot.Protocols.Adapter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Protocols.Primitives">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplProtoPrimitives\netstandard2.0\Microsoft.Copilot.Protocols.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Protocols.Connector">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplConnector\netstandard2.0\Microsoft.Copilot.Protocols.Connector.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Copilot.Teams">
+      <HintPath>D:\mcs-sdk\Microsoft.Copilot.Sdk\bin\Debug\CplTeams\netstandard2.0\Microsoft.Copilot.Teams.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/ITurnState.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/ITurnState.cs
@@ -1,5 +1,6 @@
 ﻿
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 
 namespace Microsoft.Teams.AI.State
 {

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnState.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/State/TurnState.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Copilot.BotBuilder;
+using Microsoft.Copilot.Protocols.Primitives;
 using Microsoft.Teams.AI.Exceptions;
 using Microsoft.Teams.AI.Utilities;
 using System.Runtime.CompilerServices;
@@ -422,7 +422,7 @@ namespace Microsoft.Teams.AI.State
         protected virtual Dictionary<string, string> OnComputeStorageKeys(ITurnContext context)
         {
             // Compute state keys
-            Activity activity = context.Activity;
+            IActivity activity = context.Activity;
             string channelId = activity.ChannelId;
             string botId = activity.Recipient.Id;
             string conversationId = activity.Conversation.Id;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Teams.AI.Utilities;
-using Microsoft.Bot.Schema;
-using Microsoft.Bot.Builder;
+using Microsoft.Copilot.Protocols.Primitives;
+using Microsoft.Copilot.BotBuilder;
 
 namespace Microsoft.Teams.AI
 {
@@ -115,7 +115,7 @@ namespace Microsoft.Teams.AI
             }
         }
 
-        private Task<ResourceResponse[]> StopTimerWhenSendMessageActivityHandlerAsync(ITurnContext turnContext, List<Activity> activities, Func<Task<ResourceResponse[]>> next)
+        private Task<ResourceResponse[]> StopTimerWhenSendMessageActivityHandlerAsync(ITurnContext turnContext, List<IActivity> activities, Func<Task<ResourceResponse[]>> next)
         {
             if (_timer != null)
             {


### PR DESCRIPTION
Not complete:

1) Custom User-Agent
2) Connector Request headers
3) Few unit tests need correction
4) Unclear how TeamsAttachmentDownloader is created, but it now requires IGetCopilotAccessToken
5) Removed default constructor for TeamsAdapter.  Needs follow up concerning unit tests.
6) During forking, appear to have trampled a change to  FilteredTeamsSSOTokenExchangeMiddleware and OAuthBotAuthentication that happened on main

I don't recommend using this PR.  Should likely only take a couple hours to redo when ready + additional testing.