### PR TITLE
[JS] chore: release JS 1.7.2

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.23.1",
-        "openai": "4.77.3"
+        "openai": "4.77.4"
     },
     "devDependencies": {
         "@azure/logger": "^1.1.4",
@@ -47,7 +47,6 @@
         "eslint-plugin-prettier": "^5.2.1",
         "exorcist": "^2.0.0",
         "express": "^4.21.1",
-        "mocha": "^10.7.3",
         "mocha-junit-reporter": "^2.0.0",
         "mocha": "^10.8.2",
         "ms-rest-azure": "^3.0.2",

--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -2,7 +2,7 @@
     "name": "@microsoft/teams-ai",
     "author": "Microsoft Corp.",
     "description": "SDK focused on building AI based applications for Microsoft Teams.",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "license": "MIT",
     "keywords": [
         "botbuilder",
@@ -26,7 +26,7 @@
     "types": "./lib/index.d.ts",
     "peerDependencies": {
         "botbuilder": "^4.23.1",
-        "openai": "4.77.3"
+        "openai": "4.77.4"
     },
     "dependencies": {
         "@azure/msal-node": "^2.16.1",

--- a/js/samples/01.getting-started/a.echoBot/package.json
+++ b/js/samples/01.getting-started/a.echoBot/package.json
@@ -22,10 +22,10 @@
         "url": "https://github.com/microsoft/teams-ai/"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
+++ b/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
@@ -19,11 +19,11 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
@@ -22,11 +22,11 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/a.twentyQuestions/package.json
+++ b/js/samples/03.ai-concepts/a.twentyQuestions/package.json
@@ -21,10 +21,10 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
+++ b/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
@@ -20,9 +20,9 @@
     },
     "dependencies": {
         "botbuilder": "^4.23.1",
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
@@ -21,10 +21,10 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
@@ -21,10 +21,10 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
+++ b/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
@@ -23,8 +23,8 @@
     },
     "dependencies": {
         "botbuilder": "^4.23.1",
-        "@microsoft/teams-ai": "~1.7.1",
-        "openai": "4.77.3",
+        "@microsoft/teams-ai": "~1.7.2",
+        "openai": "4.77.4",
         "dotenv": "^16.4.1",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/03.ai-concepts/f.chatModeration/package.json
+++ b/js/samples/03.ai-concepts/f.chatModeration/package.json
@@ -19,12 +19,12 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/a.teamsChefBot/package.json
+++ b/js/samples/04.ai-apps/a.teamsChefBot/package.json
@@ -22,11 +22,11 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "@microsoft/teams-js": "^2.32.0",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/04.ai-apps/b.devOpsBot/package.json
+++ b/js/samples/04.ai-apps/b.devOpsBot/package.json
@@ -20,11 +20,11 @@
     },
     "dependencies": {
         "botbuilder": "^4.23.1",
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "dotenv": "^16.4.5",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
-        "openai": "4.77.3"
+        "openai": "4.77.4"
     },
     "devDependencies": {
         "@types/jsonwebtoken": "^9.0.6",

--- a/js/samples/04.ai-apps/c.vision-cardGazer/package.json
+++ b/js/samples/04.ai-apps/c.vision-cardGazer/package.json
@@ -20,10 +20,10 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/d.assistants-mathBot/package.json
+++ b/js/samples/04.ai-apps/d.assistants-mathBot/package.json
@@ -19,12 +19,12 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/e.assistants-orderBot/package.json
+++ b/js/samples/04.ai-apps/e.assistants-orderBot/package.json
@@ -21,12 +21,12 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "jsonwebtoken": "^9.0.2",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/f.whoBot/package.json
+++ b/js/samples/04.ai-apps/f.whoBot/package.json
@@ -19,11 +19,11 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/04.ai-apps/g.datasource-azureAISearch/package.json
+++ b/js/samples/04.ai-apps/g.datasource-azureAISearch/package.json
@@ -28,11 +28,11 @@
     },
     "dependencies": {
         "@azure/search-documents": "12.1.0",
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "debug": "^4.3.7",
         "dotenv": "^16.4.1",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/04.ai-apps/h.datasource-azureOpenAI/package.json
+++ b/js/samples/04.ai-apps/h.datasource-azureOpenAI/package.json
@@ -27,10 +27,10 @@
     "dependencies": {
         "@azure/identity": "^4.5.0",
         "@azure/search-documents": "12.1.0",
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.1",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "vectra": "^0.9.0"

--- a/js/samples/04.ai-apps/i.teamsChefBot-streaming/package.json
+++ b/js/samples/04.ai-apps/i.teamsChefBot-streaming/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "@microsoft/teams-js": "^2.32.0",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",

--- a/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
+++ b/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
@@ -20,10 +20,10 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "isomorphic-fetch": "^3.0.0",
         "replace": "~1.2.0",
         "restify": "~11.1.0"

--- a/js/samples/05.authentication/b.oauth-bot/package.json
+++ b/js/samples/05.authentication/b.oauth-bot/package.json
@@ -19,11 +19,11 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/05.authentication/c.oauth-messageExtension/package.json
+++ b/js/samples/05.authentication/c.oauth-messageExtension/package.json
@@ -20,11 +20,11 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0"
     },

--- a/js/samples/05.authentication/d.teamsSSO-bot/package.json
+++ b/js/samples/05.authentication/d.teamsSSO-bot/package.json
@@ -19,11 +19,11 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "shx": "^0.3.4"

--- a/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
+++ b/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
@@ -20,12 +20,12 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.7.1",
+        "@microsoft/teams-ai": "~1.7.2",
         "botbuilder": "^4.23.1",
         "botbuilder-azure-blobs": "^4.23.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",
-        "openai": "4.77.3",
+        "openai": "4.77.4",
         "replace": "~1.2.0",
         "restify": "~11.1.0",
         "shx": "^0.3.4"

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -6818,10 +6818,10 @@ openai@4.41.1:
     node-fetch "^2.6.7"
     web-streams-polyfill "^3.2.1"
 
-openai@4.77.3:
-  version "4.77.3"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-4.77.3.tgz#10f6906f2f737a98b656b745a6b710e595ba2e4d"
-  integrity sha512-wLDy4+KWHz31HRFMW2+9KQuVuT2QWhs0z94w1Gm1h2Ut9vIHr9/rHZggbykZEfyiaJRVgw8ZS9K6AylDWzvPYw==
+openai@4.77.4:
+  version "4.77.4"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.77.4.tgz#1093d165efb3e13e763faf42fa62e34313e293e9"
+  integrity sha512-rShjKsZ/HXm1cSxXt6iFeZxiCohrVShawt0aRRQmbb+z/EXcH4OouyQZP1ShyZMb63LJajpl8aGw3DzEi8Wh9Q==
   dependencies:
     "@types/node" "^18.11.18"
     "@types/node-fetch" "^2.6.4"


### PR DESCRIPTION
#minor

## Changes

* [JS] chore: Release 1.7.0 by @corinagum in https://github.com/microsoft/teams-ai/pull/2222
* [repo] bump: (deps): Bump github/codeql-action from 3.27.5 to 3.27.6 in the production group by @dependabot in https://github.com/microsoft/teams-ai/pull/2223
* [repo] docs: Update wording in the sample readmes for clarity by @corinagum in https://github.com/microsoft/teams-ai/pull/2225
* [repo] fix: C# Citations' `encodingFormat` to not be hardcoded. Fix JS AssistantsPlanner options to set api version by @corinagum in https://github.com/microsoft/teams-ai/pull/2235
* [repo] bump: (deps): Bump github/codeql-action from 3.27.6 to 3.27.9 in the production group by @dependabot in https://github.com/microsoft/teams-ai/pull/2239
* [JS] bump: (deps-dev): Bump @microsoft/api-extractor from 7.48.0 to 7.48.1 in /js in the development group by @dependabot in https://github.com/microsoft/teams-ai/pull/2238
* [JS] Bump Teams AI for patch release 1.7.1 by @corinagum in https://github.com/microsoft/teams-ai/pull/2236
* [JS] fix: streaming - citations, feedback loop, and duplicate typing activity by @lilyydu in https://github.com/microsoft/teams-ai/pull/2185
* [JS] fix: Assistants Planner API version by @corinagum in https://github.com/microsoft/teams-ai/pull/2256
* [JS] bump: (deps-dev): Bump @types/lodash from 4.17.13 to 4.17.14 in /js in the development group by @dependabot in https://github.com/microsoft/teams-ai/pull/2255
* [JS] bump: (deps): Bump the production group across 1 directory with 2 updates by @dependabot in https://github.com/microsoft/teams-ai/pull/2254
* [JS] bump: Updating Feedback buttons to the sample by @Jegadeesh-MSFT in https://github.com/microsoft/teams-ai/pull/2245
