### PR TITLE
[JS] chore: Bump JS teams-ai package

### DIFF
--- a/js/packages/teams-ai/package.json
+++ b/js/packages/teams-ai/package.json
@@ -2,7 +2,7 @@
     "name": "@microsoft/teams-ai",
     "author": "Microsoft Corp.",
     "description": "SDK focused on building AI based applications for Microsoft Teams.",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "license": "MIT",
     "keywords": [
         "botbuilder",

--- a/js/samples/01.getting-started/a.echoBot/package.json
+++ b/js/samples/01.getting-started/a.echoBot/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/microsoft/teams-ai/"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "openai": "4.77.4",

--- a/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
+++ b/js/samples/02.teams-features/a.messageExtensions.searchCommand/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",

--- a/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
+++ b/js/samples/02.teams-features/b.adaptiveCards.typeAheadBot/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",

--- a/js/samples/03.ai-concepts/a.twentyQuestions/package.json
+++ b/js/samples/03.ai-concepts/a.twentyQuestions/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "openai": "4.77.4",

--- a/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
+++ b/js/samples/03.ai-concepts/b.AI-messageExtensions/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.23.1",
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "dotenv": "^16.4.5",
         "openai": "4.77.4",
         "replace": "~1.2.0",

--- a/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
+++ b/js/samples/03.ai-concepts/c.actionMapping-lightBot/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "openai": "4.77.4",

--- a/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
+++ b/js/samples/03.ai-concepts/d.chainedActions-listBot/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "openai": "4.77.4",

--- a/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
+++ b/js/samples/03.ai-concepts/e.customModel-LLAMA/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "botbuilder": "^4.23.1",
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "openai": "4.77.4",
         "dotenv": "^16.4.1",
         "replace": "~1.2.0",

--- a/js/samples/03.ai-concepts/f.chatModeration/package.json
+++ b/js/samples/03.ai-concepts/f.chatModeration/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "axios": "^1.7.5",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",

--- a/js/samples/04.ai-apps/a.teamsChefBot/package.json
+++ b/js/samples/04.ai-apps/a.teamsChefBot/package.json
@@ -22,7 +22,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "@microsoft/teams-js": "^2.33.0",
         "botbuilder": "^4.23.1",
         "openai": "4.77.4",

--- a/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
+++ b/js/samples/05.authentication/a.oauth-adaptiveCard/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "openai": "4.77.4",

--- a/js/samples/05.authentication/b.oauth-bot/package.json
+++ b/js/samples/05.authentication/b.oauth-bot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",

--- a/js/samples/05.authentication/c.oauth-messageExtension/package.json
+++ b/js/samples/05.authentication/c.oauth-messageExtension/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "dotenv": "^16.4.5",
         "isomorphic-fetch": "^3.0.0",

--- a/js/samples/05.authentication/d.teamsSSO-bot/package.json
+++ b/js/samples/05.authentication/d.teamsSSO-bot/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/microsoft/teams-ai"
     },
     "dependencies": {
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "botbuilder-dialogs": "^4.23.1",
         "dotenv": "^16.4.5",

--- a/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
+++ b/js/samples/05.authentication/e.teamsSSO-messageExtension/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/microsoft-graph-client": "^3.0.7",
-        "@microsoft/teams-ai": "~1.7.2",
+        "@microsoft/teams-ai": "~1.7.3",
         "botbuilder": "^4.23.1",
         "botbuilder-azure-blobs": "^4.23.1",
         "dotenv": "^16.4.5",


### PR DESCRIPTION
## Linked issues

closes: #minor

## Details

Release for JS 1.7.3

## What's Changed
* [JS] fix: local debug environment variables location in teams chef bot sample by @tecton in https://github.com/microsoft/teams-ai/pull/2240
* [JS] bump: (deps): Bump undici from 6.21.0 to 6.21.1 in /js by @dependabot in https://github.com/microsoft/teams-ai/pull/2274
* [JS] bump: (deps): Bump the production group across 1 directory with 3 updates by @dependabot in https://github.com/microsoft/teams-ai/pull/2270
* [JS] bump: (deps-dev): Bump the development group across 1 directory with 2 updates by @dependabot in https://github.com/microsoft/teams-ai/pull/2271
* [repo] bump: (deps): Bump the production group across 1 directory with 5 updates by @dependabot in https://github.com/microsoft/teams-ai/pull/2272
* [repo] bump: (deps): Bump the production group with 2 updates by @dependabot in https://github.com/microsoft/teams-ai/pull/2281
* [JS] fix: Fixed stuck typing indicator issue by @Stevenic in https://github.com/microsoft/teams-ai/pull/2286
* Upgrade OYD endpoint api-version for supporting managed identity in embedding cases by @farhad-shakerin in https://github.com/microsoft/teams-ai/pull/2287
* [repo] bump: (deps): Bump the production group with 3 updates by @dependabot in https://github.com/microsoft/teams-ai/pull/2289
* [JS] bump: (deps-dev): Bump the development group in /js with 2 updates by @dependabot in https://github.com/microsoft/teams-ai/pull/2288