### PR TITLE
[docs] use @preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For a detailed explanation of the motivations and architectural decisions behind
 The Teams CLI makes it easy to bootstrap your first agent. First, install the CLI via NPM:
 
 ```sh
-npm install -g @microsoft/teams.cli@latest
+npm install -g @microsoft/teams.cli@preview
 ```
 
 Next, use the CLI to create your agent:

--- a/book/src/developer-tools/cli/README.md
+++ b/book/src/developer-tools/cli/README.md
@@ -17,13 +17,13 @@ Install the Teams CLI globally using npm:
 
 <!-- langtabs-start -->
 ```sh
-npm install -g @microsoft/teams.cli@latest
+npm install -g @microsoft/teams.cli@preview
 ```
 <!-- langtabs-end -->
 
 > [!TIP]
 > If you prefer not to install globally, all commands below can replace `teams` with npx:
-> > ```npx @microsoft/teams.cli@latest <arguments>```
+> > ```npx @microsoft/teams.cli@preview <arguments>```
 
 ## Create an agent with one command line
 

--- a/book/src/developer-tools/devtools/chat.md
+++ b/book/src/developer-tools/devtools/chat.md
@@ -17,7 +17,7 @@ Add the dev package to your Teams app.
 
 <!-- langtabs-start -->
 ```bash
-$: npm install @microsoft/teams.dev
+$: npm install @microsoft/teams.dev@preview
 ```
 <!-- langtabs-end -->
 

--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -16,7 +16,7 @@ Use your terminal to install the Teams CLI globally using npm:
 
 <!-- langtabs-start -->
 ```sh
-npm install -g @microsoft/teams.cli@latest
+npm install -g @microsoft/teams.cli@preview
 ```
 <!-- langtabs-end -->
 

--- a/book/src/welcome/README.md
+++ b/book/src/welcome/README.md
@@ -8,7 +8,7 @@ The Teams CLI makes it easy to bootstrap your first agent. First, install the CL
 
 <!-- langtabs-start -->
 ```sh
-npm install -g @microsoft/teams.cli@latest
+npm install -g @microsoft/teams.cli@preview
 ```
 <!-- langtabs-end -->
 


### PR DESCRIPTION
#minor

Update CLI commands in documentation to use the preview version of the Teams CLI, not latest.