### PR TITLE
[C#] fix: StreamingResponse array instantiation

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
@@ -21,14 +21,14 @@ namespace Microsoft.Teams.AI.Application
         private bool _ended = false;
 
         // Queue for outgoing activities
-        private IList<Func<Activity>> _queue = [];
+        private List<Func<Activity>> _queue = new();
         private Task? _queueSync;
         private bool _chunkQueued = false;
 
         /// <summary>
         /// Fluent interface for accessing the attachments.
         /// </summary>
-        public IList<Attachment>? Attachments { get; set; } = [];
+        public List<Attachment>? Attachments { get; set; } = new();
 
         /// <summary>
         /// Gets the stream ID of the current response.

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
@@ -159,16 +159,21 @@ namespace Microsoft.Teams.AI.Application
                 if (this._ended)
                 {
                     // Send final message
-                    return new Activity
+                    Activity activity = new Activity
                     {
                         Type = ActivityTypes.Message,
                         Text = Message,
-                        Attachments = Attachments != null ? Attachments : [],
                         ChannelData = new StreamingChannelData
                         {
                             StreamType = StreamType.Final,
                         }
                     };
+
+                    if (Attachments != null && Attachments.Count > 0)
+                    {
+                        activity.Attachments = Attachments;
+                    }
+                    return activity;
                 }
                 else
                 {


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details

Update to use new() for backwards compat.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
