### PR TITLE
[C#] fix: Typing indicator is "stuck"

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/TypingTimer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Teams.AI.Utilities;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Builder;
+using Microsoft.Identity.Client;
 
 namespace Microsoft.Teams.AI
 {
@@ -19,6 +20,11 @@ namespace Microsoft.Teams.AI
         /// To detect redundant calls
         /// </summary>
         private bool _disposedValue = false;
+
+        /// <summary>
+        /// The send "typing" activity task
+        /// </summary>
+        private Task _lastSend = Task.CompletedTask;
 
         /// <summary>
         /// Constructs a new instance of the <see cref="TypingTimer"/> class.
@@ -100,7 +106,8 @@ namespace Microsoft.Teams.AI
 
             try
             {
-                await turnContext.SendActivityAsync(new Activity { Type = ActivityTypes.Typing });
+                _lastSend = turnContext.SendActivityAsync(new Activity { Type = ActivityTypes.Typing });
+                await _lastSend;
                 if (IsRunning())
                 {
                     _timer?.Change(_interval, Timeout.Infinite);
@@ -115,7 +122,7 @@ namespace Microsoft.Teams.AI
             }
         }
 
-        private Task<ResourceResponse[]> StopTimerWhenSendMessageActivityHandlerAsync(ITurnContext turnContext, List<Activity> activities, Func<Task<ResourceResponse[]>> next)
+        private async Task<ResourceResponse[]> StopTimerWhenSendMessageActivityHandlerAsync(ITurnContext turnContext, List<Activity> activities, Func<Task<ResourceResponse[]>> next)
         {
             if (_timer != null)
             {
@@ -123,13 +130,14 @@ namespace Microsoft.Teams.AI
                 {
                     if (activity.Type == ActivityTypes.Message)
                     {
+                        await _lastSend;
                         Dispose();
                         break;
                     }
                 }
             }
 
-            return next();
+            return await next();
         }
     }
 }


### PR DESCRIPTION
## Linked issues

closes: #minor
## Details
Fixes the issue where the typing timer is stuck after the bot sends the message.


#### Change details
- The send "typing" activity method is awaited to complete before the send "message" activity is processed.

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes