### PR TITLE
[C#] fix: Fixed prefix check for o1 models and added o3 support

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/AI/Models/OpenAIModel.cs
@@ -197,8 +197,8 @@ namespace Microsoft.Teams.AI.AI.Models
 
             // Get the model to use.
             string model = promptTemplate.Configuration.Completion.Model ?? _deploymentName;
-            bool isO1Model = model.StartsWith("o1-");
-            bool useSystemMessages = !isO1Model && _options.UseSystemMessages.GetValueOrDefault(false);
+            bool isThinkingModel = model.StartsWith("o1") || model.StartsWith("o3");
+            bool useSystemMessages = !isThinkingModel && _options.UseSystemMessages.GetValueOrDefault(false);
             if (!useSystemMessages && prompt.Output.Count > 0 && prompt.Output[0].Role == ChatRole.System)
             {
                 prompt.Output[0].Role = ChatRole.User;
@@ -221,7 +221,7 @@ namespace Microsoft.Teams.AI.AI.Models
                 FrequencyPenalty = (float)completion.FrequencyPenalty,
             };
 
-            if (isO1Model)
+            if (isThinkingModel)
             {
                 chatCompletionOptions.MaxOutputTokenCount = completion.MaxTokens;
                 chatCompletionOptions.Temperature = 1;


### PR DESCRIPTION
## Linked issues

closes: #2298 

## Details

Fixed hyphenation fixation, added o3 support.
See Steve's PR on this issue.
