### PR TITLE
[C#] fix: update streamType enum conversion to string

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Teams.AI.Application
                 {
                     Properties = JObject.FromObject(new {
                         streamId = ((StreamingChannelData) activity.ChannelData).streamId,
-                        streamType = ((StreamingChannelData) activity.ChannelData).StreamType,
+                        streamType = ((StreamingChannelData) activity.ChannelData).StreamType.ToString(),
                         streamSequence = ((StreamingChannelData) activity.ChannelData).StreamSequence,
 
                     })


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details
for `entities` object, update `streamType` enum conversion to string instead of int

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes