### PR TITLE
Add example for non-exposed graph endpoints (stub)

### DIFF
--- a/teams.md/docs/typescript/essentials/graph.md
+++ b/teams.md/docs/typescript/essentials/graph.md
@@ -81,3 +81,7 @@ The following clients are currently exposed:
 | teamsTemplates | [/teamsTemplates](https://learn.microsoft.com/en-us/microsoftteams/get-started-with-teams-templates) | A Team Template resource |
 | teamwork | [/teamwork](https://learn.microsoft.com/en-us/graph/api/resources/teamwork?view=graph-rest-1.0) | A range of Microsoft Teams functionalities |
 | users | [/users](https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0) | A user resource |
+
+## Direct access to currently non-exposed graph endpoints:
+
+Add an example to e.g. access to Calendar or events.


### PR DESCRIPTION
How is it possible to access graph API endpoints currently not exposed, e.g. Calendar or events?

## Linked issues

closes: # (issue number)

## Details

Provide a list of your changes here. If you are fixing a bug, please provide steps to reproduce the bug.

#### Change details

> Describe your changes, with screenshots and code snippets as appropriate

**code snippets**:

**screenshots**:

## Attestation Checklist

- [ ] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes

### Additional information

> Feel free to add other relevant information below
