### PR TITLE
Remove botAadApp/create action in favor of aadApp/create

### DIFF
--- a/js/samples/04.ai-apps/a.teamsChefBot/teamsapp.local.yml
+++ b/js/samples/04.ai-apps/a.teamsChefBot/teamsapp.local.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: 1.5
+version: v1.5
 
 provision:
     - uses: teamsApp/create # Creates a Teams app
@@ -11,14 +11,14 @@ provision:
           teamsAppId: TEAMS_APP_ID
 
     # Create or reuse an existing Microsoft Entra application for bot.
-   - uses: aadApp/create
-     with:
+    - uses: aadApp/create
+      with:
           # The Microsoft Entra application's display name
           name: TeamsChef${{APP_NAME_SUFFIX}}
           generateClientSecret: true          
           signInAudience: AzureADMultipleOrgs          
           # serviceManagementReference: "" # Optional
-     writeToEnvironmentFile:
+      writeToEnvironmentFile:
           # The Microsoft Entra application's client id created for bot.
           clientId: BOT_ID
           # The Microsoft Entra application's client secret created for bot.

--- a/js/samples/04.ai-apps/a.teamsChefBot/teamsapp.local.yml
+++ b/js/samples/04.ai-apps/a.teamsChefBot/teamsapp.local.yml
@@ -1,7 +1,7 @@
-# yaml-language-server: $schema=https://aka.ms/teams-toolkit/1.0.0/yaml.schema.json
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.5/yaml.schema.json
 # Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
 # Visit https://aka.ms/teamsfx-actions for details on actions
-version: 1.0.0
+version: 1.5
 
 provision:
     - uses: teamsApp/create # Creates a Teams app
@@ -10,13 +10,22 @@ provision:
       writeToEnvironmentFile: # Write the information of installed dependencies into environment file for the specified environment variable(s).
           teamsAppId: TEAMS_APP_ID
 
-    - uses: botAadApp/create # Creates a new AAD app for bot if BOT_ID environment variable is empty
-      with:
-          name: TeamsChef
-      writeToEnvironmentFile:
-          botId: BOT_ID
-          botPassword: SECRET_BOT_PASSWORD
-
+    # Create or reuse an existing Microsoft Entra application for bot.
+   - uses: aadApp/create
+     with:
+          # The Microsoft Entra application's display name
+          name: TeamsChef${{APP_NAME_SUFFIX}}
+          generateClientSecret: true          
+          signInAudience: AzureADMultipleOrgs          
+          # serviceManagementReference: "" # Optional
+     writeToEnvironmentFile:
+          # The Microsoft Entra application's client id created for bot.
+          clientId: BOT_ID
+          # The Microsoft Entra application's client secret created for bot.
+          clientSecret: SECRET_BOT_PASSWORD
+          # The Microsoft Entra application's object id created for bot.
+          objectId: BOT_OBJECT_ID
+          
     - uses: botFramework/create # Create or update the bot registration on dev.botframework.com
       with:
           botId: ${{BOT_ID}}


### PR DESCRIPTION
botAadApp/create is deprecated in favor of using aadApp/create. This may help also help mitigate issues with Microsoft alias users creating security issues in the MSFT tenant when using samples.
