### PR TITLE
[PY] fix: #1705 - Output of multiple calls to same tool are overwritten

### DIFF
--- a/python/packages/ai/teams/ai/ai.py
+++ b/python/packages/ai/teams/ai/ai.py
@@ -171,7 +171,8 @@ class AI(Generic[StateT]):
                     # Set output for action call
                     if command.action_id:
                         loop = True
-                        state.temp.action_outputs[command.action_id] = output or ""
+                        if not command.action in state.temp.action_outputs: state.temp.action_outputs[command.action] = {}
+                        state.temp.action_outputs[command.action][command.action_id] = output or ""
                     else:
                         loop = len(output) > 0
                         state.temp.action_outputs[command.action] = output


### PR DESCRIPTION
The current implementation of the planner did not account for multiple calls to the same tool since it did not keep track of the call id (`call.id`) which is different for each call, regardless of which tool. 

Therefore, the list was only being indexed by `tool_id`.

The result was that subsequent calls to the same tool _within the same run_ would overwrite the result of the previous call, and at the end of the run, results would be missing triggering an Exception.

The issue is fixed by adding a sublevel to the list of tools called as part of a run (this list is stored on assistants_planner.py `tool_map:dict`) which does keep track of the unique call_id, so that their result values are not overwritten by subsequent calls to the same tool within the same run.

## Linked issues

closes: #1705

## Details

In order to trigger this issue, submit a prompt that triggers multiple calls to the same tool on the same run (i.e. which city is warmer today, LA or Chicago?). The same tool would be called once for each city (i.e. get-weather) but the data returned would only contain results for one city. This results on an Exception being raised. Steps can be found on [#1705](https://github.com/microsoft/teams-ai/issues/1705).


#### Change details

> The fix consists on adding a second level to the dictionary of the tool calls (which contains the return values), so instead of being (pseudocode) `tools[tool_id]` it becomes `tools[tool_id][call_id]`. This way the return value of each and every call is retained.

Key change is that `state.temp.action_outputs[command.action_id]` becomes `state.temp.action_outputs[command.action][command.action_id]` on teams/ai/ai.py.


## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
