### PR TITLE
Fix index.html

### DIFF
--- a/book/src/README.md
+++ b/book/src/README.md
@@ -20,11 +20,11 @@ teams new quote-agent --template echo
 ```
 <!-- langtabs-end -->
 
-For more information, follow our [quick start guide](../getting-started/quickstart.md).
+For more information, follow our [quick start guide](./getting-started/quickstart.md).
 
 ## Overview
 
-Microsoft Teams has a robust developer ecosystem with a broad suite of capabilities, now unified via Teams AI v2. Whether you are building [AI-powered agents](../in-depth-guides/ai/README.md), [message extensions](../in-depth-guides/message-extensions/README.md), embedded web applications, or Graph, Teams AI v2 has you covered.
+Microsoft Teams has a robust developer ecosystem with a broad suite of capabilities, now unified via Teams AI v2. Whether you are building [AI-powered agents](./in-depth-guides/ai/README.md), [message extensions](./in-depth-guides/message-extensions/README.md), embedded web applications, or Graph, Teams AI v2 has you covered.
 
 Here is a simple example, which responds to incoming messages with information retrieved from Graph.
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-- [👋 Welcome](./welcome/README.md)
+- [👋 Welcome](./README.md)
   - [Why an SDK?](./welcome/need-for-sdk.md)
   - [Packages](./welcome/packages.md)
 - [🚀 Getting Started](./getting-started/README.md)


### PR DESCRIPTION
if index.html isn't provided (aka a root-readme), then mdbook uses the first readme in SUMMARY.md. Thanks breaks relative links if that readme isn't at the root.

What this means is realtive links like "../foo" will break from https://microsoft.github.io/teams-ai/, but will work fine with https://microsoft.github.io/teams-ai/welcome/index.html (which is the first readme in SUMMARY.md)