### PR TITLE
[JS] feat: Streaming - Citations & Sensitivity Label 

### DIFF
--- a/js/packages/teams-ai/src/models/OpenAIModel.spec.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.spec.ts
@@ -98,21 +98,23 @@ describe('OpenAIModel', () => {
         });
 
         const mockResponse = {
-            choices: [{
-                message: {
-                    role: 'assistant',
-                    content: 'Test response',
-                    context: {
-                        citations: [
-                            {
-                                content: 'Citation content',
-                                title: 'Citation title',
-                                url: 'https://citation.url'
-                            }
-                        ]
+            choices: [
+                {
+                    message: {
+                        role: 'assistant',
+                        content: 'Test response',
+                        context: {
+                            citations: [
+                                {
+                                    content: 'Citation content',
+                                    title: 'Citation title',
+                                    url: 'https://citation.url'
+                                }
+                            ]
+                        }
                     }
                 }
-            }]
+            ]
         };
 
         // Mock the API call

--- a/js/packages/teams-ai/src/moderators/AzureContentSafetyModerator.spec.ts
+++ b/js/packages/teams-ai/src/moderators/AzureContentSafetyModerator.spec.ts
@@ -119,10 +119,12 @@ describe('AzureContentSafetyModerator', () => {
                     status: '200',
                     statusText: 'OK',
                     data: {
-                        categoriesAnalysis: [{
-                            category: 'Hate',
-                            severity: 1
-                        }]
+                        categoriesAnalysis: [
+                            {
+                                category: 'Hate',
+                                severity: 1
+                            }
+                        ]
                     }
                 })
             );
@@ -170,10 +172,12 @@ describe('AzureContentSafetyModerator', () => {
                     status: '200',
                     statusText: 'OK',
                     data: {
-                        categoriesAnalysis: [{
-                            category: 'Hate',
-                            severity: 7
-                        }]
+                        categoriesAnalysis: [
+                            {
+                                category: 'Hate',
+                                severity: 7
+                            }
+                        ]
                     }
                 })
             );

--- a/js/packages/teams-ai/src/moderators/AzureContentSafetyModerator.ts
+++ b/js/packages/teams-ai/src/moderators/AzureContentSafetyModerator.ts
@@ -45,7 +45,7 @@ export interface AzureOpenAIModeratorOptions extends OpenAIModeratorOptions {
     /**
      * @deprecated
      * use `haltOnBlocklistHit`
-     * 
+     *
      * When set to true, further analyses of harmful content will not be performed in cases where blocklists are hit.
      * When set to false, all analyses of harmful content will be performed, whether or not blocklists are hit.
      * Default value is false.
@@ -160,9 +160,11 @@ export class AzureContentSafetyModerator<TState extends TurnState = TurnState> e
 
         const predicate = (category: AzureOpenAIModeratorCategory) => {
             return (c: ContentSafetyHarmCategory) => {
-                return c.category === category &&
+                return (
+                    c.category === category &&
                     c.severity > 0 &&
                     c.severity <= this._azureContentSafetyCategories[category].severity
+                );
             };
         };
 

--- a/js/packages/teams-ai/src/planners/LLMClient.ts
+++ b/js/packages/teams-ai/src/planners/LLMClient.ts
@@ -327,8 +327,10 @@ export class LLMClient<TContent = any> {
 
             // Send chunk to client
             const text = chunk.delta?.content ?? '';
+            const citations = chunk.delta?.context?.citations ?? undefined;
+
             if (text.length > 0) {
-                streamer.queueTextChunk(text);
+                streamer.queueTextChunk(text, citations);
             }
         };
 

--- a/js/packages/teams-ai/src/types/AIEntity.ts
+++ b/js/packages/teams-ai/src/types/AIEntity.ts
@@ -7,6 +7,7 @@
  */
 
 import { ClientCitation } from './ClientCitation';
+import { SensitivityUsageInfo } from './SensitivityUsageInfo';
 
 export interface AIEntity {
     /**
@@ -38,4 +39,9 @@ export interface AIEntity {
      * Optional; if citations object is included, the  sent activity will include the citations, referenced in the activity text.
      */
     citation?: ClientCitation[];
+
+    /**u
+     * Optional; if usage_info object is included, the sent activity will include the sensitivity usage information.
+     */
+    usageInfo?: SensitivityUsageInfo;
 }

--- a/js/packages/teams-ai/src/types/AIEntity.ts
+++ b/js/packages/teams-ai/src/types/AIEntity.ts
@@ -40,7 +40,7 @@ export interface AIEntity {
      */
     citation?: ClientCitation[];
 
-    /**u
+    /**
      * Optional; if usage_info object is included, the sent activity will include the sensitivity usage information.
      */
     usageInfo?: SensitivityUsageInfo;


### PR DESCRIPTION
## Linked issues

closes: #1970

## Details

This will work slightly differently than the previous non-streaming Plan flow. Citations and its respective sensitivity labels are added per each text chunk queued. However, these will only be rendered in the final message (when the full message has been received). 

Rather than exposing the SensitivityUsageInfo object as an override on the PredictedSayCommand, the label can now be directly set as usageInfo in the AIEntity object along with the AIGenerated label and the citations.

## Screenshots (configured on ListBot)
![image](https://github.com/user-attachments/assets/6fc46a1b-8b65-4267-9240-cc4bdc9f73f6)


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
