### PR TITLE
[C#] bump: dotnet to v1.6.0

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Microsoft.Teams.AI.Tests.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/Microsoft.Teams.AI.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.5" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="OpenAI" Version="2.0.0-beta.11" />

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Microsoft.Teams.AI</PackageId>
     <Product>Microsoft Teams AI SDK</Product>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -40,9 +40,9 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.5" />
     <PackageReference Include="JsonSchema.Net" Version="5.5.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.ML.Tokenizers" Version="0.22.0-preview.24271.1" />

--- a/dotnet/samples/01.messaging.echoBot/EchoBot.csproj
+++ b/dotnet/samples/01.messaging.echoBot/EchoBot.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/02.messageExtensions.a.searchCommand/SearchCommand.csproj
+++ b/dotnet/samples/02.messageExtensions.a.searchCommand/SearchCommand.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/03.adaptiveCards.a.typeAheadBot/TypeAheadBot.csproj
+++ b/dotnet/samples/03.adaptiveCards.a.typeAheadBot/TypeAheadBot.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/04.ai.a.teamsChefBot/TeamsChefBot.csproj
+++ b/dotnet/samples/04.ai.a.teamsChefBot/TeamsChefBot.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
     <PackageReference Include="Microsoft.KernelMemory.AI.OpenAI" Version="0.73.240906.1" />
     <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.73.240906.1" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/GPT.csproj
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/GPT.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/LightBot.csproj
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/LightBot.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/ListBot.csproj
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/ListBot.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->
@@ -28,21 +28,16 @@
     <Content Remove="appPackage/**/*" />
     <None Include="appPackage/**/*" />
     <None Include="env/**/*" />
-    <Content Remove="infra/**/*" />
     <None Include="infra/**/*" />
   </ItemGroup>
 
   <!-- Exclude local settings from publish -->
   <ItemGroup>
     <Content Remove="appsettings.Development.json" />
-    <None Remove="prompts\monologue\skprompt.txt" />
     <Content Include="appsettings.Development.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>None</CopyToPublishDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Prompts\Monologue\" />
   </ItemGroup>
 	
 </Project>

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/DevOpsBot.csproj
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/DevOpsBot.csproj
@@ -13,13 +13,12 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->
   <ItemGroup>
-    <Folder Include="Prompts/Sequence/" />
     <Content Include="Prompts/*/skprompt.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
@@ -31,8 +30,14 @@
     <Content Remove="appPackage/**/*" />
     <None Include="appPackage/**/*" />
     <None Include="env/**/*" />
+    <Compile Remove="Prompts\Sequence\**" />
     <Content Remove="infra/**/*" />
+    <Content Remove="Prompts\Sequence\**" />
     <None Include="infra/**/*" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Remove="Prompts\Sequence\**" />
+    <None Remove="Prompts\Sequence\**" />
   </ItemGroup>
 
   <!-- Exclude local settings from publish -->

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/teamsapp.yml
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/teamsapp.yml
@@ -81,3 +81,4 @@ deploy:
     with:
       artifactFolder: bin/Release/net6.0/win-x86/publish
       resourceId: ${{BOT_AZURE_APP_SERVICE_RESOURCE_ID}}
+projectId: 426d5b8a-9a82-40b6-b6a8-7c594361559d

--- a/dotnet/samples/04.ai.f.vision.cardMaster/CardGazer.csproj
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/CardGazer.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/samples/04.ai.f.vision.cardMaster/CardGazerBotActions.cs
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/CardGazerBotActions.cs
@@ -10,8 +10,8 @@ namespace CardGazer
 {
     public class CardGazerBotActions
     {
-        [Action("SendCard")]
-        public async Task<string> SendCard([ActionTurnContext] ITurnContext turnContext, [ActionTurnState] AppState turnState, [ActionParameters] Dictionary<string, object> args)
+        [Action("SendAdaptiveCard")]
+        public async Task<string> SendAdaptiveCard([ActionTurnContext] ITurnContext turnContext, [ActionTurnState] AppState turnState, [ActionParameters] Dictionary<string, object> args)
         {
 
             if (args.TryGetValue("card", out object? cardObject) && cardObject is JsonElement cardJson)
@@ -36,7 +36,7 @@ namespace CardGazer
             return "failed to parsed card from action arguments";
         }
 
-        [Action("ShowCardJSON")]
+        [Action("DisplayJSON")]
         public async Task<string> ShowCardJSON([ActionTurnContext] ITurnContext turnContext, [ActionTurnState] AppState turnState, [ActionParameters] Dictionary<string, object> args)
         {
             if (args.TryGetValue("card", out object? cardObject) && cardObject is JsonElement cardJson)

--- a/dotnet/samples/04.ai.f.vision.cardMaster/Program.cs
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/Program.cs
@@ -86,7 +86,7 @@ builder.Services.AddTransient<IBot>(sp =>
             prompts: prompts,
             defaultPrompt: async (context, state, planner) =>
             {
-                PromptTemplate template = prompts.GetPrompt("sequence");
+                PromptTemplate template = prompts.GetPrompt("tools");
                 return await Task.FromResult(template);
             }
         )

--- a/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/sequence/skprompt.txt
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/sequence/skprompt.txt
@@ -1,4 +1,0 @@
-﻿You are a friendly assistant for Microsoft Teams with vision support.
-You are an expert on converting doodles and images to Adaptive Cards for Microsoft Teams.
-When shown an image try to convert it to an Adaptive Card and send it using SendCard.
-For Adaptive Cards with Image placeholders use ShowCardJSON instead..

--- a/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/tools/actions.json
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/tools/actions.json
@@ -1,34 +1,32 @@
 [
   {
-    "name": "SendCard",
+    "name": "SendAdaptiveCard",
     "description": "Sends an adaptive card to the user",
     "parameters": {
       "type": "object",
       "properties": {
         "card": {
+          "$ref": "https://adaptivecards.io/schemas/adaptive-card.json#",
           "type": "object",
           "description": "The adaptive card to send"
         }
       },
-      "required": [
-        "card"
-      ]
+      "required": [ "card" ]
     }
   },
   {
-    "name": "ShowCardJSON",
+    "name": "DisplayJSON",
     "description": "Shows the user the JSON for an adaptive card",
     "parameters": {
       "type": "object",
       "properties": {
         "card": {
+          "$ref": "https://adaptivecards.io/schemas/adaptive-card.json#",
           "type": "object",
-          "description": "The adaptive card JSON to show"
+          "description": "The adaptive card JSON as raw text"
         }
       },
-      "required": [
-        "card"
-      ]
+      "required": [ "card" ]
     }
   }
 ]

--- a/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/tools/config.json
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/tools/config.json
@@ -3,7 +3,7 @@
   "description": "Vision Bot",
   "type": "completion",
   "completion": {
-    "model": "gpt-4-vision-preview",
+    "model": "gpt-4o",
     "completion_type": "chat",
     "include_history": true,
     "include_input": true,
@@ -17,6 +17,6 @@
     "stop_sequences": []
   },
   "augmentation": {
-    "augmentation_type": "sequence"
+    "augmentation_type": "tools"
   }
 }

--- a/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/tools/skprompt.txt
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/Prompts/tools/skprompt.txt
@@ -1,0 +1,4 @@
+﻿You are a friendly assistant for Microsoft Teams with vision support.
+You are an expert on converting doodles and images to Adaptive Cards for Microsoft Teams.
+When shown an image try to convert it to an Adaptive Card and send it using SendAdaptiveCard.
+When the user asks for JSON, use DisplayJSON to show the JSON of the Adaptive Card.

--- a/dotnet/samples/04.e.twentyQuestions/TwentyQuestions.csproj
+++ b/dotnet/samples/04.e.twentyQuestions/TwentyQuestions.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->

--- a/dotnet/samples/06.assistants.a.mathBot/MathBot.csproj
+++ b/dotnet/samples/06.assistants.a.mathBot/MathBot.csproj
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
-    <PackageReference Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.3" />
-    <PackageReference Include="OpenAI" Version="2.0.0-beta.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
+    <PackageReference Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.4" />
+    <PackageReference Include="OpenAI" Version="2.0.0-beta.11" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.assistants.a.mathBot/Program.cs
+++ b/dotnet/samples/06.assistants.a.mathBot/Program.cs
@@ -11,6 +11,8 @@ using Azure.Core;
 using Azure.Identity;
 using System.Runtime.CompilerServices;
 
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
@@ -149,3 +151,5 @@ app.UseRouting();
 app.MapControllers();
 
 app.Run();
+
+#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.

--- a/dotnet/samples/06.assistants.b.orderBot/OrderBot.csproj
+++ b/dotnet/samples/06.assistants.b.orderBot/OrderBot.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.3" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-	<PackageReference Include="OpenAI" Version="2.0.0-beta.7" />
-	<PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.2" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.4" />
+    <PackageReference Include="OpenAI" Version="2.0.0-beta.11" />
+  	<PackageReference Include="Azure.AI.OpenAI" Version="2.0.0-beta.5" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.assistants.b.orderBot/Program.cs
+++ b/dotnet/samples/06.assistants.b.orderBot/Program.cs
@@ -113,7 +113,7 @@ if (string.IsNullOrEmpty(assistantId))
     }
     catch (Exception e)
     {
-        throw new Exception("Failed to upload file to vector store.", e.InnerException);
+        throw new Exception("Failed to upload file to vector store.", e);
     }
     
 
@@ -133,7 +133,11 @@ if (string.IsNullOrEmpty(assistantId))
         }
     };
 
