### PR TITLE
[JS] Bug: Fixed prefix check for `o1` models and added `o3` support

### DIFF
--- a/js/packages/teams-ai/src/models/OpenAIModel.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.ts
@@ -323,8 +323,8 @@ export class OpenAIModel implements PromptCompletionModel {
 
         // Check for use of system messages
         // - 'user' messages tend to be followed better by the model then 'system' messages.
-        const isO1Model = model.startsWith('o1-');
-        const useSystemMessages = !isO1Model && this.options.useSystemMessages;
+        const isThinkingModel = model.startsWith('o1') || model.startsWith('o3');
+        const useSystemMessages = !isThinkingModel && this.options.useSystemMessages;
         if (!useSystemMessages && result.output.length > 0 && result.output[0].role == 'system') {
             result.output[0].role = 'user';
         }
@@ -344,7 +344,7 @@ export class OpenAIModel implements PromptCompletionModel {
         try {
             // Get the chat completion parameters
             const params = this.getChatCompletionParams(model, updatedMessages, template);
-            if (isO1Model) {
+            if (isThinkingModel) {
                 if (params.max_tokens) {
                     params.max_completion_tokens = params.max_tokens;
                     delete params.max_tokens;


### PR DESCRIPTION
## Linked issues

fixes: #2298 

## Details

We were identifying `o1` thinking models by looking for models starting with `o1-`. This is an issue on Azure OpenAI because the default deployment name is just `o1` without any dash. I removed the dash and also added support for `o3` based thinking models.  Now we special case all thinking models with an `isThinkingModel` check.

## Attestation Checklist

- [ x] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
