### PR TITLE
[JS] fix: Assistants Planner API version

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.23.1",
-        "openai": "4.68.2"
+        "openai": "4.77.3"
     },
     "devDependencies": {
         "@azure/logger": "^1.1.4",

--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -26,7 +26,7 @@
     "types": "./lib/index.d.ts",
     "peerDependencies": {
         "botbuilder": "^4.23.1",
-        "openai": "^4.68.2"
+        "openai": "4.77.3"
     },
     "dependencies": {
         "@azure/msal-node": "^2.16.1",

--- a/js/packages/teams-ai/src/planners/AssistantsPlanner.spec.ts
+++ b/js/packages/teams-ai/src/planners/AssistantsPlanner.spec.ts
@@ -54,7 +54,7 @@ describe('AssistantsPlanner', () => {
         const options: AssistantsPlannerOptions = {
             apiKey: 'test-key',
             assistant_id: 'test-assistant-id',
-            api_version: '2024-02-15'
+            apiVersion: '2024-02-15'
         };
 
         planner = new AssistantsPlanner<TurnState>(options);

--- a/js/packages/teams-ai/src/planners/AssistantsPlanner.ts
+++ b/js/packages/teams-ai/src/planners/AssistantsPlanner.ts
@@ -72,7 +72,7 @@ export interface AssistantsPlannerOptions {
     /**
      * Optional. Version of the API being called. Default is '2024-02-15-preview'.
      */
-    api_version?: string;
+    apiVersion?: string;
 }
 
 /**
@@ -97,7 +97,7 @@ export class AssistantsPlanner<TState extends TurnState = TurnState> implements 
         this._options = {
             polling_interval: DEFAULT_POLLING_INTERVAL,
             assistants_state_variable: DEFAULT_ASSISTANTS_STATE_VARIABLE,
-            api_version: '2024-02-15-preview',
+            apiVersion: '2024-02-15-preview',
             ...options
         };
 

--- a/js/samples/01.getting-started/a.echoBot/package.json
+++ b/js/samples/01.getting-started/a.echoBot/package.json
@@ -25,7 +25,7 @@
         "@microsoft/teams-ai": "~1.7.1",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
+++ b/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
@@ -23,7 +23,7 @@
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
@@ -26,7 +26,7 @@
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/a.twentyQuestions/package.json
+++ b/js/samples/03.ai-concepts/a.twentyQuestions/package.json
@@ -24,7 +24,7 @@
         "@microsoft/teams-ai": "~1.7.1",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
+++ b/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
@@ -22,7 +22,7 @@
         "botbuilder": "^4.23.1",
         "@microsoft/teams-ai": "~1.7.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
@@ -24,7 +24,7 @@
         "@microsoft/teams-ai": "~1.7.1",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
@@ -24,7 +24,7 @@
         "@microsoft/teams-ai": "~1.7.1",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
+++ b/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "botbuilder": "^4.23.1",
         "@microsoft/teams-ai": "~1.7.1",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "dotenv": "^16.4.1",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/03.ai-concepts/f.chatModeration/package.json
+++ b/js/samples/03.ai-concepts/f.chatModeration/package.json
@@ -24,7 +24,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/a.teamsChefBot/package.json
+++ b/js/samples/04.ai-apps/a.teamsChefBot/package.json
@@ -26,7 +26,7 @@
         "@microsoft/teams-js": "^2.31.0",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/04.ai-apps/b.devOpsBot/package.json
+++ b/js/samples/04.ai-apps/b.devOpsBot/package.json
@@ -24,7 +24,7 @@
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
-        "openai": "4.68.2"
+        "openai": "4.77.3"
     },
     "devDependencies": {
         "@types/jsonwebtoken": "^9.0.6",

--- a/js/samples/04.ai-apps/c.vision-cardGazer/package.json
+++ b/js/samples/04.ai-apps/c.vision-cardGazer/package.json
@@ -23,7 +23,7 @@
         "@microsoft/teams-ai": "~1.7.1",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/d.assistants-mathBot/package.json
+++ b/js/samples/04.ai-apps/d.assistants-mathBot/package.json
@@ -24,7 +24,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/d.assistants-mathBot/src/bot.ts
+++ b/js/samples/04.ai-apps/d.assistants-mathBot/src/bot.ts
@@ -28,7 +28,8 @@ if (!process.env.ASSISTANT_ID) {
                 tools: [{ type: 'code_interpreter' }],
                 model: 'gpt-4'
             },
-            endpoint
+            endpoint ?? undefined,
+            endpoint ? { apiVersion: process.env.OPENAI_API_VERSION } : undefined
         );
 
         console.log(`Created a new assistant with an ID of: ${assistant.id}`);
@@ -41,7 +42,7 @@ const planner = new AssistantsPlanner({
     apiKey: apiKey,
     endpoint: endpoint,
     assistant_id: process.env.ASSISTANT_ID!,
-    api_version: '2024-02-15-preview'
+    apiVersion: process.env.OPENAI_API_VERSION
 });
 
 // Define storage and application
@@ -59,9 +60,4 @@ export const run = (context: TurnContext) => app.run(context);
 app.message('/reset', async (context, state) => {
     state.deleteConversationState();
     await context.sendActivity(`Ok lets start this over.`);
-});
-
-app.ai.action(AI.HttpErrorActionName, async (context, state, data) => {
-    await context.sendActivity('An AI request failed. Please try again later.');
-    return AI.StopCommandName;
 });

--- a/js/samples/04.ai-apps/e.assistants-orderBot/package.json
+++ b/js/samples/04.ai-apps/e.assistants-orderBot/package.json
@@ -26,7 +26,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/e.assistants-orderBot/src/bot.ts
+++ b/js/samples/04.ai-apps/e.assistants-orderBot/src/bot.ts
@@ -62,7 +62,7 @@ const planner = new AssistantsPlanner({
     apiKey: apiKey,
     endpoint: endpoint,
     assistant_id: process.env.ASSISTANT_ID ?? assistantId,
-    api_version: '2024-02-15-preview'
+    apiVersion: process.env.OPENAI_API_VERSION
 });
 
 // Define storage and application
@@ -86,9 +86,4 @@ app.ai.action<Order>('place_order', async (context: TurnContext, state: TurnStat
     const card = generateCardForOrder(order);
     await context.sendActivity(MessageFactory.attachment(CardFactory.adaptiveCard(card)));
     return `order placed`;
-});
-
-app.ai.action(AI.HttpErrorActionName, async (context: TurnContext, state: TurnState, _data: unknown) => {
-    await context.sendActivity('An AI request failed. Please try again later.');
-    return AI.StopCommandName;
 });

--- a/js/samples/04.ai-apps/f.whoBot/package.json
+++ b/js/samples/04.ai-apps/f.whoBot/package.json
@@ -23,7 +23,7 @@
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/g.datasource-azureAISearch/package.json
+++ b/js/samples/04.ai-apps/g.datasource-azureAISearch/package.json
@@ -32,7 +32,7 @@
         "botbuilder": "^4.23.1",
         "debug": "^4.3.7",
         "dotenv": "^16.4.1",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/04.ai-apps/h.datasource-azureOpenAI/package.json
+++ b/js/samples/04.ai-apps/h.datasource-azureOpenAI/package.json
@@ -30,7 +30,7 @@
         "@microsoft/teams-ai": "~1.7.1",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.1",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
+++ b/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
@@ -23,7 +23,7 @@
         "@microsoft/teams-ai": "~1.7.1",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "isomorphic-fetch": "^3.0.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/05.authentication/b.oauth-bot/package.json
+++ b/js/samples/05.authentication/b.oauth-bot/package.json
@@ -23,7 +23,7 @@
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/05.authentication/c.oauth-messageExtension/package.json
+++ b/js/samples/05.authentication/c.oauth-messageExtension/package.json
@@ -24,7 +24,7 @@
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/05.authentication/d.teamsSSO-bot/package.json
+++ b/js/samples/05.authentication/d.teamsSSO-bot/package.json
@@ -23,7 +23,7 @@
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "shx": "^0.3.4"

--- a/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
+++ b/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
@@ -25,7 +25,7 @@
         "botbuilder-azure-blobs": "^4.23.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",
-        "openai": "4.68.2",
+        "openai": "4.77.3",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "shx": "^0.3.4"

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -6818,10 +6818,10 @@ openai@4.41.1:
     node-fetch "^2.6.7"
     web-streams-polyfill "^3.2.1"
 
-openai@4.68.2:
-  version "4.68.2"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-4.68.2.tgz#2443d23127c61dcc9a9356ff8ea5b21acf0ba60d"
-  integrity sha512-Ys3Jl9vkBUFtrFj4pgrF7rMte4JNekZoMgI6dWkkpOIwNUKGkc4I8jTqv86LB+TcoqkTPzV6DS269dPR9ILWsQ==
+openai@4.77.3:
+  version "4.77.3"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.77.3.tgz#10f6906f2f737a98b656b745a6b710e595ba2e4d"
+  integrity sha512-wLDy4+KWHz31HRFMW2+9KQuVuT2QWhs0z94w1Gm1h2Ut9vIHr9/rHZggbykZEfyiaJRVgw8ZS9K6AylDWzvPYw==
   dependencies:
     "@types/node" "^18.11.18"
     "@types/node-fetch" "^2.6.4"


### PR DESCRIPTION
## Linked issues

closes: #2233 

## Details

- Fix error where api version was set to api_version instead of apiVersion 
- Update openai package version in all JS samples

## Attestation Checklist

- [x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