-    assistantCreationOptions.Tools.Add(new FunctionToolDefinition("place_order", "Creates or updates a food order.", new BinaryData(OrderParameters.GetSchema())));
+    assistantCreationOptions.Tools.Add(new FunctionToolDefinition() { 
+        FunctionName = "place_order", 
+        Description = "Creates or updates a food order.",
+        Parameters = new BinaryData(OrderParameters.GetSchema())
+    });
     assistantCreationOptions.Tools.Add(new FileSearchToolDefinition());
 
     string newAssistantId = "";

--- a/dotnet/samples/06.auth.oauth.bot/BotAuth.csproj
+++ b/dotnet/samples/06.auth.oauth.bot/BotAuth.csproj
@@ -16,9 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.oauth.messageExtension/MessageExtensionAuth.csproj
+++ b/dotnet/samples/06.auth.oauth.messageExtension/MessageExtensionAuth.csproj
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Graph" Version="4.54.0" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.teamsSSO.bot/BotAuth.csproj
+++ b/dotnet/samples/06.auth.teamsSSO.bot/BotAuth.csproj
@@ -16,9 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.teamsSSO.messageExtension/MessageExtensionAuth.csproj
+++ b/dotnet/samples/06.auth.teamsSSO.messageExtension/MessageExtensionAuth.csproj
@@ -13,10 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Graph" Version="4.54.0" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/AzureAISearchBot.csproj
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/AzureAISearchBot.csproj
@@ -12,10 +12,10 @@
 	
   <ItemGroup>
     <PackageReference Include="Azure.Search.Documents" Version="11.6.0-beta.3" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/Config.cs
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/Config.cs
@@ -24,6 +24,6 @@
         public string? OpenAIApiKey { get; set; }
         public string? OpenAIEndpoint { get; set; }
         public string? AISearchApiKey { get; set; }
