### PR TITLE
[repo] fix: add stop command docs/comments for tools augmentation compatibility

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AIConstants.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/AIConstants.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Teams.AI.AI
         /// <summary>
         /// The type of command that will stop the running.
         /// </summary>
+        /// <remarks>
+        /// This command is incompatible and should not be used with `tools` augmentation 
+        /// </remarks>
         public const string StopCommand = "STOP";
 
         /// <summary>

--- a/getting-started/CONCEPTS/ACTIONS.md
+++ b/getting-started/CONCEPTS/ACTIONS.md
@@ -107,6 +107,7 @@ An action handler is a callback function that is called when an action is trigge
 
 - If the result is a non-empty string, that string is included as the output of the action to the plan. The last output can be accessed in the next triggered action via the state object: `state.temp.lastOutput`.
 - If the action handler returns `AI.StopCommandName`, the `run` method will terminate execution.
+  > **Note:** `AI.StopCommandName` does not work with `tools` augmentation!
 - If the result is an empty string and there is a list of predicted commands, the next command in the plan is executed.
 - In sequence augmentation, the returned string is appended to the prompt at runtime (see Sequence [Augmentations](./AUGMENTATIONS.md)). This is then used to generate the plan object using defined actions.
 - In monologue augmentation, the returned string is used as inner monologue to perform chain-of-thought reasoning by appending instructions to the prompt during runtime (see Monologue [Augmentation](./AUGMENTATIONS.md)). This is for predicing the next action to execute.

--- a/js/packages/teams-ai/src/AI.ts
+++ b/js/packages/teams-ai/src/AI.ts
@@ -120,6 +120,8 @@ export class AI<TState extends TurnState = TurnState> {
     /**
      * A text string that can be returned from an action to stop the AI system from continuing
      * to execute the current plan.
+     * @remarks
+     * This command is incompatible and should not be used with `tools` augmentation 
      */
     public static readonly StopCommandName = actions.StopCommandName;
 

--- a/python/packages/ai/teams/ai/actions/action_types.py
+++ b/python/packages/ai/teams/ai/actions/action_types.py
@@ -10,6 +10,8 @@ from enum import Enum
 
 class ActionTypes(str, Enum):
     STOP = "STOP"
+    "This command is incompatible and should not be used with `tools` augmentation"
+
     UNKNOWN_ACTION = "___UnknownAction___"
     FLAGGED_INPUT = "___FlaggedInput___"
     FLAGGED_OUTPUT = "___FlaggedOutput___"


### PR DESCRIPTION
## Linked issues

closes: #2126 

## Details

Context: https://github.com/microsoft/teams-ai/issues/2126 

Adding comments to communicate that the `StopCommand` is not compatible with the `tools` augmentation.

