### PR TITLE
[C#] fix: Map tokens config to `max_tokens` when non-o1 model is used.

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/OpenAIModelTests.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI.Tests/AITests/Models/OpenAIModelTests.cs
@@ -34,6 +34,25 @@ namespace Microsoft.Teams.AI.Tests.AITests.Models
         }
 
         [Fact]
+        public void Test_SetMaxTokens()
+        {
+            // Arrange
+            var options = new OpenAIModelOptions("test-key", "test-model");
+            var chatCompletionOptions = new ChatCompletionOptions();
+            var model = new OpenAIModel(options);
+            var testTokens = 100;
+
+            // Act
+            model.SetMaxTokens(testTokens, chatCompletionOptions);
+
+            // Assert
+            MethodInfo info = chatCompletionOptions.GetType().GetMethod("get__deprecatedMaxTokens", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            int maxTokens = (int)info.Invoke(chatCompletionOptions, null)!;
+            Assert.Equal(testTokens, maxTokens);
+        }
+
+
+        [Fact]
         public void Test_Constructor_AzureOpenAI_InvalidAzureApiVersion()
         {
             // Arrange

--- a/dotnet/samples/04.e.twentyQuestions/teamsapp.yml
+++ b/dotnet/samples/04.e.twentyQuestions/teamsapp.yml
@@ -81,3 +81,4 @@ deploy:
     with:
       artifactFolder: bin/Release/net6.0/win-x86/publish
       resourceId: ${{BOT_AZURE_APP_SERVICE_RESOURCE_ID}}
+projectId: 6d2b99e4-1480-4218-8d1c-46630228f713

--- a/dotnet/samples/08.datasource.azureopenai/teamsapp.yml
+++ b/dotnet/samples/08.datasource.azureopenai/teamsapp.yml
@@ -95,3 +95,4 @@ deploy:
       # You can replace it with an existing Azure Resource ID or other
       # custom environment variable.
       resourceId: ${{BOT_AZURE_APP_SERVICE_RESOURCE_ID}}
+projectId: 8c3187b5-ec34-4e3b-afd8-4526ab52d06e


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details
The `OpenAI` sdk automatically maps the `max_tokens` configuration to the `MaxOutputTokenCount` property (i.e `max_completion_tokens`). However this does not work with Azure OpenAI service as it expects `max_tokens` for non-o1 models.

#### Change details
* In `OpenAIModel.cs` if the model is not in the o1 series, then use `max_tokens` field by default.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
