### PR TITLE
[C#] fix: Improve citation logic and tests for unique citations 

### DIFF
--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Application/StreamingResponse.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Teams.AI.Application
 
                     this.Citations.Add(new ClientCitation()
                     {
-                        Position = currPos,
+                        Position = currPos + 1,
                         Appearance = new ClientCitationAppearance()
                         {
                             Name = citation.Title,

--- a/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Utilities/CitationUtils.cs
+++ b/dotnet/packages/Microsoft.TeamsAI/Microsoft.TeamsAI/Utilities/CitationUtils.cs
@@ -49,23 +49,23 @@ namespace Microsoft.Teams.AI.Utilities
             {
                 return null;
             }
-            else
+
+            // Remove duplicate matches
+            HashSet<string> filteredMatches = new();
+            foreach (Match match in matches)
             {
-                List<ClientCitation> usedCitations = new();
-                foreach (Match match in matches)
-                {
-                    citations.Find((citation) =>
-                    {
-                        if ($"[{citation.Position}]" == match.Value)
-                        {
-                            usedCitations.Add(citation);
-                            return true;
-                        }
-                        return false;
-                    });
-                }
-                return usedCitations;
+                filteredMatches.Add(match.Value);
             }
+
+            List<ClientCitation> usedCitations = new();
+            foreach (string match in filteredMatches)
+            {
+                var citation = citations.Find(c => $"[{c.Position}]" == match);
+                if (citation != null)
+                    usedCitations.Add(citation);
+            }
+
+            return usedCitations;
         }
     }
 }


### PR DESCRIPTION
closes: #2461

## Details
While sending text chunks with reference to same citations, duplicate citations are added to Entities which leads to streaming errors.

For example, if citation [1] was referenced multiple times in streamed text

streamer.QueueTextChunk("This is a sample text referencing first document [1] and second document [2], However the more relevant document appears to be first document [1].");

Total 3 citations are added into the final sent activity. This leads to upstream errors and unexpected results on client.

#### Change details

- Adjusted citation position handling in `StreamingResponse.cs` to ensure correct alignment with text.
- Enhanced duplicate match processing in `CitationUtils.cs` using a `HashSet` to filter duplicates before citation retrieval.
- Introduced `Test_SendTextChunk_SendsFinalMessageWithUniqueCitations` in `StreamingResponseTests.cs` to validate unique citations in streamed messages.

✅ My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

