### PR TITLE
[repo] fix: missing sendActivity invoke for file consent accept/decline handlers

### DIFF
--- a/js/packages/teams-ai/src/Application.ts
+++ b/js/packages/teams-ai/src/Application.ts
@@ -585,8 +585,12 @@ export class Application<TState extends TurnState = TurnState> {
                     context.activity.value?.action === 'accept'
             );
         };
-        const handlerWrapper = (context: TurnContext, state: TState) => {
-            return handler(context, state, context.activity.value as FileConsentCardResponse);
+        const handlerWrapper = async (context: TurnContext, state: TState) => {
+            await handler(context, state, context.activity.value as FileConsentCardResponse);
+            await context.sendActivity({
+                type: ActivityTypes.InvokeResponse,
+                value: { status: 200 }
+            });
         };
         this.addRoute(selector, handlerWrapper, true);
         return this;
@@ -607,8 +611,12 @@ export class Application<TState extends TurnState = TurnState> {
                     context.activity.value?.action === 'decline'
             );
         };
-        const handlerWrapper = (context: TurnContext, state: TState) => {
-            return handler(context, state, context.activity.value as FileConsentCardResponse);
+        const handlerWrapper = async (context: TurnContext, state: TState) => {
+            await handler(context, state, context.activity.value as FileConsentCardResponse);
+            await context.sendActivity({
+                type: ActivityTypes.InvokeResponse,
+                value: { status: 200 }
+            });
         };
         this.addRoute(selector, handlerWrapper, true);
         return this;

--- a/js/packages/teams-ai/src/StreamingResponse.spec.ts
+++ b/js/packages/teams-ai/src/StreamingResponse.spec.ts
@@ -129,11 +129,7 @@ describe('StreamingResponse', function () {
                 const activity = adapter.getNextReply();
                 assert.equal(activity.type, 'message', 'activity.type should be "message"');
                 assert.equal(activity.text, '', 'activity.text should be ""');
-                assert.deepEqual(
-                    activity.channelData,
-                    { streamType: 'final' },
-                    'activity.channelData should match'
-                );
+                assert.deepEqual(activity.channelData, { streamType: 'final' }, 'activity.channelData should match');
             });
         });
 

--- a/js/packages/teams-ai/src/StreamingResponse.ts
+++ b/js/packages/teams-ai/src/StreamingResponse.ts
@@ -123,7 +123,7 @@ export class StreamingResponse {
 
     /**
      * Queues the next chunk of text to be sent to the client.
-     * @private 
+     * @private
      */
     private queueNextChunk(): void {
         // Are we already waiting to send a chunk?
@@ -187,7 +187,7 @@ export class StreamingResponse {
                     // Send activity
                     await this.sendActivity(activity);
                 }
-    
+
                 resolve();
             } finally {
                 // Queue is empty, mark as idle
@@ -216,7 +216,7 @@ export class StreamingResponse {
         if (!this._streamId) {
             this._streamId = response?.id;
         }
-    }        
+    }
 }
 
 /**

--- a/js/packages/teams-ai/src/models/OpenAIModel.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.ts
@@ -587,7 +587,7 @@ export class OpenAIModel implements PromptCompletionModel {
         if (!Array.isArray(params.tools) || params.tools.length == 0) {
             if (params.tool_choice) {
                 delete params.tool_choice;
-            }           
+            }
         }
 
         return params;

--- a/js/packages/teams-ai/src/validators/ActionResponseValidator.ts
+++ b/js/packages/teams-ai/src/validators/ActionResponseValidator.ts
@@ -109,7 +109,7 @@ export class ActionResponseValidator implements PromptResponseValidator<Validate
                     `No arguments were sent with called ${this._noun}. Call the "${function_call.name}" ${this._noun} with required arguments as a valid JSON object.`,
                     `The ${this._noun} arguments had errors. Apply these fixes and call "${function_call.name}" ${this._noun} again:`
                 );
-                const args = function_call.arguments === '{}' ? undefined : function_call.arguments ?? '{}';
+                const args = function_call.arguments === '{}' ? undefined : (function_call.arguments ?? '{}');
                 const message: Message = { role: 'assistant', content: args };
                 const result = await validator.validateResponse(
                     context,

--- a/python/packages/ai/teams/app.py
+++ b/python/packages/ai/teams/app.py
@@ -441,6 +441,12 @@ class Application(Bot, Generic[StateT]):
                 if not context.activity.value:
                     return False
                 await func(context, state, context.activity.value)
+                await context.send_activity(
+                    Activity(
+                        type=ActivityTypes.invoke_response,
+                        value=InvokeResponse(status=200, body={}),
+                    )
+                )
                 return True
 
             self._routes.append(Route[StateT](__selector__, __handler__, True))
@@ -483,6 +489,12 @@ class Application(Bot, Generic[StateT]):
                 if not context.activity.value:
                     return False
                 await func(context, state, context.activity.value)
+                await context.send_activity(
+                    Activity(
+                        type=ActivityTypes.invoke_response,
+                        value=InvokeResponse(status=200, body={}),
+                    )
+                )
                 return True
 
             self._routes.append(Route[StateT](__selector__, __handler__, True))


### PR DESCRIPTION
## Linked issues

closes: #2004 

## Details

- for JS/PY, the handle wrappers were missing the sendActivity call, resulting in 502s and automatic retries
- linting

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
