### PR TITLE
[C#] bump: dotnet to 1.8.0

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Microsoft.Teams.AI.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Microsoft.Teams.AI</PackageId>
     <Product>Microsoft Teams AI SDK</Product>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
@@ -52,11 +52,6 @@
 
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
-    <None Include="C:\Users\kavinsingh\source\repos\teams-ai\dotnet\packages\Microsoft.TeamsAI\Microsoft.TeamsAI\.editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EditorConfigFiles Remove="C:\Users\kavinsingh\source\repos\teams-ai\dotnet\packages\Microsoft.TeamsAI\Microsoft.TeamsAI\.editorconfig" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/samples/01.messaging.echoBot/EchoBot.csproj
+++ b/dotnet/samples/01.messaging.echoBot/EchoBot.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/02.messageExtensions.a.searchCommand/SearchCommand.csproj
+++ b/dotnet/samples/02.messageExtensions.a.searchCommand/SearchCommand.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/03.adaptiveCards.a.typeAheadBot/TypeAheadBot.csproj
+++ b/dotnet/samples/03.adaptiveCards.a.typeAheadBot/TypeAheadBot.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/04.ai.a.teamsChefBot/TeamsChefBot.csproj
+++ b/dotnet/samples/04.ai.a.teamsChefBot/TeamsChefBot.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
     <PackageReference Include="Microsoft.KernelMemory.AI.OpenAI" Version="0.73.240906.1" />
     <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.73.240906.1" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/04.ai.b.messageExtensions.gptME/GPT.csproj
+++ b/dotnet/samples/04.ai.b.messageExtensions.gptME/GPT.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->

--- a/dotnet/samples/04.ai.c.actionMapping.lightBot/LightBot.csproj
+++ b/dotnet/samples/04.ai.c.actionMapping.lightBot/LightBot.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/samples/04.ai.d.chainedActions.listBot/ListBot.csproj
+++ b/dotnet/samples/04.ai.d.chainedActions.listBot/ListBot.csproj
@@ -12,7 +12,7 @@
 	
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->

--- a/dotnet/samples/04.ai.e.chainedActions.devOpsBot/DevOpsBot.csproj
+++ b/dotnet/samples/04.ai.e.chainedActions.devOpsBot/DevOpsBot.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->

--- a/dotnet/samples/04.ai.f.vision.cardMaster/CardGazer.csproj
+++ b/dotnet/samples/04.ai.f.vision.cardMaster/CardGazer.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/samples/04.ai.g.teamsChefBot-streaming/TeamsChefBot.csproj
+++ b/dotnet/samples/04.ai.g.teamsChefBot-streaming/TeamsChefBot.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
     <PackageReference Include="Microsoft.KernelMemory.AI.OpenAI" Version="0.79.241014.2" />
     <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.79.241014.2" />
-	<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+	<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/04.e.twentyQuestions/TwentyQuestions.csproj
+++ b/dotnet/samples/04.e.twentyQuestions/TwentyQuestions.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Include prompt as content in build output -->

--- a/dotnet/samples/05.chatModeration/ChatModeration.csproj
+++ b/dotnet/samples/05.chatModeration/ChatModeration.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
     <PackageReference Include="Microsoft.KernelMemory.AI.OpenAI" Version="0.73.240906.1" />
     <PackageReference Include="Microsoft.KernelMemory.Core" Version="0.73.240906.1" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.assistants.a.mathBot/MathBot.csproj
+++ b/dotnet/samples/06.assistants.a.mathBot/MathBot.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
     <PackageReference Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.4" />
     <PackageReference Include="OpenAI" Version="2.1.0-beta.1" />
   </ItemGroup>

--- a/dotnet/samples/06.assistants.b.orderBot/OrderBot.csproj
+++ b/dotnet/samples/06.assistants.b.orderBot/OrderBot.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Azure.AI.OpenAI.Assistants" Version="1.0.0-beta.4" />
     <PackageReference Include="OpenAI" Version="2.1.0-beta.1" />
   	<PackageReference Include="Azure.AI.OpenAI" Version="2.1.0-beta.1" />
-    <PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+    <PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.oauth.bot/BotAuth.csproj
+++ b/dotnet/samples/06.auth.oauth.bot/BotAuth.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.oauth.messageExtension/MessageExtensionAuth.csproj
+++ b/dotnet/samples/06.auth.oauth.messageExtension/MessageExtensionAuth.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Graph" Version="4.54.0" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.teamsSSO.bot/BotAuth.csproj
+++ b/dotnet/samples/06.auth.teamsSSO.bot/BotAuth.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/06.auth.teamsSSO.messageExtension/MessageExtensionAuth.csproj
+++ b/dotnet/samples/06.auth.teamsSSO.messageExtension/MessageExtensionAuth.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Graph" Version="4.54.0" />
     <PackageReference Include="Microsoft.Identity.Web.TokenCache" Version="2.16.0" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/AzureAISearchBot.csproj
+++ b/dotnet/samples/08.datasource.azureaisearch/AzureAISearchBot/AzureAISearchBot.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->

--- a/dotnet/samples/08.datasource.azureopenai/AzureOpenAIBot.csproj
+++ b/dotnet/samples/08.datasource.azureopenai/AzureOpenAIBot.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.22.9" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.22.9" />
     <PackageReference Include="Microsoft.Bot.Connector" Version="4.22.9" />
-<PackageReference Include="Microsoft.Teams.AI" Version="1.7.*" />
+<PackageReference Include="Microsoft.Teams.AI" Version="1.8.*" />
   </ItemGroup>
 
   <!-- Exclude Teams Toolkit files from build output, but can still be viewed from Solution Explorer -->


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details

* Bump `Microsoft.Teams.AI` to version 1.8.0
* Update all the samples to point to this version.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
