### PR TITLE
[repo] fix: JS, PY, C# - Update citations abstract length to be max 480 chars

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/AIEntity.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/AIEntity.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Teams.AI.AI.Action
         public string? Url { get; set; }
 
         /// <summary>
-        /// Content of the citation. Should be clipped if longer than ~500 characters.
+        /// Content of the citation. Must be clipped if longer than 480 characters.
         /// </summary>
         [JsonProperty(PropertyName = "abstract")]
         public string Abstract { get; set; } = string.Empty;

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Teams.AI.AI.Action
                 int i = 0;
                 foreach (Citation citation in command.Response.Context.Citations)
                 {
-                    string abs = CitationUtils.Snippet(citation.Content, 500);
+                    string abs = CitationUtils.Snippet(citation.Content, 480);
                     if (isTeamsChannel)
                     {
                         content.Replace("\n", "<br>");

--- a/js/packages/teams-ai/src/actions/SayCommand.ts
+++ b/js/packages/teams-ai/src/actions/SayCommand.ts
@@ -75,7 +75,7 @@ export interface ClientCitation {
         url?: string;
 
         /**
-         * Content of the citation. Should be clipped if longer than ~500 characters.
+         * Content of the citation. Must be clipped if longer than 480 characters.
          */
         abstract: string;
 
@@ -179,7 +179,7 @@ export function sayCommand<TState extends TurnState = TurnState>(feedbackLoopEna
                     appearance: {
                         '@type': 'DigitalDocument',
                         name: citation.title || `Document #${i + 1}`,
-                        abstract: Utilities.snippet(citation.content, 500)
+                        abstract: Utilities.snippet(citation.content, 480)
                     }
                 };
 

--- a/python/packages/ai/teams/ai/ai.py
+++ b/python/packages/ai/teams/ai/ai.py
@@ -304,7 +304,7 @@ class AI(Generic[StateT]):
                         position=f"{i + 1}",
                         appearance=Appearance(
                             name=citation.title or f"Document {i + 1}",
-                            abstract=snippet(citation.content, 500),
+                            abstract=snippet(citation.content, 480),
                         ),
                     )
                 )

--- a/python/packages/ai/teams/ai/citations/citations.py
+++ b/python/packages/ai/teams/ai/citations/citations.py
@@ -64,7 +64,7 @@ class Appearance(Model):
         name (str): The name of the document
         text (str): Optional; ignored in Teams
         url (str): The url of the document
-        abstract (str): Content of the citation. Should be clipped if longer than ~500 characters
+        abstract (str): Content of the citation. Must be clipped if longer than 480 characters
         encodingFormat (str): The encoding format of the citation
         image (str): Used for icon; for not it is ignored
         keywords (list[str]): The optional keywords to the citation


### PR DESCRIPTION
## Linked issues

closes: #2064

## Details

For JS, PY, and C#: Update citations abstract to be max length 480 characters instead of 500 characters.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
