### PR TITLE
[PY] fix: Reraise `AttributeError` from `__getattr__` if attribute is not found

### DIFF
--- a/python/packages/ai/teams/state/state.py
+++ b/python/packages/ai/teams/state/state.py
@@ -146,8 +146,8 @@ class State(dict, ABC):
     def __getattr__(self, key: str) -> Any:
         try:
             return self[key]
-        except KeyError:
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
+        except KeyError as exc:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'") from exc
 
     def __getattribute__(self, key: str) -> Any:
         if key in self:

--- a/python/packages/ai/teams/state/state.py
+++ b/python/packages/ai/teams/state/state.py
@@ -144,7 +144,10 @@ class State(dict, ABC):
         self[key] = value
 
     def __getattr__(self, key: str) -> Any:
-        return self[key]
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'")
 
     def __getattribute__(self, key: str) -> Any:
         if key in self:

--- a/python/packages/ai/teams/state/state.py
+++ b/python/packages/ai/teams/state/state.py
@@ -147,7 +147,9 @@ class State(dict, ABC):
         try:
             return self[key]
         except KeyError as exc:
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{key}'") from exc
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{key}'"
+            ) from exc
 
     def __getattribute__(self, key: str) -> Any:
         if key in self:


### PR DESCRIPTION
## Linked issues

closes: #2350

## Details

__getattr__ is only called if `__getattribute__` is not able to find the value by normal means. Python then calls __getattr__ to see if the class wants to compute the value for key. If it doesn't, it expects it to throw the attribute error (not a key error).

Currently, it's throwing a keyerror when this is the case.

See python docs here - https://docs.python.org/3/reference/datamodel.html#object.__getattr__

#### Change details

I essentially do what it's doing, but instead of a `KeyError` i'm reraising an `AttributeError` as python docs suggest.

**code snippets**:

**screenshots**:

## Attestation Checklist

- [ ] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
