### PR TITLE
[JS] fix: remove properties nesting for streaming entities object

### DIFF
--- a/js/packages/teams-ai/src/StreamingResponse.spec.ts
+++ b/js/packages/teams-ai/src/StreamingResponse.spec.ts
@@ -211,14 +211,14 @@ describe('StreamingResponse', function () {
                 assert.equal(activities[0].entities!.length, 1, 'length of first activity entities should be 1');
                 assert.deepEqual(
                     activities[0].entities,
-                    [{ type: 'streaminfo', properties: { ...activities[0].channelData } }],
+                    [{ type: 'streaminfo', ...activities[0].channelData }],
                     'first activity entities should match'
                 );
                 assert.equal(activities[1].channelData.streamSequence, 2, 'second activity streamSequence should be 2');
                 assert.equal(activities[1].entities!.length, 1, 'length of second activity entities should be 1');
                 assert.deepEqual(
                     activities[1].entities,
-                    [{ type: 'streaminfo', properties: { ...activities[1].channelData } }],
+                    [{ type: 'streaminfo', ...activities[1].channelData }],
                     'second activity entities should match'
                 );
                 assert.equal(activities[2].type, 'message', 'final activity type should be "message"');
@@ -232,7 +232,7 @@ describe('StreamingResponse', function () {
                 assert.deepEqual(
                     activities[2].entities,
                     [
-                        { type: 'streaminfo', properties: { streamType: 'final', streamId: response.streamId } },
+                        { type: 'streaminfo', streamType: 'final', streamId: response.streamId },
                         {
                             type: 'https://schema.org/Message',
                             '@type': 'Message',

--- a/js/packages/teams-ai/src/StreamingResponse.ts
+++ b/js/packages/teams-ai/src/StreamingResponse.ts
@@ -307,9 +307,7 @@ export class StreamingResponse {
         activity.entities = [
             {
                 type: 'streaminfo',
-                properties: {
-                    ...activity.channelData
-                }
+                ...activity.channelData
             } as Entity
         ];
 


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details

schema was updated, no longer nesting data inside `properties` param

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
