### PR TITLE
[JS] fix: Citations where context was being dropped in OpenAIModel.ts

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Action/DefaultActions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Teams.AI.AI.Action
                 int i = 0;
                 foreach (Citation citation in command.Response.Context.Citations)
                 {
-                    string abs = CitationUtils.Snippet(citation.Content, 480);
+                    string abs = CitationUtils.Snippet(citation.Content, 477);
                     if (isTeamsChannel)
                     {
                         content.Replace("\n", "<br>");

--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -25,17 +25,17 @@
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "peerDependencies": {
-        "botbuilder": "^4.23.0",
-        "openai": "^4.61.0"
+        "botbuilder": "^4.23.1",
+        "openai": "^4.68.2"
     },
     "dependencies": {
         "@azure/openai-assistants": "1.0.0-beta.6",
         "@azure/msal-node": "^2.15.0",
         "axios": "^1.7.5",
         "botbuilder-dialogs": "^4.23.1",
-        "botframework-connector": "^4.23.0",
-        "botframework-schema": "^4.23.0",
-        "botframework-streaming": "^4.23.0",
+        "botframework-connector": "^4.23.1",
+        "botframework-schema": "^4.23.1",
+        "botframework-streaming": "^4.23.1",
         "gpt-tokenizer": "^2.5.1",
         "json-colorizer": "^2.2.2",
         "jsonschema": "1.4.1",

--- a/js/packages/teams-ai/src/actions/SayCommand.ts
+++ b/js/packages/teams-ai/src/actions/SayCommand.ts
@@ -41,7 +41,7 @@ export function sayCommand<TState extends TurnState = TurnState>(feedbackLoopEna
                     appearance: {
                         '@type': 'DigitalDocument',
                         name: citation.title || `Document #${i + 1}`,
-                        abstract: Utilities.snippet(citation.content, 480)
+                        abstract: Utilities.snippet(citation.content, 477)
                     }
                 };
 

--- a/js/packages/teams-ai/src/models/OpenAIModel.spec.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.spec.ts
@@ -1,3 +1,5 @@
+/// <reference types="mocha" />
+
 import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import { OpenAIModel } from './OpenAIModel';

--- a/js/packages/teams-ai/src/models/OpenAIModel.spec.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.spec.ts
@@ -87,4 +87,56 @@ describe('OpenAIModel', () => {
             )
         );
     });
+
+    it('should handle citations in the context', async () => {
+        const model = new OpenAIModel({
+            apiKey: 'test-api-key',
+            endpoint: 'https://test-endpoint.com',
+            defaultModel: 'gpt-3.5-turbo'
+        });
+
+        const mockResponse = {
+            choices: [{
+                message: {
+                    role: 'assistant',
+                    content: 'Test response',
+                    context: {
+                        citations: [
+                            {
+                                content: 'Citation content',
+                                title: 'Citation title',
+                                url: 'https://citation.url'
+                            }
+                        ]
+                    }
+                }
+            }]
+        };
+
+        // Mock the API call
+        sinon.stub(model['_client'].chat.completions, 'create').resolves(mockResponse as any);
+
+        // Mock necessary parameters for completePrompt method
+        const context: any = {};
+        const memory: any = { getValue: () => ({}) };
+        const functions: any = {};
+        const tokenizer: any = {};
+        const template: any = {
+            config: { completion: {} },
+            prompt: { renderAsMessages: async () => ({ output: [] }) }
+        };
+
+        const result = await model.completePrompt(context, memory, functions, tokenizer, template);
+
+        assert.equal(result.status, 'success');
+        assert.equal(result.message?.role, 'assistant');
+        assert.equal(result.message?.content, 'Test response');
+        assert.deepEqual(result.message?.context?.citations, [
+            {
+                content: 'Citation content',
+                title: 'Citation title',
+                url: 'https://citation.url'
+            }
+        ]);
+    });
 });

--- a/js/packages/teams-ai/src/models/OpenAIModel.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.ts
@@ -400,8 +400,19 @@ export class OpenAIModel implements PromptCompletionModel {
                     console.log(Colorize.value('duration', Date.now() - startTime, 'ms'));
                 }
             } else {
-                const actionCalls: ActionCall[] = [];
                 const responseMessage = (completion as ChatCompletion).choices![0].message;
+                message = {
+                    role: responseMessage.role,
+                    content: responseMessage.content ?? '',
+                };
+                
+                // Preserve message context if there is any
+                const messageWithContext = responseMessage as Message<string>;
+                
+                if (messageWithContext.context) {
+                    message.context = messageWithContext.context;
+                }
+                const actionCalls: ActionCall[] = [];
                 const isToolsAugmentation =
                     template.config.augmentation && template.config.augmentation?.augmentation_type == 'tools';
 
@@ -418,16 +429,11 @@ export class OpenAIModel implements PromptCompletionModel {
                         });
                     }
                 }