-        public string? AISearchEndpoint { get; set; }
+        public string? AISearchApiEndpoint { get; set; }
     }
 }

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/Program.cs
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/Program.cs
@@ -83,7 +83,7 @@ builder.Services.AddTransient<IBot>(sp =>
         AzureOpenAIApiKey = config.Azure!.OpenAIApiKey!,
         AzureOpenAIEndpoint = config.Azure.OpenAIEndpoint!,
         AzureAISearchApiKey = config.Azure.AISearchApiKey!,
-        AzureAISearchEndpoint = new Uri(config.Azure.AISearchEndpoint!),
+        AzureAISearchEndpoint = new Uri(config.Azure.AISearchApiEndpoint!),
         AzureOpenAIEmbeddingDeployment = "text-embedding-ada-002",
     };
     AzureAISearchDataSource dataSource = new(options);

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/appsettings.Development.json
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/appsettings.Development.json
@@ -1,0 +1,18 @@
+{
+	"Logging": {
+		"LogLevel": {
+			"Default": "Information",
+			"Microsoft": "Information",
+			"Microsoft.Hosting.Lifetime": "Information"
+		}
+	},
+	"AllowedHosts": "*",
+  "BOT_ID": "$botId$",
+	"BOT_PASSWORD": "$bot-password$",
+	"Azure": {
+    "OpenAIApiKey": "",
+    "OpenAIEndpoint": "",
+    "AISearchApiKey": "",
+    "AISearchApiEndpoint": ""
+  }
+}

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/appsettings.json
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/appsettings.json
@@ -1,0 +1,21 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "BOT_ID": "$botId$",
+  "BOT_PASSWORD": "$bot-password$",
+  "Azure": {
+    "OpenAIApiKey": "",
+    "OpenAIEndpoint": "",
+    "AISearchApiKey": "",
+    "AISearchApiEndpoint": ""
+  },
+  "OpenAI": {
+    "ApiKey": ""
+  }
+}

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/teamsapp.yml
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/teamsapp.yml
@@ -95,3 +95,4 @@ deploy:
       # You can replace it with an existing Azure Resource ID or other
       # custom environment variable.
       resourceId: ${{BOT_AZURE_APP_SERVICE_RESOURCE_ID}}
+projectId: 002a9acf-a9ee-4eff-8e36-1900189fae75

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchIndexer/AzureAISearchIndexer.csproj
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchIndexer/AzureAISearchIndexer.csproj
@@ -13,7 +13,9 @@
 
   <ItemGroup>
     <Content Include="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 

--- a/dotnet/samples/08.datasource.azureopenai/AzureOpenAIBot.csproj
+++ b/dotnet/samples/08.datasource.azureopenai/AzureOpenAIBot.csproj
@@ -12,10 +12,10 @@
 	
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.7" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.5.*" />
+    <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.6.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details
* Bump `Microsoft.Teams.AI` to `v1.6.0` and updated all the samples.
* Update `Microsoft.Bot.*` dependencies to `v4.22.9` in the SDK and samples.
* Minor fixes to following samples
  * order bot
  * math bot
  * cardMaster bot

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