-                // Log the generated response
-                message = {
-                    role: responseMessage.role,
-                    content: responseMessage.content ?? ''
-                };
-
                 if (actionCalls.length > 0) {
                     message.action_calls = actionCalls;
                 }
-
+                
+                // Log the generated response
                 if (this.options.logRequests) {
                     console.log(Colorize.title('CHAT RESPONSE:'));
                     console.log(Colorize.value('duration', Date.now() - startTime, 'ms'));

--- a/js/packages/teams-ai/src/models/OpenAIModel.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.ts
@@ -375,16 +375,18 @@ export class OpenAIModel implements PromptCompletionModel {
                     }
                     // Handle tool calls
                     if (delta.tool_calls) {
-                        message.action_calls = delta.tool_calls.map((toolCall) => {
-                            return {
-                                id: toolCall.id,
-                                function: {
-                                    name: toolCall.function!.name,
-                                    arguments: toolCall.function!.arguments
-                                },
-                                type: toolCall.type
-                            } as ActionCall;
-                        });
+                        message.action_calls = delta.tool_calls.map(
+                            (toolCall: OpenAI.Chat.Completions.ChatCompletionChunk.Choice.Delta.ToolCall) => {
+                                return {
+                                    id: toolCall.id,
+                                    function: {
+                                        name: toolCall.function!.name,
+                                        arguments: toolCall.function!.arguments
+                                    },
+                                    type: toolCall.type
+                                } as ActionCall;
+                            }
+                        );
                     }
 
                     // Signal chunk received
@@ -403,12 +405,12 @@ export class OpenAIModel implements PromptCompletionModel {
                 const responseMessage = (completion as ChatCompletion).choices![0].message;
                 message = {
                     role: responseMessage.role,
-                    content: responseMessage.content ?? '',
+                    content: responseMessage.content ?? ''
                 };
-                
+
                 // Preserve message context if there is any
                 const messageWithContext = responseMessage as Message<string>;
-                
+
                 if (messageWithContext.context) {
                     message.context = messageWithContext.context;
                 }
@@ -432,7 +434,7 @@ export class OpenAIModel implements PromptCompletionModel {
                 if (actionCalls.length > 0) {
                     message.action_calls = actionCalls;
                 }
-                
+
                 // Log the generated response
                 if (this.options.logRequests) {
                     console.log(Colorize.title('CHAT RESPONSE:'));

--- a/js/samples/01.getting-started/a.echoBot/package.json
+++ b/js/samples/01.getting-started/a.echoBot/package.json
@@ -25,7 +25,7 @@
         "@microsoft/teams-ai": "~1.5.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
+++ b/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
@@ -23,7 +23,7 @@
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
@@ -26,7 +26,7 @@
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/a.twentyQuestions/package.json
+++ b/js/samples/03.ai-concepts/a.twentyQuestions/package.json
@@ -24,7 +24,7 @@
         "@microsoft/teams-ai": "~1.5.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
+++ b/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
@@ -22,7 +22,7 @@
         "botbuilder": "^4.23.1",
         "@microsoft/teams-ai": "~1.5.2",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
@@ -24,7 +24,7 @@
         "@microsoft/teams-ai": "~1.5.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
@@ -24,7 +24,7 @@
         "@microsoft/teams-ai": "~1.5.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
+++ b/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "botbuilder": "^4.23.1",
         "@microsoft/teams-ai": "~1.5.2",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "dotenv": "^16.4.1",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/03.ai-concepts/f.chatModeration/package.json
+++ b/js/samples/03.ai-concepts/f.chatModeration/package.json
@@ -24,7 +24,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/a.teamsChefBot/package.json
+++ b/js/samples/04.ai-apps/a.teamsChefBot/package.json
@@ -26,7 +26,7 @@
         "@microsoft/teams-js": "^2.29.0",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/04.ai-apps/c.vision-cardGazer/package.json
+++ b/js/samples/04.ai-apps/c.vision-cardGazer/package.json
@@ -23,7 +23,7 @@
         "@microsoft/teams-ai": "~1.5.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/d.assistants-mathBot/package.json
+++ b/js/samples/04.ai-apps/d.assistants-mathBot/package.json
@@ -24,7 +24,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/e.assistants-orderBot/package.json
+++ b/js/samples/04.ai-apps/e.assistants-orderBot/package.json
@@ -24,7 +24,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/f.whoBot/package.json
+++ b/js/samples/04.ai-apps/f.whoBot/package.json
@@ -23,7 +23,7 @@
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/g.datasource-azureAISearch/package.json
+++ b/js/samples/04.ai-apps/g.datasource-azureAISearch/package.json
@@ -32,7 +32,7 @@
         "botbuilder": "^4.23.1",
         "debug": "^4.3.7",
         "dotenv": "^16.4.1",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/04.ai-apps/h.datasource-azureOpenAI/package.json
+++ b/js/samples/04.ai-apps/h.datasource-azureOpenAI/package.json
@@ -30,7 +30,7 @@
         "@microsoft/teams-ai": "~1.5.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.1",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
+++ b/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
@@ -23,7 +23,7 @@
         "@microsoft/teams-ai": "~1.5.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "isomorphic-fetch": "^3.0.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/05.authentication/b.oauth-bot/package.json
+++ b/js/samples/05.authentication/b.oauth-bot/package.json
@@ -23,7 +23,7 @@
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/05.authentication/c.oauth-messageExtension/package.json
+++ b/js/samples/05.authentication/c.oauth-messageExtension/package.json
@@ -24,7 +24,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/05.authentication/d.teamsSSO-bot/package.json
+++ b/js/samples/05.authentication/d.teamsSSO-bot/package.json
@@ -23,7 +23,7 @@
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "shx": "^0.3.4"

--- a/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
+++ b/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
@@ -25,7 +25,7 @@
         "botbuilder-azure-blobs": "^4.23.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",
-        "openai": "4.61.0",
+        "openai": "4.68.2",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "shx": "^0.3.4"

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -2122,7 +2122,7 @@ botbuilder@^4.23.1:
     uuid "^10.0.0"
     zod "^3.23.8"
 
-botframework-connector@4.23.1, botframework-connector@^4.23.0:
+botframework-connector@4.23.1, botframework-connector@^4.23.1:
   version "4.23.1"
   resolved "https://registry.yarnpkg.com/botframework-connector/-/botframework-connector-4.23.1.tgz#060cce789cb57deedc657d136b00f318b8a2ef17"
   integrity sha512-UqOdVndOGNN1dgtLEKDD1rObPPI32tPwyrtU8WDuVukaPSL7KYp6z1SjudZ9ywDcrt5z+Rkbz2kGzaSidCVZWA==
@@ -2148,7 +2148,7 @@ botframework-connector@4.23.1, botframework-connector@^4.23.0:
     stream-http "^3.2.0"
     zod "^3.23.8"
 
-botframework-schema@4.23.1, botframework-schema@^4.23.0:
+botframework-schema@4.23.1, botframework-schema@^4.23.1:
   version "4.23.1"
   resolved "https://registry.yarnpkg.com/botframework-schema/-/botframework-schema-4.23.1.tgz#e58118194085a3fcf67adbd92b38b43981794f7c"
   integrity sha512-J/cjL9IFewO3Q2yuV+QGtWyzVFPgKCp/3adY5/+0MrBQasJS5IIGm45W4CV/uYuoAstOIpYJ9nQPzvNWbDN16g==
@@ -2157,7 +2157,7 @@ botframework-schema@4.23.1, botframework-schema@^4.23.0:
     uuid "^10.0.0"
     zod "^3.23.8"
 
-botframework-streaming@4.23.1, botframework-streaming@^4.23.0:
+botframework-streaming@4.23.1, botframework-streaming@^4.23.1:
   version "4.23.1"
   resolved "https://registry.yarnpkg.com/botframework-streaming/-/botframework-streaming-4.23.1.tgz#271db2b5f75ea929fc17832f3b4003eb3179d415"
   integrity sha512-/BjIu2BR8y/HOdJ+Wdr1nZUvW2W53G8whH65msvM95kmjEyqskeEWP62xDpZLA1OM3sLD9APNix69BX1awcbdw==

--- a/python/packages/ai/teams/ai/ai.py
+++ b/python/packages/ai/teams/ai/ai.py
@@ -304,7 +304,7 @@ class AI(Generic[StateT]):
                         position=f"{i + 1}",
                         appearance=Appearance(
                             name=citation.title or f"Document {i + 1}",
-                            abstract=snippet(citation.content, 480),
+                            abstract=snippet(citation.content, 477),
                         ),
                     )
                 )


### PR DESCRIPTION
## Linked issues

closes: #2131
closes: #2080

## Details
- Change the abstract length to 477, in the rare case where the word clips at >477 but <480, then adds ellipses
- `OpenAIModel`: re-add message context so it is not being dropped from `ToolsAugmentation` changes. This now means citations are being rendered as expected.

<img width="862" alt="image" src="https://github.com/user-attachments/assets/307e9f9f-251c-4220-aa87-1268e92057ac">


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
