### PR TITLE
Improve graph client documentation

### DIFF
--- a/teams.md/docs/typescript/essentials/graph.md
+++ b/teams.md/docs/typescript/essentials/graph.md
@@ -65,19 +65,5 @@ Here, the client takes care of using the correct token, provides helpful hints v
 
 ## Currently exposed Graph clients
 
-The following clients are currently exposed:
+The Microsoft Graph API surface is vast, and this Graph API Client supports a subset of the full functionality to cover the most common scenarios. Details on precisely which endpoints are supported is available in the [Graph API Client In-Depth Guide](../in-depth-guides/graph/).
 
-| Client Name | Graph endpoint | Description |
-|-------------|----------------|-------------|
-| appCatalogs | [/appCatalogs](https://learn.microsoft.com/en-us/graph/api/appcatalogs-list-teamsapps?view=graph-rest-1.0) | Apps from Teams App Catalog |
-| appRoleAssignments | [/appRoleAssignments](https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list-approleassignments?view=graph-rest-1.0) | List app role assignments |
-| applicationTemplates | [/applicationTemplates](https://learn.microsoft.com/en-us/graph/api/resources/applicationtemplate?view=graph-rest-1.0) | Application in the Microsoft Entra App Gallery |
-| applications | [/applications](https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0) | Application Resources |
-| chats | [/chats](https://learn.microsoft.com/en-us/graph/api/chat-list?view=graph-rest-1.0&tabs=http) | Chat resources between users |
-| communications | [/communications](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0) | Calls and Online meetings |
-| employeeExperience | [/employeeExperience](https://learn.microsoft.com/en-us/graph/api/resources/engagement-api-overview?view=graph-rest-1.0) |  Employee Experience and Engagement |
-| me | [/me](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http) | Same as `/users` but scoped to one user (who is making the request) |
-| teams | [/teams](https://learn.microsoft.com/en-us/graph/api/resources/team?view=graph-rest-1.0) | A Team resource  |
-| teamsTemplates | [/teamsTemplates](https://learn.microsoft.com/en-us/microsoftteams/get-started-with-teams-templates) | A Team Template resource |
-| teamwork | [/teamwork](https://learn.microsoft.com/en-us/graph/api/resources/teamwork?view=graph-rest-1.0) | A range of Microsoft Teams functionalities |
-| users | [/users](https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0) | A user resource |

--- a/teams.md/docs/typescript/in-depth-guides/graph/README.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/README.md
@@ -1,0 +1,22 @@
+# Graph API Client
+
+The Graph Client is a wrapper around the Microsoft Graph API. It provides a fluent API for accessing the Graph API and is scoped to a specific user or application. Having an understanding of [how the graph API works](https://learn.microsoft.com/en-us/graph/use-the-api) will help you make the most of the library. Microsoft Graph exposes resources using the OData standard, and the graph client exposes type-safe access to these resources.
+
+The Microsoft Graph API surface is vast, and this Graph API Client supports a subset of the full functionality to cover the most common scenarios. Use the following table to find details on which endpoints are supported as well as links to the official documentation for each endpoint.
+
+| Client property | Graph endpoints | Description  | 
+|--|--|--|
+| [appCatalogs](app-catalogs.md) | [/appCatalogs](https://learn.microsoft.com/en-us/graph/api/appcatalogs-list-teamsapps?view=graph-rest-1.0) | Apps from Teams App Catalog  |
+| [applications](applications.md) | [/applications](https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0) | Application Resources  |
+| [applicationTemplates](application-templates.md) | [/applicationTemplates](https://learn.microsoft.com/en-us/graph/api/resources/applicationtemplate?view=graph-rest-1.0) | Application in the Microsoft Entra App Gallery  |
+| [appRoleAssignments](app-role-assignments.md) | [/appRoleAssignments](https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list-approleassignments?view=graph-rest-1.0) | List app role assignments  |
+| [chats](chats.md) | [/chats](https://learn.microsoft.com/en-us/graph/api/chat-list?view=graph-rest-1.0&tabs=http) | Chat resources between users  |
+| [communications](communications.md) | [/communications](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0) | Calls and Online meetings  |
+| [employeeExperience](employee-experience.md) | [/employeeExperience](https://learn.microsoft.com/en-us/graph/api/resources/engagement-api-overview?view=graph-rest-1.0) | Employee Experience and Engagement  |
+| [me](me.md) | [/me](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http) | Same as `/users` but scoped to one user (who is making the request)  |
+| [sites](sites.md) | [/sites](https://learn.microsoft.com/en-us/graph/api/resources/site?view=graph-rest-1.0) | SharePoint Sites features  |
+| [solutions](solutions.md) | [/solutions](https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0) | Solutions in Microsoft Graph  |
+| [teams](teams.md) | [/teams](https://learn.microsoft.com/en-us/graph/api/resources/team?view=graph-rest-1.0) | A Team resource  |
+| [teamsTemplates](teams-templates.md) | [/teamsTemplates](https://learn.microsoft.com/en-us/microsoftteams/get-started-with-teams-templates) | A Team Template resource  |
+| [teamwork](teamwork.md) | [/teamwork](https://learn.microsoft.com/en-us/graph/api/resources/teamwork?view=graph-rest-1.0) | A range of Microsoft Teams functionalities  |
+| [users](users.md) | [/users](https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0) | A user resource  |

--- a/teams.md/docs/typescript/in-depth-guides/graph/app-catalogs.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/app-catalogs.md
@@ -1,0 +1,65 @@
+# App Catalogs
+
+This page lists all the `/appCatalogs` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/appCatalogs` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/appcatalogs-list-teamsapps?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## AppCatalogsClient Endpoints
+
+The AppCatalogsClient instance gives access to the following `/appCatalogs` endpoints. You can get a `AppCatalogsClient` instance like so:
+
+```typescript
+const appCatalogsClient = graphClient.appCatalogs;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get appCatalogs | `GET /appCatalogs` | `await appCatalogsClient.list(params);` |
+| Update appCatalogs | `PATCH /appCatalogs` | `await appCatalogsClient.update(params);` |
+
+## TeamsAppsClient Endpoints
+
+The TeamsAppsClient instance gives access to the following `/appCatalogs/teamsApps` endpoints. You can get a `TeamsAppsClient` instance like so:
+
+```typescript
+const teamsAppsClient = appCatalogsClient.teamsApps;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List teamsApp | `GET /appCatalogs/teamsApps` | `await teamsAppsClient.list(params);` |
+| Publish teamsApp | `POST /appCatalogs/teamsApps` | `await teamsAppsClient.create(params);` |
+| Get teamsApps from appCatalogs | `GET /appCatalogs/teamsApps/{teamsApp-id}` | `await teamsAppsClient.get({"teamsApp-id": teamsAppId  });` |
+| Delete teamsApp | `DELETE /appCatalogs/teamsApps/{teamsApp-id}` | `await teamsAppsClient.delete({"teamsApp-id": teamsAppId  });` |
+| Update the navigation property teamsApps in appCatalogs | `PATCH /appCatalogs/teamsApps/{teamsApp-id}` | `await teamsAppsClient.update(params);` |
+
+## AppDefinitionsClient Endpoints
+
+The AppDefinitionsClient instance gives access to the following `/appCatalogs/teamsApps/{teamsApp-id}/appDefinitions` endpoints. You can get a `AppDefinitionsClient` instance like so:
+
+```typescript
+const appDefinitionsClient = await teamsAppsClient.appDefinitions(teamsAppId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get appDefinitions from appCatalogs | `GET /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions` | `await appDefinitionsClient.list(params);` |
+| Update teamsApp | `POST /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions` | `await appDefinitionsClient.create(params);` |
+| Get appDefinitions from appCatalogs | `GET /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions/{teamsAppDefinition-id}` | `await appDefinitionsClient.get({"teamsAppDefinition-id": teamsAppDefinitionId  });` |
+| Delete navigation property appDefinitions for appCatalogs | `DELETE /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions/{teamsAppDefinition-id}` | `await appDefinitionsClient.delete({"teamsAppDefinition-id": teamsAppDefinitionId  });` |
+| Publish teamsApp | `PATCH /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions/{teamsAppDefinition-id}` | `await appDefinitionsClient.update(params);` |
+
+## BotClient Endpoints
+
+The BotClient instance gives access to the following `/appCatalogs/teamsApps/{teamsApp-id}/appDefinitions/{teamsAppDefinition-id}/bot` endpoints. You can get a `BotClient` instance like so:
+
+```typescript
+const botClient = await appDefinitionsClient.bot(teamsAppDefinitionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamworkBot | `GET /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions/{teamsAppDefinition-id}/bot` | `await botClient.list(params);` |
+| Delete navigation property bot for appCatalogs | `DELETE /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions/{teamsAppDefinition-id}/bot` | `await botClient.delete({"teamsAppDefinition-id": teamsAppDefinitionId  });` |
+| Update the navigation property bot in appCatalogs | `PATCH /appCatalogs/teamsApps/{teamsApp-id}/appDefinitions/{teamsAppDefinition-id}/bot` | `await botClient.update(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/app-role-assignments.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/app-role-assignments.md
@@ -1,0 +1,113 @@
+# App Role Assignments
+
+This page lists all the `/appRoleAssignments` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/appRoleAssignments` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list-approleassignments?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## AppRoleAssignmentsClient Endpoints
+
+The AppRoleAssignmentsClient instance gives access to the following `/appRoleAssignments` endpoints. You can get a `AppRoleAssignmentsClient` instance like so:
+
+```typescript
+const appRoleAssignmentsClient = graphClient.appRoleAssignments;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get entities from appRoleAssignments | `GET /appRoleAssignments` | `await appRoleAssignmentsClient.list(params);` |
+| Add new entity to appRoleAssignments | `POST /appRoleAssignments` | `await appRoleAssignmentsClient.create(params);` |
+| Get entity from appRoleAssignments by key | `GET /appRoleAssignments/{appRoleAssignment-id}` | `await appRoleAssignmentsClient.get({"appRoleAssignment-id": appRoleAssignmentId  });` |
+| Delete entity from appRoleAssignments | `DELETE /appRoleAssignments/{appRoleAssignment-id}` | `await appRoleAssignmentsClient.delete({"appRoleAssignment-id": appRoleAssignmentId  });` |
+| Update entity in appRoleAssignments | `PATCH /appRoleAssignments/{appRoleAssignment-id}` | `await appRoleAssignmentsClient.update(params);` |
+
+## CheckMemberGroupsClient Endpoints
+
+The CheckMemberGroupsClient instance gives access to the following `/appRoleAssignments/{appRoleAssignment-id}/checkMemberGroups` endpoints. You can get a `CheckMemberGroupsClient` instance like so:
+
+```typescript
+const checkMemberGroupsClient = await appRoleAssignmentsClient.checkMemberGroups(appRoleAssignmentId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action checkMemberGroups | `POST /appRoleAssignments/{appRoleAssignment-id}/checkMemberGroups` | `await checkMemberGroupsClient.create(params);` |
+
+## CheckMemberObjectsClient Endpoints
+
+The CheckMemberObjectsClient instance gives access to the following `/appRoleAssignments/{appRoleAssignment-id}/checkMemberObjects` endpoints. You can get a `CheckMemberObjectsClient` instance like so:
+
+```typescript
+const checkMemberObjectsClient = await appRoleAssignmentsClient.checkMemberObjects(appRoleAssignmentId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action checkMemberObjects | `POST /appRoleAssignments/{appRoleAssignment-id}/checkMemberObjects` | `await checkMemberObjectsClient.create(params);` |
+
+## GetMemberGroupsClient Endpoints
+
+The GetMemberGroupsClient instance gives access to the following `/appRoleAssignments/{appRoleAssignment-id}/getMemberGroups` endpoints. You can get a `GetMemberGroupsClient` instance like so:
+
+```typescript
+const getMemberGroupsClient = await appRoleAssignmentsClient.getMemberGroups(appRoleAssignmentId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getMemberGroups | `POST /appRoleAssignments/{appRoleAssignment-id}/getMemberGroups` | `await getMemberGroupsClient.create(params);` |
+
+## GetMemberObjectsClient Endpoints
+
+The GetMemberObjectsClient instance gives access to the following `/appRoleAssignments/{appRoleAssignment-id}/getMemberObjects` endpoints. You can get a `GetMemberObjectsClient` instance like so:
+
+```typescript
+const getMemberObjectsClient = await appRoleAssignmentsClient.getMemberObjects(appRoleAssignmentId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getMemberObjects | `POST /appRoleAssignments/{appRoleAssignment-id}/getMemberObjects` | `await getMemberObjectsClient.create(params);` |
+
+## RestoreClient Endpoints
+
+The RestoreClient instance gives access to the following `/appRoleAssignments/{appRoleAssignment-id}/restore` endpoints. You can get a `RestoreClient` instance like so:
+
+```typescript
+const restoreClient = await appRoleAssignmentsClient.restore(appRoleAssignmentId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action restore | `POST /appRoleAssignments/{appRoleAssignment-id}/restore` | `await restoreClient.create(params);` |
+
+## GetAvailableExtensionPropertiesClient Endpoints
+
+The GetAvailableExtensionPropertiesClient instance gives access to the following `/appRoleAssignments/getAvailableExtensionProperties` endpoints. You can get a `GetAvailableExtensionPropertiesClient` instance like so:
+
+```typescript
+const getAvailableExtensionPropertiesClient = appRoleAssignmentsClient.getAvailableExtensionProperties;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getAvailableExtensionProperties | `POST /appRoleAssignments/getAvailableExtensionProperties` | `await getAvailableExtensionPropertiesClient.create(params);` |
+
+## GetByIdsClient Endpoints
+
+The GetByIdsClient instance gives access to the following `/appRoleAssignments/getByIds` endpoints. You can get a `GetByIdsClient` instance like so:
+
+```typescript
+const getByIdsClient = appRoleAssignmentsClient.getByIds;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getByIds | `POST /appRoleAssignments/getByIds` | `await getByIdsClient.create(params);` |
+
+## ValidatePropertiesClient Endpoints
+
+The ValidatePropertiesClient instance gives access to the following `/appRoleAssignments/validateProperties` endpoints. You can get a `ValidatePropertiesClient` instance like so:
+
+```typescript
+const validatePropertiesClient = appRoleAssignmentsClient.validateProperties;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action validateProperties | `POST /appRoleAssignments/validateProperties` | `await validatePropertiesClient.create(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/application-templates.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/application-templates.md
@@ -1,0 +1,33 @@
+# Application Templates
+
+This page lists all the `/applicationTemplates` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/applicationTemplates` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/applicationtemplate?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## ApplicationTemplatesClient Endpoints
+
+The ApplicationTemplatesClient instance gives access to the following `/applicationTemplates` endpoints. You can get a `ApplicationTemplatesClient` instance like so:
+
+```typescript
+const applicationTemplatesClient = graphClient.applicationTemplates;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List applicationTemplates | `GET /applicationTemplates` | `await applicationTemplatesClient.list(params);` |
+| Get applicationTemplate | `GET /applicationTemplates/{applicationTemplate-id}` | `await applicationTemplatesClient.get({"applicationTemplate-id": applicationTemplateId  });` |
+
+## InstantiateClient Endpoints
+
+The InstantiateClient instance gives access to the following `/applicationTemplates/{applicationTemplate-id}/instantiate` endpoints. You can get a `InstantiateClient` instance like so:
+
+```typescript
+const instantiateClient = await applicationTemplatesClient.instantiate(applicationTemplateId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action instantiate | `POST /applicationTemplates/{applicationTemplate-id}/instantiate` | `await instantiateClient.create(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/applications.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/applications.md
@@ -1,0 +1,533 @@
+# Applications
+
+This page lists all the `/applications` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/applications` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## ApplicationsClient Endpoints
+
+The ApplicationsClient instance gives access to the following `/applications` endpoints. You can get a `ApplicationsClient` instance like so:
+
+```typescript
+const applicationsClient = graphClient.applications;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List applications | `GET /applications` | `await applicationsClient.list(params);` |
+| Create application | `POST /applications` | `await applicationsClient.create(params);` |
+| Get application | `GET /applications/{application-id}` | `await applicationsClient.get({"application-id": applicationId  });` |
+| Delete application | `DELETE /applications/{application-id}` | `await applicationsClient.delete({"application-id": applicationId  });` |
+| Upsert application | `PATCH /applications/{application-id}` | `await applicationsClient.update(params);` |
+
+## AppManagementPoliciesClient Endpoints
+
+The AppManagementPoliciesClient instance gives access to the following `/applications/{application-id}/appManagementPolicies` endpoints. You can get a `AppManagementPoliciesClient` instance like so:
+
+```typescript
+const appManagementPoliciesClient = await applicationsClient.appManagementPolicies(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get appManagementPolicies from applications | `GET /applications/{application-id}/appManagementPolicies` | `await appManagementPoliciesClient.list(params);` |
+
+## CreatedOnBehalfOfClient Endpoints
+
+The CreatedOnBehalfOfClient instance gives access to the following `/applications/{application-id}/createdOnBehalfOf` endpoints. You can get a `CreatedOnBehalfOfClient` instance like so:
+
+```typescript
+const createdOnBehalfOfClient = await applicationsClient.createdOnBehalfOf(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get createdOnBehalfOf from applications | `GET /applications/{application-id}/createdOnBehalfOf` | `await createdOnBehalfOfClient.list(params);` |
+
+## ExtensionPropertiesClient Endpoints
+
+The ExtensionPropertiesClient instance gives access to the following `/applications/{application-id}/extensionProperties` endpoints. You can get a `ExtensionPropertiesClient` instance like so:
+
+```typescript
+const extensionPropertiesClient = await applicationsClient.extensionProperties(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List extensionProperties (directory extensions) | `GET /applications/{application-id}/extensionProperties` | `await extensionPropertiesClient.list(params);` |
+| Create extensionProperty (directory extension) | `POST /applications/{application-id}/extensionProperties` | `await extensionPropertiesClient.create(params);` |
+| Get extensionProperty (directory extension) | `GET /applications/{application-id}/extensionProperties/{extensionProperty-id}` | `await extensionPropertiesClient.get({"extensionProperty-id": extensionPropertyId  });` |
+| Delete extensionProperty (directory extension) | `DELETE /applications/{application-id}/extensionProperties/{extensionProperty-id}` | `await extensionPropertiesClient.delete({"extensionProperty-id": extensionPropertyId  });` |
+| Update the navigation property extensionProperties in applications | `PATCH /applications/{application-id}/extensionProperties/{extensionProperty-id}` | `await extensionPropertiesClient.update(params);` |
+
+## FederatedIdentityCredentialsClient Endpoints
+
+The FederatedIdentityCredentialsClient instance gives access to the following `/applications/{application-id}/federatedIdentityCredentials` endpoints. You can get a `FederatedIdentityCredentialsClient` instance like so:
+
+```typescript
+const federatedIdentityCredentialsClient = await applicationsClient.federatedIdentityCredentials(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List federatedIdentityCredentials | `GET /applications/{application-id}/federatedIdentityCredentials` | `await federatedIdentityCredentialsClient.list(params);` |
+| Create federatedIdentityCredential | `POST /applications/{application-id}/federatedIdentityCredentials` | `await federatedIdentityCredentialsClient.create(params);` |
+| Get federatedIdentityCredential | `GET /applications/{application-id}/federatedIdentityCredentials/{federatedIdentityCredential-id}` | `await federatedIdentityCredentialsClient.get({"federatedIdentityCredential-id": federatedIdentityCredentialId  });` |
+| Delete federatedIdentityCredential | `DELETE /applications/{application-id}/federatedIdentityCredentials/{federatedIdentityCredential-id}` | `await federatedIdentityCredentialsClient.delete({"federatedIdentityCredential-id": federatedIdentityCredentialId  });` |
+| Upsert federatedIdentityCredential | `PATCH /applications/{application-id}/federatedIdentityCredentials/{federatedIdentityCredential-id}` | `await federatedIdentityCredentialsClient.update(params);` |
+
+## HomeRealmDiscoveryPoliciesClient Endpoints
+
+The HomeRealmDiscoveryPoliciesClient instance gives access to the following `/applications/{application-id}/homeRealmDiscoveryPolicies` endpoints. You can get a `HomeRealmDiscoveryPoliciesClient` instance like so:
+
+```typescript
+const homeRealmDiscoveryPoliciesClient = await applicationsClient.homeRealmDiscoveryPolicies(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get homeRealmDiscoveryPolicies from applications | `GET /applications/{application-id}/homeRealmDiscoveryPolicies` | `await homeRealmDiscoveryPoliciesClient.list(params);` |
+| Get homeRealmDiscoveryPolicies from applications | `GET /applications/{application-id}/homeRealmDiscoveryPolicies/{homeRealmDiscoveryPolicy-id}` | `await homeRealmDiscoveryPoliciesClient.get({"homeRealmDiscoveryPolicy-id": homeRealmDiscoveryPolicyId  });` |
+
+## LogoClient Endpoints
+
+The LogoClient instance gives access to the following `/applications/{application-id}/logo` endpoints. You can get a `LogoClient` instance like so:
+
+```typescript
+const logoClient = await applicationsClient.logo(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get logo for application from applications | `GET /applications/{application-id}/logo` | `await logoClient.list(params);` |
+| Update logo for application in applications | `PUT /applications/{application-id}/logo` | `await logoClient.set(body, {"application-id": applicationId  });` |
+| Delete logo for application in applications | `DELETE /applications/{application-id}/logo` | `await logoClient.delete({"application-id": applicationId  });` |
+
+## AddKeyClient Endpoints
+
+The AddKeyClient instance gives access to the following `/applications/{application-id}/addKey` endpoints. You can get a `AddKeyClient` instance like so:
+
+```typescript
+const addKeyClient = await applicationsClient.addKey(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action addKey | `POST /applications/{application-id}/addKey` | `await addKeyClient.create(params);` |
+
+## AddPasswordClient Endpoints
+
+The AddPasswordClient instance gives access to the following `/applications/{application-id}/addPassword` endpoints. You can get a `AddPasswordClient` instance like so:
+
+```typescript
+const addPasswordClient = await applicationsClient.addPassword(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action addPassword | `POST /applications/{application-id}/addPassword` | `await addPasswordClient.create(params);` |
+
+## CheckMemberGroupsClient Endpoints
+
+The CheckMemberGroupsClient instance gives access to the following `/applications/{application-id}/checkMemberGroups` endpoints. You can get a `CheckMemberGroupsClient` instance like so:
+
+```typescript
+const checkMemberGroupsClient = await applicationsClient.checkMemberGroups(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action checkMemberGroups | `POST /applications/{application-id}/checkMemberGroups` | `await checkMemberGroupsClient.create(params);` |
+
+## CheckMemberObjectsClient Endpoints
+
+The CheckMemberObjectsClient instance gives access to the following `/applications/{application-id}/checkMemberObjects` endpoints. You can get a `CheckMemberObjectsClient` instance like so:
+
+```typescript
+const checkMemberObjectsClient = await applicationsClient.checkMemberObjects(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action checkMemberObjects | `POST /applications/{application-id}/checkMemberObjects` | `await checkMemberObjectsClient.create(params);` |
+
+## GetMemberGroupsClient Endpoints
+
+The GetMemberGroupsClient instance gives access to the following `/applications/{application-id}/getMemberGroups` endpoints. You can get a `GetMemberGroupsClient` instance like so:
+
+```typescript
+const getMemberGroupsClient = await applicationsClient.getMemberGroups(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getMemberGroups | `POST /applications/{application-id}/getMemberGroups` | `await getMemberGroupsClient.create(params);` |
+
+## GetMemberObjectsClient Endpoints
+
+The GetMemberObjectsClient instance gives access to the following `/applications/{application-id}/getMemberObjects` endpoints. You can get a `GetMemberObjectsClient` instance like so:
+
+```typescript
+const getMemberObjectsClient = await applicationsClient.getMemberObjects(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getMemberObjects | `POST /applications/{application-id}/getMemberObjects` | `await getMemberObjectsClient.create(params);` |
+
+## RemoveKeyClient Endpoints
+
+The RemoveKeyClient instance gives access to the following `/applications/{application-id}/removeKey` endpoints. You can get a `RemoveKeyClient` instance like so:
+
+```typescript
+const removeKeyClient = await applicationsClient.removeKey(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action removeKey | `POST /applications/{application-id}/removeKey` | `await removeKeyClient.create(params);` |
+
+## RemovePasswordClient Endpoints
+
+The RemovePasswordClient instance gives access to the following `/applications/{application-id}/removePassword` endpoints. You can get a `RemovePasswordClient` instance like so:
+
+```typescript
+const removePasswordClient = await applicationsClient.removePassword(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action removePassword | `POST /applications/{application-id}/removePassword` | `await removePasswordClient.create(params);` |
+
+## RestoreClient Endpoints
+
+The RestoreClient instance gives access to the following `/applications/{application-id}/restore` endpoints. You can get a `RestoreClient` instance like so:
+
+```typescript
+const restoreClient = await applicationsClient.restore(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action restore | `POST /applications/{application-id}/restore` | `await restoreClient.create(params);` |
+
+## SetVerifiedPublisherClient Endpoints
+
+The SetVerifiedPublisherClient instance gives access to the following `/applications/{application-id}/setVerifiedPublisher` endpoints. You can get a `SetVerifiedPublisherClient` instance like so:
+
+```typescript
+const setVerifiedPublisherClient = await applicationsClient.setVerifiedPublisher(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setVerifiedPublisher | `POST /applications/{application-id}/setVerifiedPublisher` | `await setVerifiedPublisherClient.create(params);` |
+
+## UnsetVerifiedPublisherClient Endpoints
+
+The UnsetVerifiedPublisherClient instance gives access to the following `/applications/{application-id}/unsetVerifiedPublisher` endpoints. You can get a `UnsetVerifiedPublisherClient` instance like so:
+
+```typescript
+const unsetVerifiedPublisherClient = await applicationsClient.unsetVerifiedPublisher(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetVerifiedPublisher | `POST /applications/{application-id}/unsetVerifiedPublisher` | `await unsetVerifiedPublisherClient.create(params);` |
+
+## OwnersClient Endpoints
+
+The OwnersClient instance gives access to the following `/applications/{application-id}/owners` endpoints. You can get a `OwnersClient` instance like so:
+
+```typescript
+const ownersClient = await applicationsClient.owners(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List owners of an application | `GET /applications/{application-id}/owners` | `await ownersClient.list(params);` |
+
+## SynchronizationClient Endpoints
+
+The SynchronizationClient instance gives access to the following `/applications/{application-id}/synchronization` endpoints. You can get a `SynchronizationClient` instance like so:
+
+```typescript
+const synchronizationClient = await applicationsClient.synchronization(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get synchronization from applications | `GET /applications/{application-id}/synchronization` | `await synchronizationClient.list(params);` |
+| Update the navigation property synchronization in applications | `PUT /applications/{application-id}/synchronization` | `await synchronizationClient.set(body, {"application-id": applicationId  });` |
+| Delete navigation property synchronization for applications | `DELETE /applications/{application-id}/synchronization` | `await synchronizationClient.delete({"application-id": applicationId  });` |
+
+## JobsClient Endpoints
+
+The JobsClient instance gives access to the following `/applications/{application-id}/synchronization/jobs` endpoints. You can get a `JobsClient` instance like so:
+
+```typescript
+const jobsClient = synchronizationClient.jobs;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get jobs from applications | `GET /applications/{application-id}/synchronization/jobs` | `await jobsClient.list(params);` |
+| Create new navigation property to jobs for applications | `POST /applications/{application-id}/synchronization/jobs` | `await jobsClient.create(params);` |
+| Get jobs from applications | `GET /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}` | `await jobsClient.get({"synchronizationJob-id": synchronizationJobId  });` |
+| Delete navigation property jobs for applications | `DELETE /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}` | `await jobsClient.delete({"synchronizationJob-id": synchronizationJobId  });` |
+| Update the navigation property jobs in applications | `PATCH /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}` | `await jobsClient.update(params);` |
+
+## BulkUploadClient Endpoints
+
+The BulkUploadClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/bulkUpload` endpoints. You can get a `BulkUploadClient` instance like so:
+
+```typescript
+const bulkUploadClient = await jobsClient.bulkUpload(synchronizationJobId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get bulkUpload from applications | `GET /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/bulkUpload` | `await bulkUploadClient.list(params);` |
+| Delete navigation property bulkUpload for applications | `DELETE /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/bulkUpload` | `await bulkUploadClient.delete({"synchronizationJob-id": synchronizationJobId  });` |
+| Update the navigation property bulkUpload in applications | `PATCH /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/bulkUpload` | `await bulkUploadClient.update(params);` |
+
+## PauseClient Endpoints
+
+The PauseClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/pause` endpoints. You can get a `PauseClient` instance like so:
+
+```typescript
+const pauseClient = await jobsClient.pause(synchronizationJobId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action pause | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/pause` | `await pauseClient.create(params);` |
+
+## ProvisionOnDemandClient Endpoints
+
+The ProvisionOnDemandClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/provisionOnDemand` endpoints. You can get a `ProvisionOnDemandClient` instance like so:
+
+```typescript
+const provisionOnDemandClient = await jobsClient.provisionOnDemand(synchronizationJobId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action provisionOnDemand | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/provisionOnDemand` | `await provisionOnDemandClient.create(params);` |
+
+## RestartClient Endpoints
+
+The RestartClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/restart` endpoints. You can get a `RestartClient` instance like so:
+
+```typescript
+const restartClient = await jobsClient.restart(synchronizationJobId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action restart | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/restart` | `await restartClient.create(params);` |
+
+## StartClient Endpoints
+
+The StartClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/start` endpoints. You can get a `StartClient` instance like so:
+
+```typescript
+const startClient = await jobsClient.start(synchronizationJobId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action start | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/start` | `await startClient.create(params);` |
+
+## ValidateCredentialsClient Endpoints
+
+The ValidateCredentialsClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/validateCredentials` endpoints. You can get a `ValidateCredentialsClient` instance like so:
+
+```typescript
+const validateCredentialsClient = await jobsClient.validateCredentials(synchronizationJobId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action validateCredentials | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/validateCredentials` | `await validateCredentialsClient.create(params);` |
+
+## SchemaClient Endpoints
+
+The SchemaClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema` endpoints. You can get a `SchemaClient` instance like so:
+
+```typescript
+const schemaClient = await jobsClient.schema(synchronizationJobId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get schema from applications | `GET /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema` | `await schemaClient.list(params);` |
+| Delete navigation property schema for applications | `DELETE /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema` | `await schemaClient.delete({"synchronizationJob-id": synchronizationJobId  });` |
+| Update the navigation property schema in applications | `PATCH /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema` | `await schemaClient.update(params);` |
+
+## DirectoriesClient Endpoints
+
+The DirectoriesClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories` endpoints. You can get a `DirectoriesClient` instance like so:
+
+```typescript
+const directoriesClient = schemaClient.directories;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get directories from applications | `GET /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories` | `await directoriesClient.list(params);` |
+| Create new navigation property to directories for applications | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories` | `await directoriesClient.create(params);` |
+| Get directories from applications | `GET /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories/{directoryDefinition-id}` | `await directoriesClient.get({"directoryDefinition-id": directoryDefinitionId  });` |
+| Delete navigation property directories for applications | `DELETE /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories/{directoryDefinition-id}` | `await directoriesClient.delete({"directoryDefinition-id": directoryDefinitionId  });` |
+| Update the navigation property directories in applications | `PATCH /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories/{directoryDefinition-id}` | `await directoriesClient.update(params);` |
+
+## DiscoverClient Endpoints
+
+The DiscoverClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories/{directoryDefinition-id}/discover` endpoints. You can get a `DiscoverClient` instance like so:
+
+```typescript
+const discoverClient = await directoriesClient.discover(directoryDefinitionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action discover | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories/{directoryDefinition-id}/discover` | `await discoverClient.create(params);` |
+
+## ParseExpressionClient Endpoints
+
+The ParseExpressionClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/parseExpression` endpoints. You can get a `ParseExpressionClient` instance like so:
+
+```typescript
+const parseExpressionClient = schemaClient.parseExpression;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action parseExpression | `POST /applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/parseExpression` | `await parseExpressionClient.create(params);` |
+
+## ValidateCredentialsClient Endpoints
+
+The ValidateCredentialsClient instance gives access to the following `/applications/{application-id}/synchronization/jobs/validateCredentials` endpoints. You can get a `ValidateCredentialsClient` instance like so:
+
+```typescript
+const validateCredentialsClient = jobsClient.validateCredentials;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action validateCredentials | `POST /applications/{application-id}/synchronization/jobs/validateCredentials` | `await validateCredentialsClient.create(params);` |
+
+## AcquireAccessTokenClient Endpoints
+
+The AcquireAccessTokenClient instance gives access to the following `/applications/{application-id}/synchronization/acquireAccessToken` endpoints. You can get a `AcquireAccessTokenClient` instance like so:
+
+```typescript
+const acquireAccessTokenClient = synchronizationClient.acquireAccessToken;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action acquireAccessToken | `POST /applications/{application-id}/synchronization/acquireAccessToken` | `await acquireAccessTokenClient.create(params);` |
+
+## SecretsClient Endpoints
+
+The SecretsClient instance gives access to the following `/applications/{application-id}/synchronization/secrets` endpoints. You can get a `SecretsClient` instance like so:
+
+```typescript
+const secretsClient = synchronizationClient.secrets;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Update property secrets value. | `PUT /applications/{application-id}/synchronization/secrets` | `await secretsClient.set(body, {"":   });` |
+
+## TemplatesClient Endpoints
+
+The TemplatesClient instance gives access to the following `/applications/{application-id}/synchronization/templates` endpoints. You can get a `TemplatesClient` instance like so:
+
+```typescript
+const templatesClient = synchronizationClient.templates;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get templates from applications | `GET /applications/{application-id}/synchronization/templates` | `await templatesClient.list(params);` |
+| Create new navigation property to templates for applications | `POST /applications/{application-id}/synchronization/templates` | `await templatesClient.create(params);` |
+| Get templates from applications | `GET /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}` | `await templatesClient.get({"synchronizationTemplate-id": synchronizationTemplateId  });` |
+| Delete navigation property templates for applications | `DELETE /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}` | `await templatesClient.delete({"synchronizationTemplate-id": synchronizationTemplateId  });` |
+| Update synchronizationTemplate | `PATCH /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}` | `await templatesClient.update(params);` |
+
+## SchemaClient Endpoints
+
+The SchemaClient instance gives access to the following `/applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema` endpoints. You can get a `SchemaClient` instance like so:
+
+```typescript
+const schemaClient = await templatesClient.schema(synchronizationTemplateId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get schema from applications | `GET /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema` | `await schemaClient.list(params);` |
+| Delete navigation property schema for applications | `DELETE /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema` | `await schemaClient.delete({"synchronizationTemplate-id": synchronizationTemplateId  });` |
+| Update the navigation property schema in applications | `PATCH /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema` | `await schemaClient.update(params);` |
+
+## DirectoriesClient Endpoints
+
+The DirectoriesClient instance gives access to the following `/applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories` endpoints. You can get a `DirectoriesClient` instance like so:
+
+```typescript
+const directoriesClient = schemaClient.directories;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get directories from applications | `GET /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories` | `await directoriesClient.list(params);` |
+| Create new navigation property to directories for applications | `POST /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories` | `await directoriesClient.create(params);` |
+| Get directories from applications | `GET /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories/{directoryDefinition-id}` | `await directoriesClient.get({"directoryDefinition-id": directoryDefinitionId  });` |
+| Delete navigation property directories for applications | `DELETE /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories/{directoryDefinition-id}` | `await directoriesClient.delete({"directoryDefinition-id": directoryDefinitionId  });` |
+| Update the navigation property directories in applications | `PATCH /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories/{directoryDefinition-id}` | `await directoriesClient.update(params);` |
+
+## DiscoverClient Endpoints
+
+The DiscoverClient instance gives access to the following `/applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories/{directoryDefinition-id}/discover` endpoints. You can get a `DiscoverClient` instance like so:
+
+```typescript
+const discoverClient = await directoriesClient.discover(directoryDefinitionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action discover | `POST /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories/{directoryDefinition-id}/discover` | `await discoverClient.create(params);` |
+
+## ParseExpressionClient Endpoints
+
+The ParseExpressionClient instance gives access to the following `/applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/parseExpression` endpoints. You can get a `ParseExpressionClient` instance like so:
+
+```typescript
+const parseExpressionClient = schemaClient.parseExpression;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action parseExpression | `POST /applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/parseExpression` | `await parseExpressionClient.create(params);` |
+
+## TokenIssuancePoliciesClient Endpoints
+
+The TokenIssuancePoliciesClient instance gives access to the following `/applications/{application-id}/tokenIssuancePolicies` endpoints. You can get a `TokenIssuancePoliciesClient` instance like so:
+
+```typescript
+const tokenIssuancePoliciesClient = await applicationsClient.tokenIssuancePolicies(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List assigned tokenIssuancePolicies | `GET /applications/{application-id}/tokenIssuancePolicies` | `await tokenIssuancePoliciesClient.list(params);` |
+
+## TokenLifetimePoliciesClient Endpoints
+
+The TokenLifetimePoliciesClient instance gives access to the following `/applications/{application-id}/tokenLifetimePolicies` endpoints. You can get a `TokenLifetimePoliciesClient` instance like so:
+
+```typescript
+const tokenLifetimePoliciesClient = await applicationsClient.tokenLifetimePolicies(applicationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List assigned tokenLifetimePolicies | `GET /applications/{application-id}/tokenLifetimePolicies` | `await tokenLifetimePoliciesClient.list(params);` |
+
+## GetAvailableExtensionPropertiesClient Endpoints
+
+The GetAvailableExtensionPropertiesClient instance gives access to the following `/applications/getAvailableExtensionProperties` endpoints. You can get a `GetAvailableExtensionPropertiesClient` instance like so:
+
+```typescript
+const getAvailableExtensionPropertiesClient = applicationsClient.getAvailableExtensionProperties;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getAvailableExtensionProperties | `POST /applications/getAvailableExtensionProperties` | `await getAvailableExtensionPropertiesClient.create(params);` |
+
+## GetByIdsClient Endpoints
+
+The GetByIdsClient instance gives access to the following `/applications/getByIds` endpoints. You can get a `GetByIdsClient` instance like so:
+
+```typescript
+const getByIdsClient = applicationsClient.getByIds;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getByIds | `POST /applications/getByIds` | `await getByIdsClient.create(params);` |
+
+## ValidatePropertiesClient Endpoints
+
+The ValidatePropertiesClient instance gives access to the following `/applications/validateProperties` endpoints. You can get a `ValidatePropertiesClient` instance like so:
+
+```typescript
+const validatePropertiesClient = applicationsClient.validateProperties;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action validateProperties | `POST /applications/validateProperties` | `await validatePropertiesClient.create(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/chats.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/chats.md
@@ -1,0 +1,393 @@
+# Chats
+
+This page lists all the `/chats` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/chats` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/chat-list?view=graph-rest-1.0&tabs=http), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## ChatsClient Endpoints
+
+The ChatsClient instance gives access to the following `/chats` endpoints. You can get a `ChatsClient` instance like so:
+
+```typescript
+const chatsClient = graphClient.chats;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List chats | `GET /chats` | `await chatsClient.list(params);` |
+| Create chat | `POST /chats` | `await chatsClient.create(params);` |
+| Get chat | `GET /chats/{chat-id}` | `await chatsClient.get({"chat-id": chatId  });` |
+| Delete chat | `DELETE /chats/{chat-id}` | `await chatsClient.delete({"chat-id": chatId  });` |
+| Update chat | `PATCH /chats/{chat-id}` | `await chatsClient.update(params);` |
+
+## InstalledAppsClient Endpoints
+
+The InstalledAppsClient instance gives access to the following `/chats/{chat-id}/installedApps` endpoints. You can get a `InstalledAppsClient` instance like so:
+
+```typescript
+const installedAppsClient = await chatsClient.installedApps(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List apps in chat | `GET /chats/{chat-id}/installedApps` | `await installedAppsClient.list(params);` |
+| Add app to chat | `POST /chats/{chat-id}/installedApps` | `await installedAppsClient.create(params);` |
+| Get installed app in chat | `GET /chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.get({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Uninstall app in a chat | `DELETE /chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.delete({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Update the navigation property installedApps in chats | `PATCH /chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.update(params);` |
+
+## UpgradeClient Endpoints
+
+The UpgradeClient instance gives access to the following `/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/upgrade` endpoints. You can get a `UpgradeClient` instance like so:
+
+```typescript
+const upgradeClient = await installedAppsClient.upgrade(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action upgrade | `POST /chats/{chat-id}/installedApps/{teamsAppInstallation-id}/upgrade` | `await upgradeClient.create(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await installedAppsClient.teamsApp(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from chats | `GET /chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## TeamsAppDefinitionClient Endpoints
+
+The TeamsAppDefinitionClient instance gives access to the following `/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` endpoints. You can get a `TeamsAppDefinitionClient` instance like so:
+
+```typescript
+const teamsAppDefinitionClient = await installedAppsClient.teamsAppDefinition(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsAppDefinition from chats | `GET /chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` | `await teamsAppDefinitionClient.list(params);` |
+
+## LastMessagePreviewClient Endpoints
+
+The LastMessagePreviewClient instance gives access to the following `/chats/{chat-id}/lastMessagePreview` endpoints. You can get a `LastMessagePreviewClient` instance like so:
+
+```typescript
+const lastMessagePreviewClient = await chatsClient.lastMessagePreview(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastMessagePreview from chats | `GET /chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.list(params);` |
+| Delete navigation property lastMessagePreview for chats | `DELETE /chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.delete({"chat-id": chatId  });` |
+| Update the navigation property lastMessagePreview in chats | `PATCH /chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.update(params);` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/chats/{chat-id}/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = await chatsClient.members(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List conversationMembers | `GET /chats/{chat-id}/members` | `await membersClient.list(params);` |
+| Add member to a chat | `POST /chats/{chat-id}/members` | `await membersClient.create(params);` |
+| Get conversationMember | `GET /chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.get({"conversationMember-id": conversationMemberId  });` |
+| Remove member from chat | `DELETE /chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.delete({"conversationMember-id": conversationMemberId  });` |
+| Update the navigation property members in chats | `PATCH /chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.update(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/chats/{chat-id}/members/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = membersClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /chats/{chat-id}/members/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/chats/{chat-id}/members/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = membersClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /chats/{chat-id}/members/remove` | `await removeClient.create(params);` |
+
+## MessagesClient Endpoints
+
+The MessagesClient instance gives access to the following `/chats/{chat-id}/messages` endpoints. You can get a `MessagesClient` instance like so:
+
+```typescript
+const messagesClient = await chatsClient.messages(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List messages in a chat | `GET /chats/{chat-id}/messages` | `await messagesClient.list(params);` |
+| Send chatMessage in a channel or a chat | `POST /chats/{chat-id}/messages` | `await messagesClient.create(params);` |
+| Get chatMessage in a channel or chat | `GET /chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.get({"chatMessage-id": chatMessageId  });` |
+| Delete navigation property messages for chats | `DELETE /chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.delete({"chatMessage-id": chatMessageId  });` |
+| Update the navigation property messages in chats | `PATCH /chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await messagesClient.hostedContents(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List hostedContents | `GET /chats/{chat-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for chats | `POST /chats/{chat-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get chatMessageHostedContent | `GET /chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for chats | `DELETE /chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in chats | `PATCH /chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await messagesClient.setReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /chats/{chat-id}/messages/{chatMessage-id}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await messagesClient.softDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /chats/{chat-id}/messages/{chatMessage-id}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await messagesClient.undoSoftDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /chats/{chat-id}/messages/{chatMessage-id}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await messagesClient.unsetReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /chats/{chat-id}/messages/{chatMessage-id}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## RepliesClient Endpoints
+
+The RepliesClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/replies` endpoints. You can get a `RepliesClient` instance like so:
+
+```typescript
+const repliesClient = await messagesClient.replies(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get replies from chats | `GET /chats/{chat-id}/messages/{chatMessage-id}/replies` | `await repliesClient.list(params);` |
+| Create new navigation property to replies for chats | `POST /chats/{chat-id}/messages/{chatMessage-id}/replies` | `await repliesClient.create(params);` |
+| Get replies from chats | `GET /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.get({"chatMessage-id1": chatMessageId1  });` |
+| Delete navigation property replies for chats | `DELETE /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.delete({"chatMessage-id1": chatMessageId1  });` |
+| Update the navigation property replies in chats | `PATCH /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await repliesClient.hostedContents(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from chats | `GET /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for chats | `POST /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from chats | `GET /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for chats | `DELETE /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in chats | `PATCH /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await repliesClient.setReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await repliesClient.softDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await repliesClient.undoSoftDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await repliesClient.unsetReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## HideForUserClient Endpoints
+
+The HideForUserClient instance gives access to the following `/chats/{chat-id}/hideForUser` endpoints. You can get a `HideForUserClient` instance like so:
+
+```typescript
+const hideForUserClient = await chatsClient.hideForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action hideForUser | `POST /chats/{chat-id}/hideForUser` | `await hideForUserClient.create(params);` |
+
+## MarkChatReadForUserClient Endpoints
+
+The MarkChatReadForUserClient instance gives access to the following `/chats/{chat-id}/markChatReadForUser` endpoints. You can get a `MarkChatReadForUserClient` instance like so:
+
+```typescript
+const markChatReadForUserClient = await chatsClient.markChatReadForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action markChatReadForUser | `POST /chats/{chat-id}/markChatReadForUser` | `await markChatReadForUserClient.create(params);` |
+
+## MarkChatUnreadForUserClient Endpoints
+
+The MarkChatUnreadForUserClient instance gives access to the following `/chats/{chat-id}/markChatUnreadForUser` endpoints. You can get a `MarkChatUnreadForUserClient` instance like so:
+
+```typescript
+const markChatUnreadForUserClient = await chatsClient.markChatUnreadForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action markChatUnreadForUser | `POST /chats/{chat-id}/markChatUnreadForUser` | `await markChatUnreadForUserClient.create(params);` |
+
+## SendActivityNotificationClient Endpoints
+
+The SendActivityNotificationClient instance gives access to the following `/chats/{chat-id}/sendActivityNotification` endpoints. You can get a `SendActivityNotificationClient` instance like so:
+
+```typescript
+const sendActivityNotificationClient = await chatsClient.sendActivityNotification(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendActivityNotification | `POST /chats/{chat-id}/sendActivityNotification` | `await sendActivityNotificationClient.create(params);` |
+
+## UnhideForUserClient Endpoints
+
+The UnhideForUserClient instance gives access to the following `/chats/{chat-id}/unhideForUser` endpoints. You can get a `UnhideForUserClient` instance like so:
+
+```typescript
+const unhideForUserClient = await chatsClient.unhideForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unhideForUser | `POST /chats/{chat-id}/unhideForUser` | `await unhideForUserClient.create(params);` |
+
+## PermissionGrantsClient Endpoints
+
+The PermissionGrantsClient instance gives access to the following `/chats/{chat-id}/permissionGrants` endpoints. You can get a `PermissionGrantsClient` instance like so:
+
+```typescript
+const permissionGrantsClient = await chatsClient.permissionGrants(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List permissionGrants of a chat | `GET /chats/{chat-id}/permissionGrants` | `await permissionGrantsClient.list(params);` |
+| Create new navigation property to permissionGrants for chats | `POST /chats/{chat-id}/permissionGrants` | `await permissionGrantsClient.create(params);` |
+| Get permissionGrants from chats | `GET /chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.get({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Delete navigation property permissionGrants for chats | `DELETE /chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.delete({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Update the navigation property permissionGrants in chats | `PATCH /chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.update(params);` |
+
+## PinnedMessagesClient Endpoints
+
+The PinnedMessagesClient instance gives access to the following `/chats/{chat-id}/pinnedMessages` endpoints. You can get a `PinnedMessagesClient` instance like so:
+
+```typescript
+const pinnedMessagesClient = await chatsClient.pinnedMessages(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List pinnedChatMessages in a chat | `GET /chats/{chat-id}/pinnedMessages` | `await pinnedMessagesClient.list(params);` |
+| Pin a message in a chat | `POST /chats/{chat-id}/pinnedMessages` | `await pinnedMessagesClient.create(params);` |
+| Get pinnedMessages from chats | `GET /chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.get({"pinnedChatMessageInfo-id": pinnedChatMessageInfoId  });` |
+| Unpin a message from a chat | `DELETE /chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.delete({"pinnedChatMessageInfo-id": pinnedChatMessageInfoId  });` |
+| Update the navigation property pinnedMessages in chats | `PATCH /chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.update(params);` |
+
+## MessageClient Endpoints
+
+The MessageClient instance gives access to the following `/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}/message` endpoints. You can get a `MessageClient` instance like so:
+
+```typescript
+const messageClient = await pinnedMessagesClient.message(pinnedChatMessageInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get message from chats | `GET /chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}/message` | `await messageClient.list(params);` |
+
+## TabsClient Endpoints
+
+The TabsClient instance gives access to the following `/chats/{chat-id}/tabs` endpoints. You can get a `TabsClient` instance like so:
+
+```typescript
+const tabsClient = await chatsClient.tabs(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List tabs in chat | `GET /chats/{chat-id}/tabs` | `await tabsClient.list(params);` |
+| Add tab to chat | `POST /chats/{chat-id}/tabs` | `await tabsClient.create(params);` |
+| Get tab in chat | `GET /chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.get({"teamsTab-id": teamsTabId  });` |
+| Delete tab from chat | `DELETE /chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.delete({"teamsTab-id": teamsTabId  });` |
+| Update tab in chat | `PATCH /chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.update(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/chats/{chat-id}/tabs/{teamsTab-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await tabsClient.teamsApp(teamsTabId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from chats | `GET /chats/{chat-id}/tabs/{teamsTab-id}/teamsApp` | `await teamsAppClient.list(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/communications.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/communications.md
@@ -1,0 +1,631 @@
+# Communications
+
+This page lists all the `/communications` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/communications` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## CommunicationsClient Endpoints
+
+The CommunicationsClient instance gives access to the following `/communications` endpoints. You can get a `CommunicationsClient` instance like so:
+
+```typescript
+const communicationsClient = graphClient.communications;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get communications | `GET /communications` | `await communicationsClient.list(params);` |
+| Update communications | `PATCH /communications` | `await communicationsClient.update(params);` |
+
+## CallRecordsClient Endpoints
+
+The CallRecordsClient instance gives access to the following `/communications/callRecords` endpoints. You can get a `CallRecordsClient` instance like so:
+
+```typescript
+const callRecordsClient = communicationsClient.callRecords;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List callRecords | `GET /communications/callRecords` | `await callRecordsClient.list(params);` |
+| Create new navigation property to callRecords for communications | `POST /communications/callRecords` | `await callRecordsClient.create(params);` |
+| Get callRecord | `GET /communications/callRecords/{callRecord-id}` | `await callRecordsClient.get({"callRecord-id": callRecordId  });` |
+| Delete navigation property callRecords for communications | `DELETE /communications/callRecords/{callRecord-id}` | `await callRecordsClient.delete({"callRecord-id": callRecordId  });` |
+| Update the navigation property callRecords in communications | `PATCH /communications/callRecords/{callRecord-id}` | `await callRecordsClient.update(params);` |
+
+## OrganizerV2Client Endpoints
+
+The OrganizerV2Client instance gives access to the following `/communications/callRecords/{callRecord-id}/organizer_v2` endpoints. You can get a `OrganizerV2Client` instance like so:
+
+```typescript
+const organizer_v2Client = await callRecordsClient.organizer_v2(callRecordId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get organizer_v2 from communications | `GET /communications/callRecords/{callRecord-id}/organizer_v2` | `await organizer_v2Client.list(params);` |
+| Delete navigation property organizer_v2 for communications | `DELETE /communications/callRecords/{callRecord-id}/organizer_v2` | `await organizer_v2Client.delete({"callRecord-id": callRecordId  });` |
+| Update the navigation property organizer_v2 in communications | `PATCH /communications/callRecords/{callRecord-id}/organizer_v2` | `await organizer_v2Client.update(params);` |
+
+## ParticipantsV2Client Endpoints
+
+The ParticipantsV2Client instance gives access to the following `/communications/callRecords/{callRecord-id}/participants_v2` endpoints. You can get a `ParticipantsV2Client` instance like so:
+
+```typescript
+const participants_v2Client = await callRecordsClient.participants_v2(callRecordId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List participants_v2 | `GET /communications/callRecords/{callRecord-id}/participants_v2` | `await participants_v2Client.list(params);` |
+| Create new navigation property to participants_v2 for communications | `POST /communications/callRecords/{callRecord-id}/participants_v2` | `await participants_v2Client.create(params);` |
+| Get participants_v2 from communications | `GET /communications/callRecords/{callRecord-id}/participants_v2/{participant-id}` | `await participants_v2Client.get({"participant-id": participantId  });` |
+| Delete navigation property participants_v2 for communications | `DELETE /communications/callRecords/{callRecord-id}/participants_v2/{participant-id}` | `await participants_v2Client.delete({"participant-id": participantId  });` |
+| Update the navigation property participants_v2 in communications | `PATCH /communications/callRecords/{callRecord-id}/participants_v2/{participant-id}` | `await participants_v2Client.update(params);` |
+
+## SessionsClient Endpoints
+
+The SessionsClient instance gives access to the following `/communications/callRecords/{callRecord-id}/sessions` endpoints. You can get a `SessionsClient` instance like so:
+
+```typescript
+const sessionsClient = await callRecordsClient.sessions(callRecordId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List sessions | `GET /communications/callRecords/{callRecord-id}/sessions` | `await sessionsClient.list(params);` |
+| Create new navigation property to sessions for communications | `POST /communications/callRecords/{callRecord-id}/sessions` | `await sessionsClient.create(params);` |
+| Get sessions from communications | `GET /communications/callRecords/{callRecord-id}/sessions/{session-id}` | `await sessionsClient.get({"session-id": sessionId  });` |
+| Delete navigation property sessions for communications | `DELETE /communications/callRecords/{callRecord-id}/sessions/{session-id}` | `await sessionsClient.delete({"session-id": sessionId  });` |
+| Update the navigation property sessions in communications | `PATCH /communications/callRecords/{callRecord-id}/sessions/{session-id}` | `await sessionsClient.update(params);` |
+
+## SegmentsClient Endpoints
+
+The SegmentsClient instance gives access to the following `/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments` endpoints. You can get a `SegmentsClient` instance like so:
+
+```typescript
+const segmentsClient = await sessionsClient.segments(sessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get segments from communications | `GET /communications/callRecords/{callRecord-id}/sessions/{session-id}/segments` | `await segmentsClient.list(params);` |
+| Create new navigation property to segments for communications | `POST /communications/callRecords/{callRecord-id}/sessions/{session-id}/segments` | `await segmentsClient.create(params);` |
+| Get segments from communications | `GET /communications/callRecords/{callRecord-id}/sessions/{session-id}/segments/{segment-id}` | `await segmentsClient.get({"segment-id": segmentId  });` |
+| Delete navigation property segments for communications | `DELETE /communications/callRecords/{callRecord-id}/sessions/{session-id}/segments/{segment-id}` | `await segmentsClient.delete({"segment-id": segmentId  });` |
+| Update the navigation property segments in communications | `PATCH /communications/callRecords/{callRecord-id}/sessions/{session-id}/segments/{segment-id}` | `await segmentsClient.update(params);` |
+
+## CallsClient Endpoints
+
+The CallsClient instance gives access to the following `/communications/calls` endpoints. You can get a `CallsClient` instance like so:
+
+```typescript
+const callsClient = communicationsClient.calls;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get call | `GET /communications/calls` | `await callsClient.list(params);` |
+| Create call | `POST /communications/calls` | `await callsClient.create(params);` |
+| Get call | `GET /communications/calls/{call-id}` | `await callsClient.get({"call-id": callId  });` |
+| Delete call | `DELETE /communications/calls/{call-id}` | `await callsClient.delete({"call-id": callId  });` |
+| Update the navigation property calls in communications | `PATCH /communications/calls/{call-id}` | `await callsClient.update(params);` |
+
+## AudioRoutingGroupsClient Endpoints
+
+The AudioRoutingGroupsClient instance gives access to the following `/communications/calls/{call-id}/audioRoutingGroups` endpoints. You can get a `AudioRoutingGroupsClient` instance like so:
+
+```typescript
+const audioRoutingGroupsClient = await callsClient.audioRoutingGroups(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List audioRoutingGroups | `GET /communications/calls/{call-id}/audioRoutingGroups` | `await audioRoutingGroupsClient.list(params);` |
+| Create audioRoutingGroup | `POST /communications/calls/{call-id}/audioRoutingGroups` | `await audioRoutingGroupsClient.create(params);` |
+| Get audioRoutingGroup | `GET /communications/calls/{call-id}/audioRoutingGroups/{audioRoutingGroup-id}` | `await audioRoutingGroupsClient.get({"audioRoutingGroup-id": audioRoutingGroupId  });` |
+| Delete audioRoutingGroup | `DELETE /communications/calls/{call-id}/audioRoutingGroups/{audioRoutingGroup-id}` | `await audioRoutingGroupsClient.delete({"audioRoutingGroup-id": audioRoutingGroupId  });` |
+| Update audioRoutingGroup | `PATCH /communications/calls/{call-id}/audioRoutingGroups/{audioRoutingGroup-id}` | `await audioRoutingGroupsClient.update(params);` |
+
+## ContentSharingSessionsClient Endpoints
+
+The ContentSharingSessionsClient instance gives access to the following `/communications/calls/{call-id}/contentSharingSessions` endpoints. You can get a `ContentSharingSessionsClient` instance like so:
+
+```typescript
+const contentSharingSessionsClient = await callsClient.contentSharingSessions(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List contentSharingSessions | `GET /communications/calls/{call-id}/contentSharingSessions` | `await contentSharingSessionsClient.list(params);` |
+| Create new navigation property to contentSharingSessions for communications | `POST /communications/calls/{call-id}/contentSharingSessions` | `await contentSharingSessionsClient.create(params);` |
+| Get contentSharingSession | `GET /communications/calls/{call-id}/contentSharingSessions/{contentSharingSession-id}` | `await contentSharingSessionsClient.get({"contentSharingSession-id": contentSharingSessionId  });` |
+| Delete navigation property contentSharingSessions for communications | `DELETE /communications/calls/{call-id}/contentSharingSessions/{contentSharingSession-id}` | `await contentSharingSessionsClient.delete({"contentSharingSession-id": contentSharingSessionId  });` |
+| Update the navigation property contentSharingSessions in communications | `PATCH /communications/calls/{call-id}/contentSharingSessions/{contentSharingSession-id}` | `await contentSharingSessionsClient.update(params);` |
+
+## AddLargeGalleryViewClient Endpoints
+
+The AddLargeGalleryViewClient instance gives access to the following `/communications/calls/{call-id}/addLargeGalleryView` endpoints. You can get a `AddLargeGalleryViewClient` instance like so:
+
+```typescript
+const addLargeGalleryViewClient = await callsClient.addLargeGalleryView(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action addLargeGalleryView | `POST /communications/calls/{call-id}/addLargeGalleryView` | `await addLargeGalleryViewClient.create(params);` |
+
+## AnswerClient Endpoints
+
+The AnswerClient instance gives access to the following `/communications/calls/{call-id}/answer` endpoints. You can get a `AnswerClient` instance like so:
+
+```typescript
+const answerClient = await callsClient.answer(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action answer | `POST /communications/calls/{call-id}/answer` | `await answerClient.create(params);` |
+
+## CancelMediaProcessingClient Endpoints
+
+The CancelMediaProcessingClient instance gives access to the following `/communications/calls/{call-id}/cancelMediaProcessing` endpoints. You can get a `CancelMediaProcessingClient` instance like so:
+
+```typescript
+const cancelMediaProcessingClient = await callsClient.cancelMediaProcessing(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancelMediaProcessing | `POST /communications/calls/{call-id}/cancelMediaProcessing` | `await cancelMediaProcessingClient.create(params);` |
+
+## ChangeScreenSharingRoleClient Endpoints
+
+The ChangeScreenSharingRoleClient instance gives access to the following `/communications/calls/{call-id}/changeScreenSharingRole` endpoints. You can get a `ChangeScreenSharingRoleClient` instance like so:
+
+```typescript
+const changeScreenSharingRoleClient = await callsClient.changeScreenSharingRole(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action changeScreenSharingRole | `POST /communications/calls/{call-id}/changeScreenSharingRole` | `await changeScreenSharingRoleClient.create(params);` |
+
+## KeepAliveClient Endpoints
+
+The KeepAliveClient instance gives access to the following `/communications/calls/{call-id}/keepAlive` endpoints. You can get a `KeepAliveClient` instance like so:
+
+```typescript
+const keepAliveClient = await callsClient.keepAlive(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action keepAlive | `POST /communications/calls/{call-id}/keepAlive` | `await keepAliveClient.create(params);` |
+
+## MuteClient Endpoints
+
+The MuteClient instance gives access to the following `/communications/calls/{call-id}/mute` endpoints. You can get a `MuteClient` instance like so:
+
+```typescript
+const muteClient = await callsClient.mute(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action mute | `POST /communications/calls/{call-id}/mute` | `await muteClient.create(params);` |
+
+## PlayPromptClient Endpoints
+
+The PlayPromptClient instance gives access to the following `/communications/calls/{call-id}/playPrompt` endpoints. You can get a `PlayPromptClient` instance like so:
+
+```typescript
+const playPromptClient = await callsClient.playPrompt(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action playPrompt | `POST /communications/calls/{call-id}/playPrompt` | `await playPromptClient.create(params);` |
+
+## RecordResponseClient Endpoints
+
+The RecordResponseClient instance gives access to the following `/communications/calls/{call-id}/recordResponse` endpoints. You can get a `RecordResponseClient` instance like so:
+
+```typescript
+const recordResponseClient = await callsClient.recordResponse(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action recordResponse | `POST /communications/calls/{call-id}/recordResponse` | `await recordResponseClient.create(params);` |
+
+## RedirectClient Endpoints
+
+The RedirectClient instance gives access to the following `/communications/calls/{call-id}/redirect` endpoints. You can get a `RedirectClient` instance like so:
+
+```typescript
+const redirectClient = await callsClient.redirect(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action redirect | `POST /communications/calls/{call-id}/redirect` | `await redirectClient.create(params);` |
+
+## RejectClient Endpoints
+
+The RejectClient instance gives access to the following `/communications/calls/{call-id}/reject` endpoints. You can get a `RejectClient` instance like so:
+
+```typescript
+const rejectClient = await callsClient.reject(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action reject | `POST /communications/calls/{call-id}/reject` | `await rejectClient.create(params);` |
+
+## SendDtmfTonesClient Endpoints
+
+The SendDtmfTonesClient instance gives access to the following `/communications/calls/{call-id}/sendDtmfTones` endpoints. You can get a `SendDtmfTonesClient` instance like so:
+
+```typescript
+const sendDtmfTonesClient = await callsClient.sendDtmfTones(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendDtmfTones | `POST /communications/calls/{call-id}/sendDtmfTones` | `await sendDtmfTonesClient.create(params);` |
+
+## SubscribeToToneClient Endpoints
+
+The SubscribeToToneClient instance gives access to the following `/communications/calls/{call-id}/subscribeToTone` endpoints. You can get a `SubscribeToToneClient` instance like so:
+
+```typescript
+const subscribeToToneClient = await callsClient.subscribeToTone(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action subscribeToTone | `POST /communications/calls/{call-id}/subscribeToTone` | `await subscribeToToneClient.create(params);` |
+
+## TransferClient Endpoints
+
+The TransferClient instance gives access to the following `/communications/calls/{call-id}/transfer` endpoints. You can get a `TransferClient` instance like so:
+
+```typescript
+const transferClient = await callsClient.transfer(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action transfer | `POST /communications/calls/{call-id}/transfer` | `await transferClient.create(params);` |
+
+## UnmuteClient Endpoints
+
+The UnmuteClient instance gives access to the following `/communications/calls/{call-id}/unmute` endpoints. You can get a `UnmuteClient` instance like so:
+
+```typescript
+const unmuteClient = await callsClient.unmute(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unmute | `POST /communications/calls/{call-id}/unmute` | `await unmuteClient.create(params);` |
+
+## UpdateRecordingStatusClient Endpoints
+
+The UpdateRecordingStatusClient instance gives access to the following `/communications/calls/{call-id}/updateRecordingStatus` endpoints. You can get a `UpdateRecordingStatusClient` instance like so:
+
+```typescript
+const updateRecordingStatusClient = await callsClient.updateRecordingStatus(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action updateRecordingStatus | `POST /communications/calls/{call-id}/updateRecordingStatus` | `await updateRecordingStatusClient.create(params);` |
+
+## OperationsClient Endpoints
+
+The OperationsClient instance gives access to the following `/communications/calls/{call-id}/operations` endpoints. You can get a `OperationsClient` instance like so:
+
+```typescript
+const operationsClient = await callsClient.operations(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get addLargeGalleryViewOperation | `GET /communications/calls/{call-id}/operations` | `await operationsClient.list(params);` |
+| Create new navigation property to operations for communications | `POST /communications/calls/{call-id}/operations` | `await operationsClient.create(params);` |
+| Get addLargeGalleryViewOperation | `GET /communications/calls/{call-id}/operations/{commsOperation-id}` | `await operationsClient.get({"commsOperation-id": commsOperationId  });` |
+| Delete navigation property operations for communications | `DELETE /communications/calls/{call-id}/operations/{commsOperation-id}` | `await operationsClient.delete({"commsOperation-id": commsOperationId  });` |
+| Update the navigation property operations in communications | `PATCH /communications/calls/{call-id}/operations/{commsOperation-id}` | `await operationsClient.update(params);` |
+
+## ParticipantsClient Endpoints
+
+The ParticipantsClient instance gives access to the following `/communications/calls/{call-id}/participants` endpoints. You can get a `ParticipantsClient` instance like so:
+
+```typescript
+const participantsClient = await callsClient.participants(callId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List participants | `GET /communications/calls/{call-id}/participants` | `await participantsClient.list(params);` |
+| Create new navigation property to participants for communications | `POST /communications/calls/{call-id}/participants` | `await participantsClient.create(params);` |
+| Get participant | `GET /communications/calls/{call-id}/participants/{participant-id}` | `await participantsClient.get({"participant-id": participantId  });` |
+| Delete participant | `DELETE /communications/calls/{call-id}/participants/{participant-id}` | `await participantsClient.delete({"participant-id": participantId  });` |
+| Update the navigation property participants in communications | `PATCH /communications/calls/{call-id}/participants/{participant-id}` | `await participantsClient.update(params);` |
+
+## MuteClient Endpoints
+
+The MuteClient instance gives access to the following `/communications/calls/{call-id}/participants/{participant-id}/mute` endpoints. You can get a `MuteClient` instance like so:
+
+```typescript
+const muteClient = await participantsClient.mute(participantId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action mute | `POST /communications/calls/{call-id}/participants/{participant-id}/mute` | `await muteClient.create(params);` |
+
+## StartHoldMusicClient Endpoints
+
+The StartHoldMusicClient instance gives access to the following `/communications/calls/{call-id}/participants/{participant-id}/startHoldMusic` endpoints. You can get a `StartHoldMusicClient` instance like so:
+
+```typescript
+const startHoldMusicClient = await participantsClient.startHoldMusic(participantId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action startHoldMusic | `POST /communications/calls/{call-id}/participants/{participant-id}/startHoldMusic` | `await startHoldMusicClient.create(params);` |
+
+## StopHoldMusicClient Endpoints
+
+The StopHoldMusicClient instance gives access to the following `/communications/calls/{call-id}/participants/{participant-id}/stopHoldMusic` endpoints. You can get a `StopHoldMusicClient` instance like so:
+
+```typescript
+const stopHoldMusicClient = await participantsClient.stopHoldMusic(participantId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action stopHoldMusic | `POST /communications/calls/{call-id}/participants/{participant-id}/stopHoldMusic` | `await stopHoldMusicClient.create(params);` |
+
+## InviteClient Endpoints
+
+The InviteClient instance gives access to the following `/communications/calls/{call-id}/participants/invite` endpoints. You can get a `InviteClient` instance like so:
+
+```typescript
+const inviteClient = participantsClient.invite;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action invite | `POST /communications/calls/{call-id}/participants/invite` | `await inviteClient.create(params);` |
+
+## LogTeleconferenceDeviceQualityClient Endpoints
+
+The LogTeleconferenceDeviceQualityClient instance gives access to the following `/communications/calls/logTeleconferenceDeviceQuality` endpoints. You can get a `LogTeleconferenceDeviceQualityClient` instance like so:
+
+```typescript
+const logTeleconferenceDeviceQualityClient = callsClient.logTeleconferenceDeviceQuality;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action logTeleconferenceDeviceQuality | `POST /communications/calls/logTeleconferenceDeviceQuality` | `await logTeleconferenceDeviceQualityClient.create(params);` |
+
+## GetPresencesByUserIdClient Endpoints
+
+The GetPresencesByUserIdClient instance gives access to the following `/communications/getPresencesByUserId` endpoints. You can get a `GetPresencesByUserIdClient` instance like so:
+
+```typescript
+const getPresencesByUserIdClient = communicationsClient.getPresencesByUserId;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getPresencesByUserId | `POST /communications/getPresencesByUserId` | `await getPresencesByUserIdClient.create(params);` |
+
+## OnlineMeetingsClient Endpoints
+
+The OnlineMeetingsClient instance gives access to the following `/communications/onlineMeetings` endpoints. You can get a `OnlineMeetingsClient` instance like so:
+
+```typescript
+const onlineMeetingsClient = communicationsClient.onlineMeetings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get onlineMeeting | `GET /communications/onlineMeetings` | `await onlineMeetingsClient.list(params);` |
+| Create new navigation property to onlineMeetings for communications | `POST /communications/onlineMeetings` | `await onlineMeetingsClient.create(params);` |
+| Get onlineMeetings from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}` | `await onlineMeetingsClient.get({"onlineMeeting-id": onlineMeetingId  });` |
+| Delete navigation property onlineMeetings for communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}` | `await onlineMeetingsClient.delete({"onlineMeeting-id": onlineMeetingId  });` |
+| Update the navigation property onlineMeetings in communications | `PATCH /communications/onlineMeetings/{onlineMeeting-id}` | `await onlineMeetingsClient.update(params);` |
+
+## AttendanceReportsClient Endpoints
+
+The AttendanceReportsClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/attendanceReports` endpoints. You can get a `AttendanceReportsClient` instance like so:
+
+```typescript
+const attendanceReportsClient = await onlineMeetingsClient.attendanceReports(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceReports from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports` | `await attendanceReportsClient.list(params);` |
+| Create new navigation property to attendanceReports for communications | `POST /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports` | `await attendanceReportsClient.create(params);` |
+| Get attendanceReports from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.get({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Delete navigation property attendanceReports for communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.delete({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Update the navigation property attendanceReports in communications | `PATCH /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.update(params);` |
+
+## AttendanceRecordsClient Endpoints
+
+The AttendanceRecordsClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` endpoints. You can get a `AttendanceRecordsClient` instance like so:
+
+```typescript
+const attendanceRecordsClient = await attendanceReportsClient.attendanceRecords(meetingAttendanceReportId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceRecords from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.list(params);` |
+| Create new navigation property to attendanceRecords for communications | `POST /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.create(params);` |
+| Get attendanceRecords from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.get({"attendanceRecord-id": attendanceRecordId  });` |
+| Delete navigation property attendanceRecords for communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.delete({"attendanceRecord-id": attendanceRecordId  });` |
+| Update the navigation property attendanceRecords in communications | `PATCH /communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.update(params);` |
+
+## AttendeeReportClient Endpoints
+
+The AttendeeReportClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/attendeeReport` endpoints. You can get a `AttendeeReportClient` instance like so:
+
+```typescript
+const attendeeReportClient = await onlineMeetingsClient.attendeeReport(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendeeReport for the navigation property onlineMeetings from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/attendeeReport` | `await attendeeReportClient.list(params);` |
+| Update attendeeReport for the navigation property onlineMeetings in communications | `PUT /communications/onlineMeetings/{onlineMeeting-id}/attendeeReport` | `await attendeeReportClient.set(body, {"onlineMeeting-id": onlineMeetingId  });` |
+| Delete attendeeReport for the navigation property onlineMeetings in communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/attendeeReport` | `await attendeeReportClient.delete({"onlineMeeting-id": onlineMeetingId  });` |
+
+## SendVirtualAppointmentReminderSmsClient Endpoints
+
+The SendVirtualAppointmentReminderSmsClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentReminderSms` endpoints. You can get a `SendVirtualAppointmentReminderSmsClient` instance like so:
+
+```typescript
+const sendVirtualAppointmentReminderSmsClient = await onlineMeetingsClient.sendVirtualAppointmentReminderSms(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendVirtualAppointmentReminderSms | `POST /communications/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentReminderSms` | `await sendVirtualAppointmentReminderSmsClient.create(params);` |
+
+## SendVirtualAppointmentSmsClient Endpoints
+
+The SendVirtualAppointmentSmsClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentSms` endpoints. You can get a `SendVirtualAppointmentSmsClient` instance like so:
+
+```typescript
+const sendVirtualAppointmentSmsClient = await onlineMeetingsClient.sendVirtualAppointmentSms(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendVirtualAppointmentSms | `POST /communications/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentSms` | `await sendVirtualAppointmentSmsClient.create(params);` |
+
+## RecordingsClient Endpoints
+
+The RecordingsClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/recordings` endpoints. You can get a `RecordingsClient` instance like so:
+
+```typescript
+const recordingsClient = await onlineMeetingsClient.recordings(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get recordings from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/recordings` | `await recordingsClient.list(params);` |
+| Create new navigation property to recordings for communications | `POST /communications/onlineMeetings/{onlineMeeting-id}/recordings` | `await recordingsClient.create(params);` |
+| Get recordings from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}` | `await recordingsClient.get({"callRecording-id": callRecordingId  });` |
+| Delete navigation property recordings for communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}` | `await recordingsClient.delete({"callRecording-id": callRecordingId  });` |
+| Update the navigation property recordings in communications | `PATCH /communications/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}` | `await recordingsClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await recordingsClient.content(callRecordingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property recordings from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property recordings in communications | `PUT /communications/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` | `await contentClient.set(body, {"callRecording-id": callRecordingId  });` |
+| Delete content for the navigation property recordings in communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` | `await contentClient.delete({"callRecording-id": callRecordingId  });` |
+
+## TranscriptsClient Endpoints
+
+The TranscriptsClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/transcripts` endpoints. You can get a `TranscriptsClient` instance like so:
+
+```typescript
+const transcriptsClient = await onlineMeetingsClient.transcripts(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get transcripts from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/transcripts` | `await transcriptsClient.list(params);` |
+| Create new navigation property to transcripts for communications | `POST /communications/onlineMeetings/{onlineMeeting-id}/transcripts` | `await transcriptsClient.create(params);` |
+| Get transcripts from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}` | `await transcriptsClient.get({"callTranscript-id": callTranscriptId  });` |
+| Delete navigation property transcripts for communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}` | `await transcriptsClient.delete({"callTranscript-id": callTranscriptId  });` |
+| Update the navigation property transcripts in communications | `PATCH /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}` | `await transcriptsClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await transcriptsClient.content(callTranscriptId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property transcripts from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property transcripts in communications | `PUT /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` | `await contentClient.set(body, {"callTranscript-id": callTranscriptId  });` |
+| Delete content for the navigation property transcripts in communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` | `await contentClient.delete({"callTranscript-id": callTranscriptId  });` |
+
+## MetadataContentClient Endpoints
+
+The MetadataContentClient instance gives access to the following `/communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` endpoints. You can get a `MetadataContentClient` instance like so:
+
+```typescript
+const metadataContentClient = await transcriptsClient.metadataContent(callTranscriptId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get metadataContent for the navigation property transcripts from communications | `GET /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` | `await metadataContentClient.list(params);` |
+| Update metadataContent for the navigation property transcripts in communications | `PUT /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` | `await metadataContentClient.set(body, {"callTranscript-id": callTranscriptId  });` |
+| Delete metadataContent for the navigation property transcripts in communications | `DELETE /communications/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` | `await metadataContentClient.delete({"callTranscript-id": callTranscriptId  });` |
+
+## CreateOrGetClient Endpoints
+
+The CreateOrGetClient instance gives access to the following `/communications/onlineMeetings/createOrGet` endpoints. You can get a `CreateOrGetClient` instance like so:
+
+```typescript
+const createOrGetClient = onlineMeetingsClient.createOrGet;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createOrGet | `POST /communications/onlineMeetings/createOrGet` | `await createOrGetClient.create(params);` |
+
+## PresencesClient Endpoints
+
+The PresencesClient instance gives access to the following `/communications/presences` endpoints. You can get a `PresencesClient` instance like so:
+
+```typescript
+const presencesClient = communicationsClient.presences;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get presence | `GET /communications/presences` | `await presencesClient.list(params);` |
+| Create new navigation property to presences for communications | `POST /communications/presences` | `await presencesClient.create(params);` |
+| Get presence | `GET /communications/presences/{presence-id}` | `await presencesClient.get({"presence-id": presenceId  });` |
+| Delete navigation property presences for communications | `DELETE /communications/presences/{presence-id}` | `await presencesClient.delete({"presence-id": presenceId  });` |
+| Update the navigation property presences in communications | `PATCH /communications/presences/{presence-id}` | `await presencesClient.update(params);` |
+
+## ClearPresenceClient Endpoints
+
+The ClearPresenceClient instance gives access to the following `/communications/presences/{presence-id}/clearPresence` endpoints. You can get a `ClearPresenceClient` instance like so:
+
+```typescript
+const clearPresenceClient = await presencesClient.clearPresence(presenceId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action clearPresence | `POST /communications/presences/{presence-id}/clearPresence` | `await clearPresenceClient.create(params);` |
+
+## ClearUserPreferredPresenceClient Endpoints
+
+The ClearUserPreferredPresenceClient instance gives access to the following `/communications/presences/{presence-id}/clearUserPreferredPresence` endpoints. You can get a `ClearUserPreferredPresenceClient` instance like so:
+
+```typescript
+const clearUserPreferredPresenceClient = await presencesClient.clearUserPreferredPresence(presenceId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action clearUserPreferredPresence | `POST /communications/presences/{presence-id}/clearUserPreferredPresence` | `await clearUserPreferredPresenceClient.create(params);` |
+
+## SetPresenceClient Endpoints
+
+The SetPresenceClient instance gives access to the following `/communications/presences/{presence-id}/setPresence` endpoints. You can get a `SetPresenceClient` instance like so:
+
+```typescript
+const setPresenceClient = await presencesClient.setPresence(presenceId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setPresence | `POST /communications/presences/{presence-id}/setPresence` | `await setPresenceClient.create(params);` |
+
+## SetStatusMessageClient Endpoints
+
+The SetStatusMessageClient instance gives access to the following `/communications/presences/{presence-id}/setStatusMessage` endpoints. You can get a `SetStatusMessageClient` instance like so:
+
+```typescript
+const setStatusMessageClient = await presencesClient.setStatusMessage(presenceId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setStatusMessage | `POST /communications/presences/{presence-id}/setStatusMessage` | `await setStatusMessageClient.create(params);` |
+
+## SetUserPreferredPresenceClient Endpoints
+
+The SetUserPreferredPresenceClient instance gives access to the following `/communications/presences/{presence-id}/setUserPreferredPresence` endpoints. You can get a `SetUserPreferredPresenceClient` instance like so:
+
+```typescript
+const setUserPreferredPresenceClient = await presencesClient.setUserPreferredPresence(presenceId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setUserPreferredPresence | `POST /communications/presences/{presence-id}/setUserPreferredPresence` | `await setUserPreferredPresenceClient.create(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/employee-experience.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/employee-experience.md
@@ -1,0 +1,55 @@
+# Employee Experience
+
+This page lists all the `/employeeExperience` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/employeeExperience` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/engagement-api-overview?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## LearningProvidersClient Endpoints
+
+The LearningProvidersClient instance gives access to the following `/employeeExperience/learningProviders` endpoints. You can get a `LearningProvidersClient` instance like so:
+
+```typescript
+const learningProvidersClient = employeeExperienceClient.learningProviders;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List learningProviders | `GET /employeeExperience/learningProviders` | `await learningProvidersClient.list(params);` |
+| Create learningProvider | `POST /employeeExperience/learningProviders` | `await learningProvidersClient.create(params);` |
+| Get learningProvider | `GET /employeeExperience/learningProviders/{learningProvider-id}` | `await learningProvidersClient.get({"learningProvider-id": learningProviderId  });` |
+| Delete learningProvider | `DELETE /employeeExperience/learningProviders/{learningProvider-id}` | `await learningProvidersClient.delete({"learningProvider-id": learningProviderId  });` |
+| Update learningProvider | `PATCH /employeeExperience/learningProviders/{learningProvider-id}` | `await learningProvidersClient.update(params);` |
+
+## LearningContentsClient Endpoints
+
+The LearningContentsClient instance gives access to the following `/employeeExperience/learningProviders/{learningProvider-id}/learningContents` endpoints. You can get a `LearningContentsClient` instance like so:
+
+```typescript
+const learningContentsClient = await learningProvidersClient.learningContents(learningProviderId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List learningContents | `GET /employeeExperience/learningProviders/{learningProvider-id}/learningContents` | `await learningContentsClient.list(params);` |
+| Create new navigation property to learningContents for employeeExperience | `POST /employeeExperience/learningProviders/{learningProvider-id}/learningContents` | `await learningContentsClient.create(params);` |
+| Get learningContent | `GET /employeeExperience/learningProviders/{learningProvider-id}/learningContents/{learningContent-id}` | `await learningContentsClient.get({"learningContent-id": learningContentId  });` |
+| Delete learningContent | `DELETE /employeeExperience/learningProviders/{learningProvider-id}/learningContents/{learningContent-id}` | `await learningContentsClient.delete({"learningContent-id": learningContentId  });` |
+| Update the navigation property learningContents in employeeExperience | `PATCH /employeeExperience/learningProviders/{learningProvider-id}/learningContents/{learningContent-id}` | `await learningContentsClient.update(params);` |
+
+## LearningCourseActivitiesClient Endpoints
+
+The LearningCourseActivitiesClient instance gives access to the following `/employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities` endpoints. You can get a `LearningCourseActivitiesClient` instance like so:
+
+```typescript
+const learningCourseActivitiesClient = await learningProvidersClient.learningCourseActivities(learningProviderId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get learningCourseActivity | `GET /employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities` | `await learningCourseActivitiesClient.list(params);` |
+| Create learningCourseActivity | `POST /employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities` | `await learningCourseActivitiesClient.create(params);` |
+| Get learningCourseActivities from employeeExperience | `GET /employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities/{learningCourseActivity-id}` | `await learningCourseActivitiesClient.get({"learningCourseActivity-id": learningCourseActivityId  });` |
+| Delete learningCourseActivity | `DELETE /employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities/{learningCourseActivity-id}` | `await learningCourseActivitiesClient.delete({"learningCourseActivity-id": learningCourseActivityId  });` |
+| Update learningCourseActivity | `PATCH /employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities/{learningCourseActivity-id}` | `await learningCourseActivitiesClient.update(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/me.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/me.md
@@ -1,0 +1,2602 @@
+# Me
+
+This page lists all the `/me` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/me` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## MeClient Endpoints
+
+The MeClient instance gives access to the following `/me` endpoints. You can get a `MeClient` instance like so:
+
+```typescript
+const meClient = graphClient.me;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get a user | `GET /me` | `await meClient.list(params);` |
+| Update user | `PATCH /me` | `await meClient.update(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = meClient.calendar;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar | `GET /me/calendar` | `await calendarClient.list(params);` |
+| Update calendar | `PATCH /me/calendar` | `await calendarClient.update(params);` |
+
+## CalendarPermissionsClient Endpoints
+
+The CalendarPermissionsClient instance gives access to the following `/me/calendar/calendarPermissions` endpoints. You can get a `CalendarPermissionsClient` instance like so:
+
+```typescript
+const calendarPermissionsClient = calendarClient.calendarPermissions;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendarPermissions from me | `GET /me/calendar/calendarPermissions` | `await calendarPermissionsClient.list(params);` |
+| Create calendarPermission | `POST /me/calendar/calendarPermissions` | `await calendarPermissionsClient.create(params);` |
+| Get calendarPermissions from me | `GET /me/calendar/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.get({"calendarPermission-id": calendarPermissionId  });` |
+| Delete navigation property calendarPermissions for me | `DELETE /me/calendar/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.delete({"calendarPermission-id": calendarPermissionId  });` |
+| Update the navigation property calendarPermissions in me | `PATCH /me/calendar/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.update(params);` |
+
+## CalendarViewClient Endpoints
+
+The CalendarViewClient instance gives access to the following `/me/calendar/calendarView` endpoints. You can get a `CalendarViewClient` instance like so:
+
+```typescript
+const calendarViewClient = calendarClient.calendarView;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List calendarView | `GET /me/calendar/calendarView` | `await calendarViewClient.list(params);` |
+| Get calendarView from me | `GET /me/calendar/calendarView/{event-id}` | `await calendarViewClient.get({"event-id": eventId  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendar/calendarView/{event-id}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await calendarViewClient.attachments(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendar/calendarView/{event-id}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendar/calendarView/{event-id}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendar/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendar/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendar/calendarView/{event-id}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendar/calendarView/{event-id}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendar/calendarView/{event-id}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await calendarViewClient.calendar(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendar/calendarView/{event-id}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendar/calendarView/{event-id}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await calendarViewClient.extensions(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendar/calendarView/{event-id}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendar/calendarView/{event-id}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendar/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendar/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendar/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## InstancesClient Endpoints
+
+The InstancesClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances` endpoints. You can get a `InstancesClient` instance like so:
+
+```typescript
+const instancesClient = await calendarViewClient.instances(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get instances from me | `GET /me/calendar/calendarView/{event-id}/instances` | `await instancesClient.list(params);` |
+| Get instances from me | `GET /me/calendar/calendarView/{event-id}/instances/{event-id1}` | `await instancesClient.get({"event-id1": eventId1  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await instancesClient.attachments(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await instancesClient.calendar(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendar/calendarView/{event-id}/instances/{event-id1}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await instancesClient.extensions(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendar/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendar/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendar/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendar/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await instancesClient.accept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await instancesClient.cancel(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await instancesClient.decline(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await instancesClient.dismissReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await instancesClient.forward(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await instancesClient.snoozeReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendar/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await instancesClient.tentativelyAccept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendar/calendarView/{event-id}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await calendarViewClient.accept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendar/calendarView/{event-id}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendar/calendarView/{event-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await calendarViewClient.cancel(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendar/calendarView/{event-id}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendar/calendarView/{event-id}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await calendarViewClient.decline(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendar/calendarView/{event-id}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendar/calendarView/{event-id}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await calendarViewClient.dismissReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendar/calendarView/{event-id}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendar/calendarView/{event-id}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await calendarViewClient.forward(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendar/calendarView/{event-id}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendar/calendarView/{event-id}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await calendarViewClient.snoozeReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendar/calendarView/{event-id}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendar/calendarView/{event-id}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await calendarViewClient.tentativelyAccept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendar/calendarView/{event-id}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## EventsClient Endpoints
+
+The EventsClient instance gives access to the following `/me/calendar/events` endpoints. You can get a `EventsClient` instance like so:
+
+```typescript
+const eventsClient = calendarClient.events;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List events | `GET /me/calendar/events` | `await eventsClient.list(params);` |
+| Create new navigation property to events for me | `POST /me/calendar/events` | `await eventsClient.create(params);` |
+| Get events from me | `GET /me/calendar/events/{event-id}` | `await eventsClient.get({"event-id": eventId  });` |
+| Delete navigation property events for me | `DELETE /me/calendar/events/{event-id}` | `await eventsClient.delete({"event-id": eventId  });` |
+| Update the navigation property events in me | `PATCH /me/calendar/events/{event-id}` | `await eventsClient.update(params);` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendar/events/{event-id}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await eventsClient.attachments(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendar/events/{event-id}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendar/events/{event-id}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendar/events/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendar/events/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendar/events/{event-id}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendar/events/{event-id}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendar/events/{event-id}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await eventsClient.calendar(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendar/events/{event-id}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendar/events/{event-id}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await eventsClient.extensions(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendar/events/{event-id}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendar/events/{event-id}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendar/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendar/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendar/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## InstancesClient Endpoints
+
+The InstancesClient instance gives access to the following `/me/calendar/events/{event-id}/instances` endpoints. You can get a `InstancesClient` instance like so:
+
+```typescript
+const instancesClient = await eventsClient.instances(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get instances from me | `GET /me/calendar/events/{event-id}/instances` | `await instancesClient.list(params);` |
+| Get instances from me | `GET /me/calendar/events/{event-id}/instances/{event-id1}` | `await instancesClient.get({"event-id1": eventId1  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await instancesClient.attachments(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendar/events/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendar/events/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendar/events/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendar/events/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendar/events/{event-id}/instances/{event-id1}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await instancesClient.calendar(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendar/events/{event-id}/instances/{event-id1}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await instancesClient.extensions(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendar/events/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendar/events/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendar/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendar/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendar/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await instancesClient.accept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendar/events/{event-id}/instances/{event-id1}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await instancesClient.cancel(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendar/events/{event-id}/instances/{event-id1}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await instancesClient.decline(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendar/events/{event-id}/instances/{event-id1}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await instancesClient.dismissReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendar/events/{event-id}/instances/{event-id1}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await instancesClient.forward(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendar/events/{event-id}/instances/{event-id1}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await instancesClient.snoozeReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendar/events/{event-id}/instances/{event-id1}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendar/events/{event-id}/instances/{event-id1}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await instancesClient.tentativelyAccept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendar/events/{event-id}/instances/{event-id1}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendar/events/{event-id}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await eventsClient.accept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendar/events/{event-id}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendar/events/{event-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await eventsClient.cancel(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendar/events/{event-id}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendar/events/{event-id}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await eventsClient.decline(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendar/events/{event-id}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendar/events/{event-id}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await eventsClient.dismissReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendar/events/{event-id}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendar/events/{event-id}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await eventsClient.forward(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendar/events/{event-id}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendar/events/{event-id}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await eventsClient.snoozeReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendar/events/{event-id}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendar/events/{event-id}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await eventsClient.tentativelyAccept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendar/events/{event-id}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## GetScheduleClient Endpoints
+
+The GetScheduleClient instance gives access to the following `/me/calendar/getSchedule` endpoints. You can get a `GetScheduleClient` instance like so:
+
+```typescript
+const getScheduleClient = calendarClient.getSchedule;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getSchedule | `POST /me/calendar/getSchedule` | `await getScheduleClient.create(params);` |
+
+## CalendarGroupsClient Endpoints
+
+The CalendarGroupsClient instance gives access to the following `/me/calendarGroups` endpoints. You can get a `CalendarGroupsClient` instance like so:
+
+```typescript
+const calendarGroupsClient = meClient.calendarGroups;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List calendarGroups | `GET /me/calendarGroups` | `await calendarGroupsClient.list(params);` |
+| Create CalendarGroup | `POST /me/calendarGroups` | `await calendarGroupsClient.create(params);` |
+| Get calendarGroup | `GET /me/calendarGroups/{calendarGroup-id}` | `await calendarGroupsClient.get({"calendarGroup-id": calendarGroupId  });` |
+| Delete calendarGroup | `DELETE /me/calendarGroups/{calendarGroup-id}` | `await calendarGroupsClient.delete({"calendarGroup-id": calendarGroupId  });` |
+| Update calendargroup | `PATCH /me/calendarGroups/{calendarGroup-id}` | `await calendarGroupsClient.update(params);` |
+
+## CalendarsClient Endpoints
+
+The CalendarsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars` endpoints. You can get a `CalendarsClient` instance like so:
+
+```typescript
+const calendarsClient = await calendarGroupsClient.calendars(calendarGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List calendars | `GET /me/calendarGroups/{calendarGroup-id}/calendars` | `await calendarsClient.list(params);` |
+| Create Calendar | `POST /me/calendarGroups/{calendarGroup-id}/calendars` | `await calendarsClient.create(params);` |
+| Get calendars from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}` | `await calendarsClient.get({"calendar-id": calendarId  });` |
+| Delete navigation property calendars for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}` | `await calendarsClient.delete({"calendar-id": calendarId  });` |
+| Update the navigation property calendars in me | `PATCH /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}` | `await calendarsClient.update(params);` |
+
+## CalendarPermissionsClient Endpoints
+
+The CalendarPermissionsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarPermissions` endpoints. You can get a `CalendarPermissionsClient` instance like so:
+
+```typescript
+const calendarPermissionsClient = await calendarsClient.calendarPermissions(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendarPermissions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarPermissions` | `await calendarPermissionsClient.list(params);` |
+| Create new navigation property to calendarPermissions for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarPermissions` | `await calendarPermissionsClient.create(params);` |
+| Get calendarPermissions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.get({"calendarPermission-id": calendarPermissionId  });` |
+| Delete navigation property calendarPermissions for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.delete({"calendarPermission-id": calendarPermissionId  });` |
+| Update the navigation property calendarPermissions in me | `PATCH /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.update(params);` |
+
+## CalendarViewClient Endpoints
+
+The CalendarViewClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView` endpoints. You can get a `CalendarViewClient` instance like so:
+
+```typescript
+const calendarViewClient = await calendarsClient.calendarView(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendarView from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView` | `await calendarViewClient.list(params);` |
+| Get calendarView from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}` | `await calendarViewClient.get({"event-id": eventId  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await calendarViewClient.attachments(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await calendarViewClient.calendar(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await calendarViewClient.extensions(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## InstancesClient Endpoints
+
+The InstancesClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances` endpoints. You can get a `InstancesClient` instance like so:
+
+```typescript
+const instancesClient = await calendarViewClient.instances(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get instances from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances` | `await instancesClient.list(params);` |
+| Get instances from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}` | `await instancesClient.get({"event-id1": eventId1  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await instancesClient.attachments(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await instancesClient.calendar(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await instancesClient.extensions(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await instancesClient.accept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await instancesClient.cancel(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await instancesClient.decline(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await instancesClient.dismissReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await instancesClient.forward(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await instancesClient.snoozeReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await instancesClient.tentativelyAccept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await calendarViewClient.accept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await calendarViewClient.cancel(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await calendarViewClient.decline(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await calendarViewClient.dismissReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await calendarViewClient.forward(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await calendarViewClient.snoozeReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await calendarViewClient.tentativelyAccept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## EventsClient Endpoints
+
+The EventsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events` endpoints. You can get a `EventsClient` instance like so:
+
+```typescript
+const eventsClient = await calendarsClient.events(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get events from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events` | `await eventsClient.list(params);` |
+| Create new navigation property to events for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events` | `await eventsClient.create(params);` |
+| Get events from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}` | `await eventsClient.get({"event-id": eventId  });` |
+| Delete navigation property events for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}` | `await eventsClient.delete({"event-id": eventId  });` |
+| Update the navigation property events in me | `PATCH /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}` | `await eventsClient.update(params);` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await eventsClient.attachments(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await eventsClient.calendar(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await eventsClient.extensions(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## InstancesClient Endpoints
+
+The InstancesClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances` endpoints. You can get a `InstancesClient` instance like so:
+
+```typescript
+const instancesClient = await eventsClient.instances(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get instances from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances` | `await instancesClient.list(params);` |
+| Get instances from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}` | `await instancesClient.get({"event-id1": eventId1  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await instancesClient.attachments(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await instancesClient.calendar(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await instancesClient.extensions(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await instancesClient.accept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await instancesClient.cancel(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await instancesClient.decline(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await instancesClient.dismissReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await instancesClient.forward(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await instancesClient.snoozeReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await instancesClient.tentativelyAccept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await eventsClient.accept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await eventsClient.cancel(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await eventsClient.decline(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await eventsClient.dismissReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await eventsClient.forward(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await eventsClient.snoozeReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await eventsClient.tentativelyAccept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## GetScheduleClient Endpoints
+
+The GetScheduleClient instance gives access to the following `/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/getSchedule` endpoints. You can get a `GetScheduleClient` instance like so:
+
+```typescript
+const getScheduleClient = await calendarsClient.getSchedule(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getSchedule | `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/getSchedule` | `await getScheduleClient.create(params);` |
+
+## CalendarsClient Endpoints
+
+The CalendarsClient instance gives access to the following `/me/calendars` endpoints. You can get a `CalendarsClient` instance like so:
+
+```typescript
+const calendarsClient = meClient.calendars;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List calendars | `GET /me/calendars` | `await calendarsClient.list(params);` |
+| Create calendar | `POST /me/calendars` | `await calendarsClient.create(params);` |
+| Get calendars from me | `GET /me/calendars/{calendar-id}` | `await calendarsClient.get({"calendar-id": calendarId  });` |
+| Delete navigation property calendars for me | `DELETE /me/calendars/{calendar-id}` | `await calendarsClient.delete({"calendar-id": calendarId  });` |
+| Update the navigation property calendars in me | `PATCH /me/calendars/{calendar-id}` | `await calendarsClient.update(params);` |
+
+## CalendarPermissionsClient Endpoints
+
+The CalendarPermissionsClient instance gives access to the following `/me/calendars/{calendar-id}/calendarPermissions` endpoints. You can get a `CalendarPermissionsClient` instance like so:
+
+```typescript
+const calendarPermissionsClient = await calendarsClient.calendarPermissions(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendarPermissions from me | `GET /me/calendars/{calendar-id}/calendarPermissions` | `await calendarPermissionsClient.list(params);` |
+| Create new navigation property to calendarPermissions for me | `POST /me/calendars/{calendar-id}/calendarPermissions` | `await calendarPermissionsClient.create(params);` |
+| Get calendarPermissions from me | `GET /me/calendars/{calendar-id}/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.get({"calendarPermission-id": calendarPermissionId  });` |
+| Delete navigation property calendarPermissions for me | `DELETE /me/calendars/{calendar-id}/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.delete({"calendarPermission-id": calendarPermissionId  });` |
+| Update the navigation property calendarPermissions in me | `PATCH /me/calendars/{calendar-id}/calendarPermissions/{calendarPermission-id}` | `await calendarPermissionsClient.update(params);` |
+
+## CalendarViewClient Endpoints
+
+The CalendarViewClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView` endpoints. You can get a `CalendarViewClient` instance like so:
+
+```typescript
+const calendarViewClient = await calendarsClient.calendarView(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendarView from me | `GET /me/calendars/{calendar-id}/calendarView` | `await calendarViewClient.list(params);` |
+| Get calendarView from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}` | `await calendarViewClient.get({"event-id": eventId  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await calendarViewClient.attachments(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendars/{calendar-id}/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await calendarViewClient.calendar(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await calendarViewClient.extensions(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendars/{calendar-id}/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendars/{calendar-id}/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## InstancesClient Endpoints
+
+The InstancesClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances` endpoints. You can get a `InstancesClient` instance like so:
+
+```typescript
+const instancesClient = await calendarViewClient.instances(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get instances from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/instances` | `await instancesClient.list(params);` |
+| Get instances from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}` | `await instancesClient.get({"event-id1": eventId1  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await instancesClient.attachments(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await instancesClient.calendar(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await instancesClient.extensions(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await instancesClient.accept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await instancesClient.cancel(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await instancesClient.decline(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await instancesClient.dismissReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await instancesClient.forward(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await instancesClient.snoozeReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await instancesClient.tentativelyAccept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await calendarViewClient.accept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await calendarViewClient.cancel(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await calendarViewClient.decline(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await calendarViewClient.dismissReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await calendarViewClient.forward(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await calendarViewClient.snoozeReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendars/{calendar-id}/calendarView/{event-id}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await calendarViewClient.tentativelyAccept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendars/{calendar-id}/calendarView/{event-id}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## EventsClient Endpoints
+
+The EventsClient instance gives access to the following `/me/calendars/{calendar-id}/events` endpoints. You can get a `EventsClient` instance like so:
+
+```typescript
+const eventsClient = await calendarsClient.events(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get events from me | `GET /me/calendars/{calendar-id}/events` | `await eventsClient.list(params);` |
+| Create event | `POST /me/calendars/{calendar-id}/events` | `await eventsClient.create(params);` |
+| Get events from me | `GET /me/calendars/{calendar-id}/events/{event-id}` | `await eventsClient.get({"event-id": eventId  });` |
+| Delete navigation property events for me | `DELETE /me/calendars/{calendar-id}/events/{event-id}` | `await eventsClient.delete({"event-id": eventId  });` |
+| Update the navigation property events in me | `PATCH /me/calendars/{calendar-id}/events/{event-id}` | `await eventsClient.update(params);` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await eventsClient.attachments(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendars/{calendar-id}/events/{event-id}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendars/{calendar-id}/events/{event-id}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendars/{calendar-id}/events/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendars/{calendar-id}/events/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendars/{calendar-id}/events/{event-id}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await eventsClient.calendar(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendars/{calendar-id}/events/{event-id}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await eventsClient.extensions(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendars/{calendar-id}/events/{event-id}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendars/{calendar-id}/events/{event-id}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendars/{calendar-id}/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendars/{calendar-id}/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendars/{calendar-id}/events/{event-id}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## InstancesClient Endpoints
+
+The InstancesClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances` endpoints. You can get a `InstancesClient` instance like so:
+
+```typescript
+const instancesClient = await eventsClient.instances(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get instances from me | `GET /me/calendars/{calendar-id}/events/{event-id}/instances` | `await instancesClient.list(params);` |
+| Get instances from me | `GET /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}` | `await instancesClient.get({"event-id1": eventId1  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await instancesClient.attachments(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await instancesClient.calendar(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await instancesClient.extensions(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await instancesClient.accept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await instancesClient.cancel(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await instancesClient.decline(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await instancesClient.dismissReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await instancesClient.forward(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await instancesClient.snoozeReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await instancesClient.tentativelyAccept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await eventsClient.accept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendars/{calendar-id}/events/{event-id}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await eventsClient.cancel(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendars/{calendar-id}/events/{event-id}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await eventsClient.decline(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendars/{calendar-id}/events/{event-id}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await eventsClient.dismissReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendars/{calendar-id}/events/{event-id}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await eventsClient.forward(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendars/{calendar-id}/events/{event-id}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await eventsClient.snoozeReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendars/{calendar-id}/events/{event-id}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendars/{calendar-id}/events/{event-id}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await eventsClient.tentativelyAccept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendars/{calendar-id}/events/{event-id}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## GetScheduleClient Endpoints
+
+The GetScheduleClient instance gives access to the following `/me/calendars/{calendar-id}/getSchedule` endpoints. You can get a `GetScheduleClient` instance like so:
+
+```typescript
+const getScheduleClient = await calendarsClient.getSchedule(calendarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getSchedule | `POST /me/calendars/{calendar-id}/getSchedule` | `await getScheduleClient.create(params);` |
+
+## CalendarViewClient Endpoints
+
+The CalendarViewClient instance gives access to the following `/me/calendarView` endpoints. You can get a `CalendarViewClient` instance like so:
+
+```typescript
+const calendarViewClient = meClient.calendarView;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List calendarView | `GET /me/calendarView` | `await calendarViewClient.list(params);` |
+| Get calendarView from me | `GET /me/calendarView/{event-id}` | `await calendarViewClient.get({"event-id": eventId  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendarView/{event-id}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await calendarViewClient.attachments(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendarView/{event-id}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendarView/{event-id}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendarView/{event-id}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendarView/{event-id}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendarView/{event-id}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendarView/{event-id}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await calendarViewClient.calendar(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendarView/{event-id}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendarView/{event-id}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await calendarViewClient.extensions(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendarView/{event-id}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendarView/{event-id}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendarView/{event-id}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## InstancesClient Endpoints
+
+The InstancesClient instance gives access to the following `/me/calendarView/{event-id}/instances` endpoints. You can get a `InstancesClient` instance like so:
+
+```typescript
+const instancesClient = await calendarViewClient.instances(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get instances from me | `GET /me/calendarView/{event-id}/instances` | `await instancesClient.list(params);` |
+| Get instances from me | `GET /me/calendarView/{event-id}/instances/{event-id1}` | `await instancesClient.get({"event-id1": eventId1  });` |
+
+## AttachmentsClient Endpoints
+
+The AttachmentsClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/attachments` endpoints. You can get a `AttachmentsClient` instance like so:
+
+```typescript
+const attachmentsClient = await instancesClient.attachments(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attachments from me | `GET /me/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.list(params);` |
+| Create new navigation property to attachments for me | `POST /me/calendarView/{event-id}/instances/{event-id1}/attachments` | `await attachmentsClient.create(params);` |
+| Get attachments from me | `GET /me/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.get({"attachment-id": attachmentId  });` |
+| Delete navigation property attachments for me | `DELETE /me/calendarView/{event-id}/instances/{event-id1}/attachments/{attachment-id}` | `await attachmentsClient.delete({"attachment-id": attachmentId  });` |
+
+## CreateUploadSessionClient Endpoints
+
+The CreateUploadSessionClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` endpoints. You can get a `CreateUploadSessionClient` instance like so:
+
+```typescript
+const createUploadSessionClient = attachmentsClient.createUploadSession;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createUploadSession | `POST /me/calendarView/{event-id}/instances/{event-id1}/attachments/createUploadSession` | `await createUploadSessionClient.create(params);` |
+
+## CalendarClient Endpoints
+
+The CalendarClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/calendar` endpoints. You can get a `CalendarClient` instance like so:
+
+```typescript
+const calendarClient = await instancesClient.calendar(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get calendar from me | `GET /me/calendarView/{event-id}/instances/{event-id1}/calendar` | `await calendarClient.list(params);` |
+
+## ExtensionsClient Endpoints
+
+The ExtensionsClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/extensions` endpoints. You can get a `ExtensionsClient` instance like so:
+
+```typescript
+const extensionsClient = await instancesClient.extensions(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get extensions from me | `GET /me/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.list(params);` |
+| Create new navigation property to extensions for me | `POST /me/calendarView/{event-id}/instances/{event-id1}/extensions` | `await extensionsClient.create(params);` |
+| Get extensions from me | `GET /me/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.get({"extension-id": extensionId  });` |
+| Delete navigation property extensions for me | `DELETE /me/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.delete({"extension-id": extensionId  });` |
+| Update the navigation property extensions in me | `PATCH /me/calendarView/{event-id}/instances/{event-id1}/extensions/{extension-id}` | `await extensionsClient.update(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await instancesClient.accept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendarView/{event-id}/instances/{event-id1}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await instancesClient.cancel(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendarView/{event-id}/instances/{event-id1}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await instancesClient.decline(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendarView/{event-id}/instances/{event-id1}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await instancesClient.dismissReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendarView/{event-id}/instances/{event-id1}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await instancesClient.forward(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendarView/{event-id}/instances/{event-id1}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await instancesClient.snoozeReminder(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendarView/{event-id}/instances/{event-id1}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await instancesClient.tentativelyAccept(eventId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendarView/{event-id}/instances/{event-id1}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## AcceptClient Endpoints
+
+The AcceptClient instance gives access to the following `/me/calendarView/{event-id}/accept` endpoints. You can get a `AcceptClient` instance like so:
+
+```typescript
+const acceptClient = await calendarViewClient.accept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action accept | `POST /me/calendarView/{event-id}/accept` | `await acceptClient.create(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/me/calendarView/{event-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await calendarViewClient.cancel(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /me/calendarView/{event-id}/cancel` | `await cancelClient.create(params);` |
+
+## DeclineClient Endpoints
+
+The DeclineClient instance gives access to the following `/me/calendarView/{event-id}/decline` endpoints. You can get a `DeclineClient` instance like so:
+
+```typescript
+const declineClient = await calendarViewClient.decline(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action decline | `POST /me/calendarView/{event-id}/decline` | `await declineClient.create(params);` |
+
+## DismissReminderClient Endpoints
+
+The DismissReminderClient instance gives access to the following `/me/calendarView/{event-id}/dismissReminder` endpoints. You can get a `DismissReminderClient` instance like so:
+
+```typescript
+const dismissReminderClient = await calendarViewClient.dismissReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action dismissReminder | `POST /me/calendarView/{event-id}/dismissReminder` | `await dismissReminderClient.create(params);` |
+
+## ForwardClient Endpoints
+
+The ForwardClient instance gives access to the following `/me/calendarView/{event-id}/forward` endpoints. You can get a `ForwardClient` instance like so:
+
+```typescript
+const forwardClient = await calendarViewClient.forward(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action forward | `POST /me/calendarView/{event-id}/forward` | `await forwardClient.create(params);` |
+
+## SnoozeReminderClient Endpoints
+
+The SnoozeReminderClient instance gives access to the following `/me/calendarView/{event-id}/snoozeReminder` endpoints. You can get a `SnoozeReminderClient` instance like so:
+
+```typescript
+const snoozeReminderClient = await calendarViewClient.snoozeReminder(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action snoozeReminder | `POST /me/calendarView/{event-id}/snoozeReminder` | `await snoozeReminderClient.create(params);` |
+
+## TentativelyAcceptClient Endpoints
+
+The TentativelyAcceptClient instance gives access to the following `/me/calendarView/{event-id}/tentativelyAccept` endpoints. You can get a `TentativelyAcceptClient` instance like so:
+
+```typescript
+const tentativelyAcceptClient = await calendarViewClient.tentativelyAccept(eventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action tentativelyAccept | `POST /me/calendarView/{event-id}/tentativelyAccept` | `await tentativelyAcceptClient.create(params);` |
+
+## ChatsClient Endpoints
+
+The ChatsClient instance gives access to the following `/me/chats` endpoints. You can get a `ChatsClient` instance like so:
+
+```typescript
+const chatsClient = meClient.chats;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get chats from me | `GET /me/chats` | `await chatsClient.list(params);` |
+| Create new navigation property to chats for me | `POST /me/chats` | `await chatsClient.create(params);` |
+| Get chats from me | `GET /me/chats/{chat-id}` | `await chatsClient.get({"chat-id": chatId  });` |
+| Delete navigation property chats for me | `DELETE /me/chats/{chat-id}` | `await chatsClient.delete({"chat-id": chatId  });` |
+| Update the navigation property chats in me | `PATCH /me/chats/{chat-id}` | `await chatsClient.update(params);` |
+
+## InstalledAppsClient Endpoints
+
+The InstalledAppsClient instance gives access to the following `/me/chats/{chat-id}/installedApps` endpoints. You can get a `InstalledAppsClient` instance like so:
+
+```typescript
+const installedAppsClient = await chatsClient.installedApps(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get installedApps from me | `GET /me/chats/{chat-id}/installedApps` | `await installedAppsClient.list(params);` |
+| Create new navigation property to installedApps for me | `POST /me/chats/{chat-id}/installedApps` | `await installedAppsClient.create(params);` |
+| Get installedApps from me | `GET /me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.get({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Delete navigation property installedApps for me | `DELETE /me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.delete({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Update the navigation property installedApps in me | `PATCH /me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.update(params);` |
+
+## UpgradeClient Endpoints
+
+The UpgradeClient instance gives access to the following `/me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/upgrade` endpoints. You can get a `UpgradeClient` instance like so:
+
+```typescript
+const upgradeClient = await installedAppsClient.upgrade(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action upgrade | `POST /me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/upgrade` | `await upgradeClient.create(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await installedAppsClient.teamsApp(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from me | `GET /me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## TeamsAppDefinitionClient Endpoints
+
+The TeamsAppDefinitionClient instance gives access to the following `/me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` endpoints. You can get a `TeamsAppDefinitionClient` instance like so:
+
+```typescript
+const teamsAppDefinitionClient = await installedAppsClient.teamsAppDefinition(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsAppDefinition from me | `GET /me/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` | `await teamsAppDefinitionClient.list(params);` |
+
+## LastMessagePreviewClient Endpoints
+
+The LastMessagePreviewClient instance gives access to the following `/me/chats/{chat-id}/lastMessagePreview` endpoints. You can get a `LastMessagePreviewClient` instance like so:
+
+```typescript
+const lastMessagePreviewClient = await chatsClient.lastMessagePreview(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastMessagePreview from me | `GET /me/chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.list(params);` |
+| Delete navigation property lastMessagePreview for me | `DELETE /me/chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.delete({"chat-id": chatId  });` |
+| Update the navigation property lastMessagePreview in me | `PATCH /me/chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.update(params);` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/me/chats/{chat-id}/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = await chatsClient.members(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List members of a chat | `GET /me/chats/{chat-id}/members` | `await membersClient.list(params);` |
+| Create new navigation property to members for me | `POST /me/chats/{chat-id}/members` | `await membersClient.create(params);` |
+| Get members from me | `GET /me/chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.get({"conversationMember-id": conversationMemberId  });` |
+| Delete navigation property members for me | `DELETE /me/chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.delete({"conversationMember-id": conversationMemberId  });` |
+| Update the navigation property members in me | `PATCH /me/chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.update(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/me/chats/{chat-id}/members/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = membersClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /me/chats/{chat-id}/members/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/me/chats/{chat-id}/members/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = membersClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /me/chats/{chat-id}/members/remove` | `await removeClient.create(params);` |
+
+## MessagesClient Endpoints
+
+The MessagesClient instance gives access to the following `/me/chats/{chat-id}/messages` endpoints. You can get a `MessagesClient` instance like so:
+
+```typescript
+const messagesClient = await chatsClient.messages(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get messages from me | `GET /me/chats/{chat-id}/messages` | `await messagesClient.list(params);` |
+| Create new navigation property to messages for me | `POST /me/chats/{chat-id}/messages` | `await messagesClient.create(params);` |
+| Get messages from me | `GET /me/chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.get({"chatMessage-id": chatMessageId  });` |
+| Delete navigation property messages for me | `DELETE /me/chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.delete({"chatMessage-id": chatMessageId  });` |
+| Update the navigation property messages in me | `PATCH /me/chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await messagesClient.hostedContents(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from me | `GET /me/chats/{chat-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for me | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from me | `GET /me/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for me | `DELETE /me/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in me | `PATCH /me/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await messagesClient.setReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await messagesClient.softDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await messagesClient.undoSoftDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await messagesClient.unsetReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## RepliesClient Endpoints
+
+The RepliesClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/replies` endpoints. You can get a `RepliesClient` instance like so:
+
+```typescript
+const repliesClient = await messagesClient.replies(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get replies from me | `GET /me/chats/{chat-id}/messages/{chatMessage-id}/replies` | `await repliesClient.list(params);` |
+| Create new navigation property to replies for me | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/replies` | `await repliesClient.create(params);` |
+| Get replies from me | `GET /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.get({"chatMessage-id1": chatMessageId1  });` |
+| Delete navigation property replies for me | `DELETE /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.delete({"chatMessage-id1": chatMessageId1  });` |
+| Update the navigation property replies in me | `PATCH /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await repliesClient.hostedContents(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from me | `GET /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for me | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from me | `GET /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for me | `DELETE /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in me | `PATCH /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await repliesClient.setReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await repliesClient.softDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await repliesClient.undoSoftDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await repliesClient.unsetReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## HideForUserClient Endpoints
+
+The HideForUserClient instance gives access to the following `/me/chats/{chat-id}/hideForUser` endpoints. You can get a `HideForUserClient` instance like so:
+
+```typescript
+const hideForUserClient = await chatsClient.hideForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action hideForUser | `POST /me/chats/{chat-id}/hideForUser` | `await hideForUserClient.create(params);` |
+
+## MarkChatReadForUserClient Endpoints
+
+The MarkChatReadForUserClient instance gives access to the following `/me/chats/{chat-id}/markChatReadForUser` endpoints. You can get a `MarkChatReadForUserClient` instance like so:
+
+```typescript
+const markChatReadForUserClient = await chatsClient.markChatReadForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action markChatReadForUser | `POST /me/chats/{chat-id}/markChatReadForUser` | `await markChatReadForUserClient.create(params);` |
+
+## MarkChatUnreadForUserClient Endpoints
+
+The MarkChatUnreadForUserClient instance gives access to the following `/me/chats/{chat-id}/markChatUnreadForUser` endpoints. You can get a `MarkChatUnreadForUserClient` instance like so:
+
+```typescript
+const markChatUnreadForUserClient = await chatsClient.markChatUnreadForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action markChatUnreadForUser | `POST /me/chats/{chat-id}/markChatUnreadForUser` | `await markChatUnreadForUserClient.create(params);` |
+
+## SendActivityNotificationClient Endpoints
+
+The SendActivityNotificationClient instance gives access to the following `/me/chats/{chat-id}/sendActivityNotification` endpoints. You can get a `SendActivityNotificationClient` instance like so:
+
+```typescript
+const sendActivityNotificationClient = await chatsClient.sendActivityNotification(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendActivityNotification | `POST /me/chats/{chat-id}/sendActivityNotification` | `await sendActivityNotificationClient.create(params);` |
+
+## UnhideForUserClient Endpoints
+
+The UnhideForUserClient instance gives access to the following `/me/chats/{chat-id}/unhideForUser` endpoints. You can get a `UnhideForUserClient` instance like so:
+
+```typescript
+const unhideForUserClient = await chatsClient.unhideForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unhideForUser | `POST /me/chats/{chat-id}/unhideForUser` | `await unhideForUserClient.create(params);` |
+
+## PermissionGrantsClient Endpoints
+
+The PermissionGrantsClient instance gives access to the following `/me/chats/{chat-id}/permissionGrants` endpoints. You can get a `PermissionGrantsClient` instance like so:
+
+```typescript
+const permissionGrantsClient = await chatsClient.permissionGrants(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get permissionGrants from me | `GET /me/chats/{chat-id}/permissionGrants` | `await permissionGrantsClient.list(params);` |
+| Create new navigation property to permissionGrants for me | `POST /me/chats/{chat-id}/permissionGrants` | `await permissionGrantsClient.create(params);` |
+| Get permissionGrants from me | `GET /me/chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.get({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Delete navigation property permissionGrants for me | `DELETE /me/chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.delete({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Update the navigation property permissionGrants in me | `PATCH /me/chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.update(params);` |
+
+## PinnedMessagesClient Endpoints
+
+The PinnedMessagesClient instance gives access to the following `/me/chats/{chat-id}/pinnedMessages` endpoints. You can get a `PinnedMessagesClient` instance like so:
+
+```typescript
+const pinnedMessagesClient = await chatsClient.pinnedMessages(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get pinnedMessages from me | `GET /me/chats/{chat-id}/pinnedMessages` | `await pinnedMessagesClient.list(params);` |
+| Create new navigation property to pinnedMessages for me | `POST /me/chats/{chat-id}/pinnedMessages` | `await pinnedMessagesClient.create(params);` |
+| Get pinnedMessages from me | `GET /me/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.get({"pinnedChatMessageInfo-id": pinnedChatMessageInfoId  });` |
+| Delete navigation property pinnedMessages for me | `DELETE /me/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.delete({"pinnedChatMessageInfo-id": pinnedChatMessageInfoId  });` |
+| Update the navigation property pinnedMessages in me | `PATCH /me/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.update(params);` |
+
+## MessageClient Endpoints
+
+The MessageClient instance gives access to the following `/me/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}/message` endpoints. You can get a `MessageClient` instance like so:
+
+```typescript
+const messageClient = await pinnedMessagesClient.message(pinnedChatMessageInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get message from me | `GET /me/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}/message` | `await messageClient.list(params);` |
+
+## TabsClient Endpoints
+
+The TabsClient instance gives access to the following `/me/chats/{chat-id}/tabs` endpoints. You can get a `TabsClient` instance like so:
+
+```typescript
+const tabsClient = await chatsClient.tabs(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get tabs from me | `GET /me/chats/{chat-id}/tabs` | `await tabsClient.list(params);` |
+| Create new navigation property to tabs for me | `POST /me/chats/{chat-id}/tabs` | `await tabsClient.create(params);` |
+| Get tabs from me | `GET /me/chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.get({"teamsTab-id": teamsTabId  });` |
+| Delete navigation property tabs for me | `DELETE /me/chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.delete({"teamsTab-id": teamsTabId  });` |
+| Update the navigation property tabs in me | `PATCH /me/chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.update(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/me/chats/{chat-id}/tabs/{teamsTab-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await tabsClient.teamsApp(teamsTabId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from me | `GET /me/chats/{chat-id}/tabs/{teamsTab-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## PhotoClient Endpoints
+
+The PhotoClient instance gives access to the following `/me/photo` endpoints. You can get a `PhotoClient` instance like so:
+
+```typescript
+const photoClient = meClient.photo;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get profilePhoto | `GET /me/photo` | `await photoClient.list(params);` |
+| Delete profilePhoto | `DELETE /me/photo` | `await photoClient.delete({"":   });` |
+| Update profilePhoto | `PATCH /me/photo` | `await photoClient.update(params);` |
+
+## PhotosClient Endpoints
+
+The PhotosClient instance gives access to the following `/me/photos` endpoints. You can get a `PhotosClient` instance like so:
+
+```typescript
+const photosClient = meClient.photos;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get photos from me | `GET /me/photos` | `await photosClient.list(params);` |
+| Get photos from me | `GET /me/photos/{profilePhoto-id}` | `await photosClient.get({"profilePhoto-id": profilePhotoId  });` |
+
+## PresenceClient Endpoints
+
+The PresenceClient instance gives access to the following `/me/presence` endpoints. You can get a `PresenceClient` instance like so:
+
+```typescript
+const presenceClient = meClient.presence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get presence | `GET /me/presence` | `await presenceClient.list(params);` |
+| Delete navigation property presence for me | `DELETE /me/presence` | `await presenceClient.delete({"":   });` |
+| Update the navigation property presence in me | `PATCH /me/presence` | `await presenceClient.update(params);` |
+
+## ClearPresenceClient Endpoints
+
+The ClearPresenceClient instance gives access to the following `/me/presence/clearPresence` endpoints. You can get a `ClearPresenceClient` instance like so:
+
+```typescript
+const clearPresenceClient = presenceClient.clearPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action clearPresence | `POST /me/presence/clearPresence` | `await clearPresenceClient.create(params);` |
+
+## ClearUserPreferredPresenceClient Endpoints
+
+The ClearUserPreferredPresenceClient instance gives access to the following `/me/presence/clearUserPreferredPresence` endpoints. You can get a `ClearUserPreferredPresenceClient` instance like so:
+
+```typescript
+const clearUserPreferredPresenceClient = presenceClient.clearUserPreferredPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action clearUserPreferredPresence | `POST /me/presence/clearUserPreferredPresence` | `await clearUserPreferredPresenceClient.create(params);` |
+
+## SetPresenceClient Endpoints
+
+The SetPresenceClient instance gives access to the following `/me/presence/setPresence` endpoints. You can get a `SetPresenceClient` instance like so:
+
+```typescript
+const setPresenceClient = presenceClient.setPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setPresence | `POST /me/presence/setPresence` | `await setPresenceClient.create(params);` |
+
+## SetStatusMessageClient Endpoints
+
+The SetStatusMessageClient instance gives access to the following `/me/presence/setStatusMessage` endpoints. You can get a `SetStatusMessageClient` instance like so:
+
+```typescript
+const setStatusMessageClient = presenceClient.setStatusMessage;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setStatusMessage | `POST /me/presence/setStatusMessage` | `await setStatusMessageClient.create(params);` |
+
+## SetUserPreferredPresenceClient Endpoints
+
+The SetUserPreferredPresenceClient instance gives access to the following `/me/presence/setUserPreferredPresence` endpoints. You can get a `SetUserPreferredPresenceClient` instance like so:
+
+```typescript
+const setUserPreferredPresenceClient = presenceClient.setUserPreferredPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setUserPreferredPresence | `POST /me/presence/setUserPreferredPresence` | `await setUserPreferredPresenceClient.create(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/sites.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/sites.md
@@ -1,0 +1,4149 @@
+# Sites
+
+This page lists all the `/sites` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/sites` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/site?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## SitesClient Endpoints
+
+The SitesClient instance gives access to the following `/sites` endpoints. You can get a `SitesClient` instance like so:
+
+```typescript
+const sitesClient = graphClient.sites;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List sites | `GET /sites` | `await sitesClient.list(params);` |
+| Get a site resource | `GET /sites/{site-id}` | `await sitesClient.get({"site-id": siteId  });` |
+| Update entity in sites | `PATCH /sites/{site-id}` | `await sitesClient.update(params);` |
+
+## AnalyticsClient Endpoints
+
+The AnalyticsClient instance gives access to the following `/sites/{site-id}/analytics` endpoints. You can get a `AnalyticsClient` instance like so:
+
+```typescript
+const analyticsClient = await sitesClient.analytics(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get analytics from sites | `GET /sites/{site-id}/analytics` | `await analyticsClient.list(params);` |
+| Delete navigation property analytics for sites | `DELETE /sites/{site-id}/analytics` | `await analyticsClient.delete({"site-id": siteId  });` |
+| Update the navigation property analytics in sites | `PATCH /sites/{site-id}/analytics` | `await analyticsClient.update(params);` |
+
+## AllTimeClient Endpoints
+
+The AllTimeClient instance gives access to the following `/sites/{site-id}/analytics/allTime` endpoints. You can get a `AllTimeClient` instance like so:
+
+```typescript
+const allTimeClient = analyticsClient.allTime;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get allTime from sites | `GET /sites/{site-id}/analytics/allTime` | `await allTimeClient.list(params);` |
+
+## ItemActivityStatsClient Endpoints
+
+The ItemActivityStatsClient instance gives access to the following `/sites/{site-id}/analytics/itemActivityStats` endpoints. You can get a `ItemActivityStatsClient` instance like so:
+
+```typescript
+const itemActivityStatsClient = analyticsClient.itemActivityStats;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get itemActivityStats from sites | `GET /sites/{site-id}/analytics/itemActivityStats` | `await itemActivityStatsClient.list(params);` |
+| Create new navigation property to itemActivityStats for sites | `POST /sites/{site-id}/analytics/itemActivityStats` | `await itemActivityStatsClient.create(params);` |
+| Get itemActivityStats from sites | `GET /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}` | `await itemActivityStatsClient.get({"itemActivityStat-id": itemActivityStatId  });` |
+| Delete navigation property itemActivityStats for sites | `DELETE /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}` | `await itemActivityStatsClient.delete({"itemActivityStat-id": itemActivityStatId  });` |
+| Update the navigation property itemActivityStats in sites | `PATCH /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}` | `await itemActivityStatsClient.update(params);` |
+
+## ActivitiesClient Endpoints
+
+The ActivitiesClient instance gives access to the following `/sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities` endpoints. You can get a `ActivitiesClient` instance like so:
+
+```typescript
+const activitiesClient = await itemActivityStatsClient.activities(itemActivityStatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get activities from sites | `GET /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities` | `await activitiesClient.list(params);` |
+| Create new navigation property to activities for sites | `POST /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities` | `await activitiesClient.create(params);` |
+| Get activities from sites | `GET /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}` | `await activitiesClient.get({"itemActivity-id": itemActivityId  });` |
+| Delete navigation property activities for sites | `DELETE /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}` | `await activitiesClient.delete({"itemActivity-id": itemActivityId  });` |
+| Update the navigation property activities in sites | `PATCH /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}` | `await activitiesClient.update(params);` |
+
+## DriveItemClient Endpoints
+
+The DriveItemClient instance gives access to the following `/sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}/driveItem` endpoints. You can get a `DriveItemClient` instance like so:
+
+```typescript
+const driveItemClient = await activitiesClient.driveItem(itemActivityId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get driveItem from sites | `GET /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}/driveItem` | `await driveItemClient.list(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}/driveItem/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = driveItemClient.content;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property driveItem from sites | `GET /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}/driveItem/content` | `await contentClient.list(params);` |
+| Update content for the navigation property driveItem in sites | `PUT /sites/{site-id}/analytics/itemActivityStats/{itemActivityStat-id}/activities/{itemActivity-id}/driveItem/content` | `await contentClient.set(body, {"":   });` |
+
+## LastSevenDaysClient Endpoints
+
+The LastSevenDaysClient instance gives access to the following `/sites/{site-id}/analytics/lastSevenDays` endpoints. You can get a `LastSevenDaysClient` instance like so:
+
+```typescript
+const lastSevenDaysClient = analyticsClient.lastSevenDays;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastSevenDays from sites | `GET /sites/{site-id}/analytics/lastSevenDays` | `await lastSevenDaysClient.list(params);` |
+
+## ColumnsClient Endpoints
+
+The ColumnsClient instance gives access to the following `/sites/{site-id}/columns` endpoints. You can get a `ColumnsClient` instance like so:
+
+```typescript
+const columnsClient = await sitesClient.columns(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List columns in a site | `GET /sites/{site-id}/columns` | `await columnsClient.list(params);` |
+| Create a columnDefinition in a site | `POST /sites/{site-id}/columns` | `await columnsClient.create(params);` |
+| Get columns from sites | `GET /sites/{site-id}/columns/{columnDefinition-id}` | `await columnsClient.get({"columnDefinition-id": columnDefinitionId  });` |
+| Delete navigation property columns for sites | `DELETE /sites/{site-id}/columns/{columnDefinition-id}` | `await columnsClient.delete({"columnDefinition-id": columnDefinitionId  });` |
+| Update the navigation property columns in sites | `PATCH /sites/{site-id}/columns/{columnDefinition-id}` | `await columnsClient.update(params);` |
+
+## SourceColumnClient Endpoints
+
+The SourceColumnClient instance gives access to the following `/sites/{site-id}/columns/{columnDefinition-id}/sourceColumn` endpoints. You can get a `SourceColumnClient` instance like so:
+
+```typescript
+const sourceColumnClient = await columnsClient.sourceColumn(columnDefinitionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sourceColumn from sites | `GET /sites/{site-id}/columns/{columnDefinition-id}/sourceColumn` | `await sourceColumnClient.list(params);` |
+
+## ContentTypesClient Endpoints
+
+The ContentTypesClient instance gives access to the following `/sites/{site-id}/contentTypes` endpoints. You can get a `ContentTypesClient` instance like so:
+
+```typescript
+const contentTypesClient = await sitesClient.contentTypes(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List contentTypes in a site | `GET /sites/{site-id}/contentTypes` | `await contentTypesClient.list(params);` |
+| Create a content type | `POST /sites/{site-id}/contentTypes` | `await contentTypesClient.create(params);` |
+| Get contentType | `GET /sites/{site-id}/contentTypes/{contentType-id}` | `await contentTypesClient.get({"contentType-id": contentTypeId  });` |
+| Delete contentType | `DELETE /sites/{site-id}/contentTypes/{contentType-id}` | `await contentTypesClient.delete({"contentType-id": contentTypeId  });` |
+| Update contentType | `PATCH /sites/{site-id}/contentTypes/{contentType-id}` | `await contentTypesClient.update(params);` |
+
+## BaseClient Endpoints
+
+The BaseClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/base` endpoints. You can get a `BaseClient` instance like so:
+
+```typescript
+const baseClient = await contentTypesClient.base(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get base from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/base` | `await baseClient.list(params);` |
+
+## BaseTypesClient Endpoints
+
+The BaseTypesClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/baseTypes` endpoints. You can get a `BaseTypesClient` instance like so:
+
+```typescript
+const baseTypesClient = await contentTypesClient.baseTypes(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get baseTypes from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/baseTypes` | `await baseTypesClient.list(params);` |
+| Get baseTypes from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/baseTypes/{contentType-id1}` | `await baseTypesClient.get({"contentType-id1": contentTypeId1  });` |
+
+## ColumnLinksClient Endpoints
+
+The ColumnLinksClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/columnLinks` endpoints. You can get a `ColumnLinksClient` instance like so:
+
+```typescript
+const columnLinksClient = await contentTypesClient.columnLinks(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get columnLinks from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/columnLinks` | `await columnLinksClient.list(params);` |
+| Create new navigation property to columnLinks for sites | `POST /sites/{site-id}/contentTypes/{contentType-id}/columnLinks` | `await columnLinksClient.create(params);` |
+| Get columnLinks from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/columnLinks/{columnLink-id}` | `await columnLinksClient.get({"columnLink-id": columnLinkId  });` |
+| Delete navigation property columnLinks for sites | `DELETE /sites/{site-id}/contentTypes/{contentType-id}/columnLinks/{columnLink-id}` | `await columnLinksClient.delete({"columnLink-id": columnLinkId  });` |
+| Update the navigation property columnLinks in sites | `PATCH /sites/{site-id}/contentTypes/{contentType-id}/columnLinks/{columnLink-id}` | `await columnLinksClient.update(params);` |
+
+## ColumnPositionsClient Endpoints
+
+The ColumnPositionsClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/columnPositions` endpoints. You can get a `ColumnPositionsClient` instance like so:
+
+```typescript
+const columnPositionsClient = await contentTypesClient.columnPositions(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get columnPositions from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/columnPositions` | `await columnPositionsClient.list(params);` |
+| Get columnPositions from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/columnPositions/{columnDefinition-id}` | `await columnPositionsClient.get({"columnDefinition-id": columnDefinitionId  });` |
+
+## ColumnsClient Endpoints
+
+The ColumnsClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/columns` endpoints. You can get a `ColumnsClient` instance like so:
+
+```typescript
+const columnsClient = await contentTypesClient.columns(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List columnDefinitions in a content type | `GET /sites/{site-id}/contentTypes/{contentType-id}/columns` | `await columnsClient.list(params);` |
+| Create a columnDefinition in a content type | `POST /sites/{site-id}/contentTypes/{contentType-id}/columns` | `await columnsClient.create(params);` |
+| Get columnDefinition | `GET /sites/{site-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}` | `await columnsClient.get({"columnDefinition-id": columnDefinitionId  });` |
+| Delete columnDefinition | `DELETE /sites/{site-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}` | `await columnsClient.delete({"columnDefinition-id": columnDefinitionId  });` |
+| Update columnDefinition | `PATCH /sites/{site-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}` | `await columnsClient.update(params);` |
+
+## SourceColumnClient Endpoints
+
+The SourceColumnClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}/sourceColumn` endpoints. You can get a `SourceColumnClient` instance like so:
+
+```typescript
+const sourceColumnClient = await columnsClient.sourceColumn(columnDefinitionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sourceColumn from sites | `GET /sites/{site-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}/sourceColumn` | `await sourceColumnClient.list(params);` |
+
+## AssociateWithHubSitesClient Endpoints
+
+The AssociateWithHubSitesClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/associateWithHubSites` endpoints. You can get a `AssociateWithHubSitesClient` instance like so:
+
+```typescript
+const associateWithHubSitesClient = await contentTypesClient.associateWithHubSites(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action associateWithHubSites | `POST /sites/{site-id}/contentTypes/{contentType-id}/associateWithHubSites` | `await associateWithHubSitesClient.create(params);` |
+
+## CopyToDefaultContentLocationClient Endpoints
+
+The CopyToDefaultContentLocationClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/copyToDefaultContentLocation` endpoints. You can get a `CopyToDefaultContentLocationClient` instance like so:
+
+```typescript
+const copyToDefaultContentLocationClient = await contentTypesClient.copyToDefaultContentLocation(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToDefaultContentLocation | `POST /sites/{site-id}/contentTypes/{contentType-id}/copyToDefaultContentLocation` | `await copyToDefaultContentLocationClient.create(params);` |
+
+## PublishClient Endpoints
+
+The PublishClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/publish` endpoints. You can get a `PublishClient` instance like so:
+
+```typescript
+const publishClient = await contentTypesClient.publish(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action publish | `POST /sites/{site-id}/contentTypes/{contentType-id}/publish` | `await publishClient.create(params);` |
+
+## UnpublishClient Endpoints
+
+The UnpublishClient instance gives access to the following `/sites/{site-id}/contentTypes/{contentType-id}/unpublish` endpoints. You can get a `UnpublishClient` instance like so:
+
+```typescript
+const unpublishClient = await contentTypesClient.unpublish(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unpublish | `POST /sites/{site-id}/contentTypes/{contentType-id}/unpublish` | `await unpublishClient.create(params);` |
+
+## AddCopyClient Endpoints
+
+The AddCopyClient instance gives access to the following `/sites/{site-id}/contentTypes/addCopy` endpoints. You can get a `AddCopyClient` instance like so:
+
+```typescript
+const addCopyClient = contentTypesClient.addCopy;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action addCopy | `POST /sites/{site-id}/contentTypes/addCopy` | `await addCopyClient.create(params);` |
+
+## AddCopyFromContentTypeHubClient Endpoints
+
+The AddCopyFromContentTypeHubClient instance gives access to the following `/sites/{site-id}/contentTypes/addCopyFromContentTypeHub` endpoints. You can get a `AddCopyFromContentTypeHubClient` instance like so:
+
+```typescript
+const addCopyFromContentTypeHubClient = contentTypesClient.addCopyFromContentTypeHub;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action addCopyFromContentTypeHub | `POST /sites/{site-id}/contentTypes/addCopyFromContentTypeHub` | `await addCopyFromContentTypeHubClient.create(params);` |
+
+## CreatedByUserClient Endpoints
+
+The CreatedByUserClient instance gives access to the following `/sites/{site-id}/createdByUser` endpoints. You can get a `CreatedByUserClient` instance like so:
+
+```typescript
+const createdByUserClient = await sitesClient.createdByUser(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get createdByUser from sites | `GET /sites/{site-id}/createdByUser` | `await createdByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/createdByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = createdByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/createdByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = createdByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/createdByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## DriveClient Endpoints
+
+The DriveClient instance gives access to the following `/sites/{site-id}/drive` endpoints. You can get a `DriveClient` instance like so:
+
+```typescript
+const driveClient = await sitesClient.drive(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get drive from sites | `GET /sites/{site-id}/drive` | `await driveClient.list(params);` |
+
+## DrivesClient Endpoints
+
+The DrivesClient instance gives access to the following `/sites/{site-id}/drives` endpoints. You can get a `DrivesClient` instance like so:
+
+```typescript
+const drivesClient = await sitesClient.drives(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get drives from sites | `GET /sites/{site-id}/drives` | `await drivesClient.list(params);` |
+| Get drives from sites | `GET /sites/{site-id}/drives/{drive-id}` | `await drivesClient.get({"drive-id": driveId  });` |
+
+## ExternalColumnsClient Endpoints
+
+The ExternalColumnsClient instance gives access to the following `/sites/{site-id}/externalColumns` endpoints. You can get a `ExternalColumnsClient` instance like so:
+
+```typescript
+const externalColumnsClient = await sitesClient.externalColumns(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get externalColumns from sites | `GET /sites/{site-id}/externalColumns` | `await externalColumnsClient.list(params);` |
+| Get externalColumns from sites | `GET /sites/{site-id}/externalColumns/{columnDefinition-id}` | `await externalColumnsClient.get({"columnDefinition-id": columnDefinitionId  });` |
+
+## ItemsClient Endpoints
+
+The ItemsClient instance gives access to the following `/sites/{site-id}/items` endpoints. You can get a `ItemsClient` instance like so:
+
+```typescript
+const itemsClient = await sitesClient.items(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get items from sites | `GET /sites/{site-id}/items` | `await itemsClient.list(params);` |
+| Get items from sites | `GET /sites/{site-id}/items/{baseItem-id}` | `await itemsClient.get({"baseItem-id": baseItemId  });` |
+
+## LastModifiedByUserClient Endpoints
+
+The LastModifiedByUserClient instance gives access to the following `/sites/{site-id}/lastModifiedByUser` endpoints. You can get a `LastModifiedByUserClient` instance like so:
+
+```typescript
+const lastModifiedByUserClient = await sitesClient.lastModifiedByUser(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastModifiedByUser from sites | `GET /sites/{site-id}/lastModifiedByUser` | `await lastModifiedByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/lastModifiedByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = lastModifiedByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/lastModifiedByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = lastModifiedByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/lastModifiedByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## ListsClient Endpoints
+
+The ListsClient instance gives access to the following `/sites/{site-id}/lists` endpoints. You can get a `ListsClient` instance like so:
+
+```typescript
+const listsClient = await sitesClient.lists(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lists in a site | `GET /sites/{site-id}/lists` | `await listsClient.list(params);` |
+| Create a new list | `POST /sites/{site-id}/lists` | `await listsClient.create(params);` |
+| Get metadata for a list | `GET /sites/{site-id}/lists/{list-id}` | `await listsClient.get({"list-id": listId  });` |
+| Delete navigation property lists for sites | `DELETE /sites/{site-id}/lists/{list-id}` | `await listsClient.delete({"list-id": listId  });` |
+| Update the navigation property lists in sites | `PATCH /sites/{site-id}/lists/{list-id}` | `await listsClient.update(params);` |
+
+## ColumnsClient Endpoints
+
+The ColumnsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/columns` endpoints. You can get a `ColumnsClient` instance like so:
+
+```typescript
+const columnsClient = await listsClient.columns(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List columnDefinitions in a list | `GET /sites/{site-id}/lists/{list-id}/columns` | `await columnsClient.list(params);` |
+| Create a columnDefinition in a list | `POST /sites/{site-id}/lists/{list-id}/columns` | `await columnsClient.create(params);` |
+| Get columns from sites | `GET /sites/{site-id}/lists/{list-id}/columns/{columnDefinition-id}` | `await columnsClient.get({"columnDefinition-id": columnDefinitionId  });` |
+| Delete navigation property columns for sites | `DELETE /sites/{site-id}/lists/{list-id}/columns/{columnDefinition-id}` | `await columnsClient.delete({"columnDefinition-id": columnDefinitionId  });` |
+| Update the navigation property columns in sites | `PATCH /sites/{site-id}/lists/{list-id}/columns/{columnDefinition-id}` | `await columnsClient.update(params);` |
+
+## SourceColumnClient Endpoints
+
+The SourceColumnClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/columns/{columnDefinition-id}/sourceColumn` endpoints. You can get a `SourceColumnClient` instance like so:
+
+```typescript
+const sourceColumnClient = await columnsClient.sourceColumn(columnDefinitionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sourceColumn from sites | `GET /sites/{site-id}/lists/{list-id}/columns/{columnDefinition-id}/sourceColumn` | `await sourceColumnClient.list(params);` |
+
+## ContentTypesClient Endpoints
+
+The ContentTypesClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes` endpoints. You can get a `ContentTypesClient` instance like so:
+
+```typescript
+const contentTypesClient = await listsClient.contentTypes(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List contentTypes in a list | `GET /sites/{site-id}/lists/{list-id}/contentTypes` | `await contentTypesClient.list(params);` |
+| Create new navigation property to contentTypes for sites | `POST /sites/{site-id}/lists/{list-id}/contentTypes` | `await contentTypesClient.create(params);` |
+| Get contentTypes from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}` | `await contentTypesClient.get({"contentType-id": contentTypeId  });` |
+| Delete navigation property contentTypes for sites | `DELETE /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}` | `await contentTypesClient.delete({"contentType-id": contentTypeId  });` |
+| Update the navigation property contentTypes in sites | `PATCH /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}` | `await contentTypesClient.update(params);` |
+
+## BaseClient Endpoints
+
+The BaseClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/base` endpoints. You can get a `BaseClient` instance like so:
+
+```typescript
+const baseClient = await contentTypesClient.base(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get base from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/base` | `await baseClient.list(params);` |
+
+## BaseTypesClient Endpoints
+
+The BaseTypesClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/baseTypes` endpoints. You can get a `BaseTypesClient` instance like so:
+
+```typescript
+const baseTypesClient = await contentTypesClient.baseTypes(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get baseTypes from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/baseTypes` | `await baseTypesClient.list(params);` |
+| Get baseTypes from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/baseTypes/{contentType-id1}` | `await baseTypesClient.get({"contentType-id1": contentTypeId1  });` |
+
+## ColumnLinksClient Endpoints
+
+The ColumnLinksClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnLinks` endpoints. You can get a `ColumnLinksClient` instance like so:
+
+```typescript
+const columnLinksClient = await contentTypesClient.columnLinks(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get columnLinks from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnLinks` | `await columnLinksClient.list(params);` |
+| Create new navigation property to columnLinks for sites | `POST /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnLinks` | `await columnLinksClient.create(params);` |
+| Get columnLinks from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnLinks/{columnLink-id}` | `await columnLinksClient.get({"columnLink-id": columnLinkId  });` |
+| Delete navigation property columnLinks for sites | `DELETE /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnLinks/{columnLink-id}` | `await columnLinksClient.delete({"columnLink-id": columnLinkId  });` |
+| Update the navigation property columnLinks in sites | `PATCH /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnLinks/{columnLink-id}` | `await columnLinksClient.update(params);` |
+
+## ColumnPositionsClient Endpoints
+
+The ColumnPositionsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnPositions` endpoints. You can get a `ColumnPositionsClient` instance like so:
+
+```typescript
+const columnPositionsClient = await contentTypesClient.columnPositions(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get columnPositions from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnPositions` | `await columnPositionsClient.list(params);` |
+| Get columnPositions from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columnPositions/{columnDefinition-id}` | `await columnPositionsClient.get({"columnDefinition-id": columnDefinitionId  });` |
+
+## ColumnsClient Endpoints
+
+The ColumnsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns` endpoints. You can get a `ColumnsClient` instance like so:
+
+```typescript
+const columnsClient = await contentTypesClient.columns(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get columns from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns` | `await columnsClient.list(params);` |
+| Create new navigation property to columns for sites | `POST /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns` | `await columnsClient.create(params);` |
+| Get columns from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}` | `await columnsClient.get({"columnDefinition-id": columnDefinitionId  });` |
+| Delete navigation property columns for sites | `DELETE /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}` | `await columnsClient.delete({"columnDefinition-id": columnDefinitionId  });` |
+| Update the navigation property columns in sites | `PATCH /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}` | `await columnsClient.update(params);` |
+
+## SourceColumnClient Endpoints
+
+The SourceColumnClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}/sourceColumn` endpoints. You can get a `SourceColumnClient` instance like so:
+
+```typescript
+const sourceColumnClient = await columnsClient.sourceColumn(columnDefinitionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sourceColumn from sites | `GET /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/columns/{columnDefinition-id}/sourceColumn` | `await sourceColumnClient.list(params);` |
+
+## AssociateWithHubSitesClient Endpoints
+
+The AssociateWithHubSitesClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/associateWithHubSites` endpoints. You can get a `AssociateWithHubSitesClient` instance like so:
+
+```typescript
+const associateWithHubSitesClient = await contentTypesClient.associateWithHubSites(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action associateWithHubSites | `POST /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/associateWithHubSites` | `await associateWithHubSitesClient.create(params);` |
+
+## CopyToDefaultContentLocationClient Endpoints
+
+The CopyToDefaultContentLocationClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/copyToDefaultContentLocation` endpoints. You can get a `CopyToDefaultContentLocationClient` instance like so:
+
+```typescript
+const copyToDefaultContentLocationClient = await contentTypesClient.copyToDefaultContentLocation(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToDefaultContentLocation | `POST /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/copyToDefaultContentLocation` | `await copyToDefaultContentLocationClient.create(params);` |
+
+## PublishClient Endpoints
+
+The PublishClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/publish` endpoints. You can get a `PublishClient` instance like so:
+
+```typescript
+const publishClient = await contentTypesClient.publish(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action publish | `POST /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/publish` | `await publishClient.create(params);` |
+
+## UnpublishClient Endpoints
+
+The UnpublishClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/unpublish` endpoints. You can get a `UnpublishClient` instance like so:
+
+```typescript
+const unpublishClient = await contentTypesClient.unpublish(contentTypeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unpublish | `POST /sites/{site-id}/lists/{list-id}/contentTypes/{contentType-id}/unpublish` | `await unpublishClient.create(params);` |
+
+## AddCopyClient Endpoints
+
+The AddCopyClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/addCopy` endpoints. You can get a `AddCopyClient` instance like so:
+
+```typescript
+const addCopyClient = contentTypesClient.addCopy;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action addCopy | `POST /sites/{site-id}/lists/{list-id}/contentTypes/addCopy` | `await addCopyClient.create(params);` |
+
+## AddCopyFromContentTypeHubClient Endpoints
+
+The AddCopyFromContentTypeHubClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/contentTypes/addCopyFromContentTypeHub` endpoints. You can get a `AddCopyFromContentTypeHubClient` instance like so:
+
+```typescript
+const addCopyFromContentTypeHubClient = contentTypesClient.addCopyFromContentTypeHub;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action addCopyFromContentTypeHub | `POST /sites/{site-id}/lists/{list-id}/contentTypes/addCopyFromContentTypeHub` | `await addCopyFromContentTypeHubClient.create(params);` |
+
+## CreatedByUserClient Endpoints
+
+The CreatedByUserClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/createdByUser` endpoints. You can get a `CreatedByUserClient` instance like so:
+
+```typescript
+const createdByUserClient = await listsClient.createdByUser(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get createdByUser from sites | `GET /sites/{site-id}/lists/{list-id}/createdByUser` | `await createdByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/createdByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = createdByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/lists/{list-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/lists/{list-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/createdByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = createdByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/lists/{list-id}/createdByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## DriveClient Endpoints
+
+The DriveClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/drive` endpoints. You can get a `DriveClient` instance like so:
+
+```typescript
+const driveClient = await listsClient.drive(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get drive from sites | `GET /sites/{site-id}/lists/{list-id}/drive` | `await driveClient.list(params);` |
+
+## ItemsClient Endpoints
+
+The ItemsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items` endpoints. You can get a `ItemsClient` instance like so:
+
+```typescript
+const itemsClient = await listsClient.items(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Enumerate items in a list | `GET /sites/{site-id}/lists/{list-id}/items` | `await itemsClient.list(params);` |
+| Create a new item in a list | `POST /sites/{site-id}/lists/{list-id}/items` | `await itemsClient.create(params);` |
+| Get listItem | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}` | `await itemsClient.get({"listItem-id": listItemId  });` |
+| Delete an item from a list | `DELETE /sites/{site-id}/lists/{list-id}/items/{listItem-id}` | `await itemsClient.delete({"listItem-id": listItemId  });` |
+| Update the navigation property items in sites | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}` | `await itemsClient.update(params);` |
+
+## AnalyticsClient Endpoints
+
+The AnalyticsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/analytics` endpoints. You can get a `AnalyticsClient` instance like so:
+
+```typescript
+const analyticsClient = await itemsClient.analytics(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get analytics from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/analytics` | `await analyticsClient.list(params);` |
+
+## CreatedByUserClient Endpoints
+
+The CreatedByUserClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/createdByUser` endpoints. You can get a `CreatedByUserClient` instance like so:
+
+```typescript
+const createdByUserClient = await itemsClient.createdByUser(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get createdByUser from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/createdByUser` | `await createdByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/createdByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = createdByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/createdByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = createdByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/createdByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## DocumentSetVersionsClient Endpoints
+
+The DocumentSetVersionsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions` endpoints. You can get a `DocumentSetVersionsClient` instance like so:
+
+```typescript
+const documentSetVersionsClient = await itemsClient.documentSetVersions(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List documentSetVersions | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions` | `await documentSetVersionsClient.list(params);` |
+| Create documentSetVersion | `POST /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions` | `await documentSetVersionsClient.create(params);` |
+| Get documentSetVersion | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}` | `await documentSetVersionsClient.get({"documentSetVersion-id": documentSetVersionId  });` |
+| Delete documentSetVersion | `DELETE /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}` | `await documentSetVersionsClient.delete({"documentSetVersion-id": documentSetVersionId  });` |
+| Update the navigation property documentSetVersions in sites | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}` | `await documentSetVersionsClient.update(params);` |
+
+## FieldsClient Endpoints
+
+The FieldsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}/fields` endpoints. You can get a `FieldsClient` instance like so:
+
+```typescript
+const fieldsClient = await documentSetVersionsClient.fields(documentSetVersionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fields from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}/fields` | `await fieldsClient.list(params);` |
+| Delete navigation property fields for sites | `DELETE /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}/fields` | `await fieldsClient.delete({"documentSetVersion-id": documentSetVersionId  });` |
+| Update the navigation property fields in sites | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}/fields` | `await fieldsClient.update(params);` |
+
+## RestoreClient Endpoints
+
+The RestoreClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}/restore` endpoints. You can get a `RestoreClient` instance like so:
+
+```typescript
+const restoreClient = await documentSetVersionsClient.restore(documentSetVersionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action restore | `POST /sites/{site-id}/lists/{list-id}/items/{listItem-id}/documentSetVersions/{documentSetVersion-id}/restore` | `await restoreClient.create(params);` |
+
+## DriveItemClient Endpoints
+
+The DriveItemClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/driveItem` endpoints. You can get a `DriveItemClient` instance like so:
+
+```typescript
+const driveItemClient = await itemsClient.driveItem(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get driveItem from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/driveItem` | `await driveItemClient.list(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/driveItem/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = driveItemClient.content;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property driveItem from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/driveItem/content` | `await contentClient.list(params);` |
+| Update content for the navigation property driveItem in sites | `PUT /sites/{site-id}/lists/{list-id}/items/{listItem-id}/driveItem/content` | `await contentClient.set(body, {"":   });` |
+
+## FieldsClient Endpoints
+
+The FieldsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/fields` endpoints. You can get a `FieldsClient` instance like so:
+
+```typescript
+const fieldsClient = await itemsClient.fields(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fields from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/fields` | `await fieldsClient.list(params);` |
+| Delete navigation property fields for sites | `DELETE /sites/{site-id}/lists/{list-id}/items/{listItem-id}/fields` | `await fieldsClient.delete({"listItem-id": listItemId  });` |
+| Update listItem | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}/fields` | `await fieldsClient.update(params);` |
+
+## LastModifiedByUserClient Endpoints
+
+The LastModifiedByUserClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/lastModifiedByUser` endpoints. You can get a `LastModifiedByUserClient` instance like so:
+
+```typescript
+const lastModifiedByUserClient = await itemsClient.lastModifiedByUser(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastModifiedByUser from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/lastModifiedByUser` | `await lastModifiedByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/lastModifiedByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = lastModifiedByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/lastModifiedByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = lastModifiedByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/lastModifiedByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## CreateLinkClient Endpoints
+
+The CreateLinkClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/createLink` endpoints. You can get a `CreateLinkClient` instance like so:
+
+```typescript
+const createLinkClient = await itemsClient.createLink(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createLink | `POST /sites/{site-id}/lists/{list-id}/items/{listItem-id}/createLink` | `await createLinkClient.create(params);` |
+
+## VersionsClient Endpoints
+
+The VersionsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions` endpoints. You can get a `VersionsClient` instance like so:
+
+```typescript
+const versionsClient = await itemsClient.versions(listItemId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Listing versions of a ListItem | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions` | `await versionsClient.list(params);` |
+| Create new navigation property to versions for sites | `POST /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions` | `await versionsClient.create(params);` |
+| Get a ListItemVersion resource | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}` | `await versionsClient.get({"listItemVersion-id": listItemVersionId  });` |
+| Delete navigation property versions for sites | `DELETE /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}` | `await versionsClient.delete({"listItemVersion-id": listItemVersionId  });` |
+| Update the navigation property versions in sites | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}` | `await versionsClient.update(params);` |
+
+## FieldsClient Endpoints
+
+The FieldsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}/fields` endpoints. You can get a `FieldsClient` instance like so:
+
+```typescript
+const fieldsClient = await versionsClient.fields(listItemVersionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fields from sites | `GET /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}/fields` | `await fieldsClient.list(params);` |
+| Delete navigation property fields for sites | `DELETE /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}/fields` | `await fieldsClient.delete({"listItemVersion-id": listItemVersionId  });` |
+| Update the navigation property fields in sites | `PATCH /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}/fields` | `await fieldsClient.update(params);` |
+
+## RestoreVersionClient Endpoints
+
+The RestoreVersionClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}/restoreVersion` endpoints. You can get a `RestoreVersionClient` instance like so:
+
+```typescript
+const restoreVersionClient = await versionsClient.restoreVersion(listItemVersionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action restoreVersion | `POST /sites/{site-id}/lists/{list-id}/items/{listItem-id}/versions/{listItemVersion-id}/restoreVersion` | `await restoreVersionClient.create(params);` |
+
+## LastModifiedByUserClient Endpoints
+
+The LastModifiedByUserClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/lastModifiedByUser` endpoints. You can get a `LastModifiedByUserClient` instance like so:
+
+```typescript
+const lastModifiedByUserClient = await listsClient.lastModifiedByUser(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastModifiedByUser from sites | `GET /sites/{site-id}/lists/{list-id}/lastModifiedByUser` | `await lastModifiedByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/lastModifiedByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = lastModifiedByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/lists/{list-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/lists/{list-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/lastModifiedByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = lastModifiedByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/lists/{list-id}/lastModifiedByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## OperationsClient Endpoints
+
+The OperationsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/operations` endpoints. You can get a `OperationsClient` instance like so:
+
+```typescript
+const operationsClient = await listsClient.operations(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get operations from sites | `GET /sites/{site-id}/lists/{list-id}/operations` | `await operationsClient.list(params);` |
+| Create new navigation property to operations for sites | `POST /sites/{site-id}/lists/{list-id}/operations` | `await operationsClient.create(params);` |
+| Get operations from sites | `GET /sites/{site-id}/lists/{list-id}/operations/{richLongRunningOperation-id}` | `await operationsClient.get({"richLongRunningOperation-id": richLongRunningOperationId  });` |
+| Delete navigation property operations for sites | `DELETE /sites/{site-id}/lists/{list-id}/operations/{richLongRunningOperation-id}` | `await operationsClient.delete({"richLongRunningOperation-id": richLongRunningOperationId  });` |
+| Update the navigation property operations in sites | `PATCH /sites/{site-id}/lists/{list-id}/operations/{richLongRunningOperation-id}` | `await operationsClient.update(params);` |
+
+## SubscriptionsClient Endpoints
+
+The SubscriptionsClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/subscriptions` endpoints. You can get a `SubscriptionsClient` instance like so:
+
+```typescript
+const subscriptionsClient = await listsClient.subscriptions(listId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get subscriptions from sites | `GET /sites/{site-id}/lists/{list-id}/subscriptions` | `await subscriptionsClient.list(params);` |
+| Create new navigation property to subscriptions for sites | `POST /sites/{site-id}/lists/{list-id}/subscriptions` | `await subscriptionsClient.create(params);` |
+| Get subscriptions from sites | `GET /sites/{site-id}/lists/{list-id}/subscriptions/{subscription-id}` | `await subscriptionsClient.get({"subscription-id": subscriptionId  });` |
+| Delete navigation property subscriptions for sites | `DELETE /sites/{site-id}/lists/{list-id}/subscriptions/{subscription-id}` | `await subscriptionsClient.delete({"subscription-id": subscriptionId  });` |
+| Update the navigation property subscriptions in sites | `PATCH /sites/{site-id}/lists/{list-id}/subscriptions/{subscription-id}` | `await subscriptionsClient.update(params);` |
+
+## ReauthorizeClient Endpoints
+
+The ReauthorizeClient instance gives access to the following `/sites/{site-id}/lists/{list-id}/subscriptions/{subscription-id}/reauthorize` endpoints. You can get a `ReauthorizeClient` instance like so:
+
+```typescript
+const reauthorizeClient = await subscriptionsClient.reauthorize(subscriptionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action reauthorize | `POST /sites/{site-id}/lists/{list-id}/subscriptions/{subscription-id}/reauthorize` | `await reauthorizeClient.create(params);` |
+
+## OnenoteClient Endpoints
+
+The OnenoteClient instance gives access to the following `/sites/{site-id}/onenote` endpoints. You can get a `OnenoteClient` instance like so:
+
+```typescript
+const onenoteClient = await sitesClient.onenote(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get onenote from sites | `GET /sites/{site-id}/onenote` | `await onenoteClient.list(params);` |
+| Delete navigation property onenote for sites | `DELETE /sites/{site-id}/onenote` | `await onenoteClient.delete({"site-id": siteId  });` |
+| Update the navigation property onenote in sites | `PATCH /sites/{site-id}/onenote` | `await onenoteClient.update(params);` |
+
+## NotebooksClient Endpoints
+
+The NotebooksClient instance gives access to the following `/sites/{site-id}/onenote/notebooks` endpoints. You can get a `NotebooksClient` instance like so:
+
+```typescript
+const notebooksClient = onenoteClient.notebooks;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get notebooks from sites | `GET /sites/{site-id}/onenote/notebooks` | `await notebooksClient.list(params);` |
+| Create new navigation property to notebooks for sites | `POST /sites/{site-id}/onenote/notebooks` | `await notebooksClient.create(params);` |
+| Get notebooks from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}` | `await notebooksClient.get({"notebook-id": notebookId  });` |
+| Delete navigation property notebooks for sites | `DELETE /sites/{site-id}/onenote/notebooks/{notebook-id}` | `await notebooksClient.delete({"notebook-id": notebookId  });` |
+| Update the navigation property notebooks in sites | `PATCH /sites/{site-id}/onenote/notebooks/{notebook-id}` | `await notebooksClient.update(params);` |
+
+## CopyNotebookClient Endpoints
+
+The CopyNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/copyNotebook` endpoints. You can get a `CopyNotebookClient` instance like so:
+
+```typescript
+const copyNotebookClient = await notebooksClient.copyNotebook(notebookId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyNotebook | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/copyNotebook` | `await copyNotebookClient.create(params);` |
+
+## SectionGroupsClient Endpoints
+
+The SectionGroupsClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups` endpoints. You can get a `SectionGroupsClient` instance like so:
+
+```typescript
+const sectionGroupsClient = await notebooksClient.sectionGroups(notebookId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups` | `await sectionGroupsClient.list(params);` |
+| Create new navigation property to sectionGroups for sites | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups` | `await sectionGroupsClient.create(params);` |
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}` | `await sectionGroupsClient.get({"sectionGroup-id": sectionGroupId  });` |
+| Delete navigation property sectionGroups for sites | `DELETE /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}` | `await sectionGroupsClient.delete({"sectionGroup-id": sectionGroupId  });` |
+| Update the navigation property sectionGroups in sites | `PATCH /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}` | `await sectionGroupsClient.update(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await sectionGroupsClient.parentNotebook(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionGroupClient Endpoints
+
+The ParentSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/parentSectionGroup` endpoints. You can get a `ParentSectionGroupClient` instance like so:
+
+```typescript
+const parentSectionGroupClient = await sectionGroupsClient.parentSectionGroup(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSectionGroup from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/parentSectionGroup` | `await parentSectionGroupClient.list(params);` |
+
+## SectionGroupsClient Endpoints
+
+The SectionGroupsClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sectionGroups` endpoints. You can get a `SectionGroupsClient` instance like so:
+
+```typescript
+const sectionGroupsClient = await sectionGroupsClient.sectionGroups(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sectionGroups` | `await sectionGroupsClient.list(params);` |
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sectionGroups/{sectionGroup-id1}` | `await sectionGroupsClient.get({"sectionGroup-id1": sectionGroupId1  });` |
+
+## SectionsClient Endpoints
+
+The SectionsClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections` endpoints. You can get a `SectionsClient` instance like so:
+
+```typescript
+const sectionsClient = await sectionGroupsClient.sections(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sections from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections` | `await sectionsClient.list(params);` |
+| Create new navigation property to sections for sites | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections` | `await sectionsClient.create(params);` |
+| Get sections from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}` | `await sectionsClient.get({"onenoteSection-id": onenoteSectionId  });` |
+| Delete navigation property sections for sites | `DELETE /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}` | `await sectionsClient.delete({"onenoteSection-id": onenoteSectionId  });` |
+| Update the navigation property sections in sites | `PATCH /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}` | `await sectionsClient.update(params);` |
+
+## CopyToNotebookClient Endpoints
+
+The CopyToNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToNotebook` endpoints. You can get a `CopyToNotebookClient` instance like so:
+
+```typescript
+const copyToNotebookClient = await sectionsClient.copyToNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToNotebook | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToNotebook` | `await copyToNotebookClient.create(params);` |
+
+## CopyToSectionGroupClient Endpoints
+
+The CopyToSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToSectionGroup` endpoints. You can get a `CopyToSectionGroupClient` instance like so:
+
+```typescript
+const copyToSectionGroupClient = await sectionsClient.copyToSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSectionGroup | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToSectionGroup` | `await copyToSectionGroupClient.create(params);` |
+
+## PagesClient Endpoints
+
+The PagesClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages` endpoints. You can get a `PagesClient` instance like so:
+
+```typescript
+const pagesClient = await sectionsClient.pages(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get pages from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages` | `await pagesClient.list(params);` |
+| Create new navigation property to pages for sites | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages` | `await pagesClient.create(params);` |
+| Get pages from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.get({"onenotePage-id": onenotePageId  });` |
+| Delete navigation property pages for sites | `DELETE /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.delete({"onenotePage-id": onenotePageId  });` |
+| Update the navigation property pages in sites | `PATCH /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await pagesClient.content(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property pages from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property pages in sites | `PUT /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.set(body, {"onenotePage-id": onenotePageId  });` |
+
+## CopyToSectionClient Endpoints
+
+The CopyToSectionClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` endpoints. You can get a `CopyToSectionClient` instance like so:
+
+```typescript
+const copyToSectionClient = await pagesClient.copyToSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSection | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` | `await copyToSectionClient.create(params);` |
+
+## OnenotePatchContentClient Endpoints
+
+The OnenotePatchContentClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` endpoints. You can get a `OnenotePatchContentClient` instance like so:
+
+```typescript
+const onenotePatchContentClient = await pagesClient.onenotePatchContent(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action onenotePatchContent | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` | `await onenotePatchContentClient.create(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await pagesClient.parentNotebook(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionClient Endpoints
+
+The ParentSectionClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` endpoints. You can get a `ParentSectionClient` instance like so:
+
+```typescript
+const parentSectionClient = await pagesClient.parentSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSection from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` | `await parentSectionClient.list(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await sectionsClient.parentNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionGroupClient Endpoints
+
+The ParentSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentSectionGroup` endpoints. You can get a `ParentSectionGroupClient` instance like so:
+
+```typescript
+const parentSectionGroupClient = await sectionsClient.parentSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSectionGroup from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentSectionGroup` | `await parentSectionGroupClient.list(params);` |
+
+## SectionsClient Endpoints
+
+The SectionsClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections` endpoints. You can get a `SectionsClient` instance like so:
+
+```typescript
+const sectionsClient = await notebooksClient.sections(notebookId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sections from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections` | `await sectionsClient.list(params);` |
+| Create new navigation property to sections for sites | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sections` | `await sectionsClient.create(params);` |
+| Get sections from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}` | `await sectionsClient.get({"onenoteSection-id": onenoteSectionId  });` |
+| Delete navigation property sections for sites | `DELETE /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}` | `await sectionsClient.delete({"onenoteSection-id": onenoteSectionId  });` |
+| Update the navigation property sections in sites | `PATCH /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}` | `await sectionsClient.update(params);` |
+
+## CopyToNotebookClient Endpoints
+
+The CopyToNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/copyToNotebook` endpoints. You can get a `CopyToNotebookClient` instance like so:
+
+```typescript
+const copyToNotebookClient = await sectionsClient.copyToNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToNotebook | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/copyToNotebook` | `await copyToNotebookClient.create(params);` |
+
+## CopyToSectionGroupClient Endpoints
+
+The CopyToSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/copyToSectionGroup` endpoints. You can get a `CopyToSectionGroupClient` instance like so:
+
+```typescript
+const copyToSectionGroupClient = await sectionsClient.copyToSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSectionGroup | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/copyToSectionGroup` | `await copyToSectionGroupClient.create(params);` |
+
+## PagesClient Endpoints
+
+The PagesClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages` endpoints. You can get a `PagesClient` instance like so:
+
+```typescript
+const pagesClient = await sectionsClient.pages(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get pages from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages` | `await pagesClient.list(params);` |
+| Create new navigation property to pages for sites | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages` | `await pagesClient.create(params);` |
+| Get pages from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.get({"onenotePage-id": onenotePageId  });` |
+| Delete navigation property pages for sites | `DELETE /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.delete({"onenotePage-id": onenotePageId  });` |
+| Update the navigation property pages in sites | `PATCH /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await pagesClient.content(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property pages from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property pages in sites | `PUT /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.set(body, {"onenotePage-id": onenotePageId  });` |
+
+## CopyToSectionClient Endpoints
+
+The CopyToSectionClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` endpoints. You can get a `CopyToSectionClient` instance like so:
+
+```typescript
+const copyToSectionClient = await pagesClient.copyToSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSection | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` | `await copyToSectionClient.create(params);` |
+
+## OnenotePatchContentClient Endpoints
+
+The OnenotePatchContentClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` endpoints. You can get a `OnenotePatchContentClient` instance like so:
+
+```typescript
+const onenotePatchContentClient = await pagesClient.onenotePatchContent(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action onenotePatchContent | `POST /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` | `await onenotePatchContentClient.create(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await pagesClient.parentNotebook(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionClient Endpoints
+
+The ParentSectionClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` endpoints. You can get a `ParentSectionClient` instance like so:
+
+```typescript
+const parentSectionClient = await pagesClient.parentSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSection from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` | `await parentSectionClient.list(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await sectionsClient.parentNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionGroupClient Endpoints
+
+The ParentSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/parentSectionGroup` endpoints. You can get a `ParentSectionGroupClient` instance like so:
+
+```typescript
+const parentSectionGroupClient = await sectionsClient.parentSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSectionGroup from sites | `GET /sites/{site-id}/onenote/notebooks/{notebook-id}/sections/{onenoteSection-id}/parentSectionGroup` | `await parentSectionGroupClient.list(params);` |
+
+## GetNotebookFromWebUrlClient Endpoints
+
+The GetNotebookFromWebUrlClient instance gives access to the following `/sites/{site-id}/onenote/notebooks/getNotebookFromWebUrl` endpoints. You can get a `GetNotebookFromWebUrlClient` instance like so:
+
+```typescript
+const getNotebookFromWebUrlClient = notebooksClient.getNotebookFromWebUrl;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getNotebookFromWebUrl | `POST /sites/{site-id}/onenote/notebooks/getNotebookFromWebUrl` | `await getNotebookFromWebUrlClient.create(params);` |
+
+## OperationsClient Endpoints
+
+The OperationsClient instance gives access to the following `/sites/{site-id}/onenote/operations` endpoints. You can get a `OperationsClient` instance like so:
+
+```typescript
+const operationsClient = onenoteClient.operations;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get operations from sites | `GET /sites/{site-id}/onenote/operations` | `await operationsClient.list(params);` |
+| Create new navigation property to operations for sites | `POST /sites/{site-id}/onenote/operations` | `await operationsClient.create(params);` |
+| Get operations from sites | `GET /sites/{site-id}/onenote/operations/{onenoteOperation-id}` | `await operationsClient.get({"onenoteOperation-id": onenoteOperationId  });` |
+| Delete navigation property operations for sites | `DELETE /sites/{site-id}/onenote/operations/{onenoteOperation-id}` | `await operationsClient.delete({"onenoteOperation-id": onenoteOperationId  });` |
+| Update the navigation property operations in sites | `PATCH /sites/{site-id}/onenote/operations/{onenoteOperation-id}` | `await operationsClient.update(params);` |
+
+## PagesClient Endpoints
+
+The PagesClient instance gives access to the following `/sites/{site-id}/onenote/pages` endpoints. You can get a `PagesClient` instance like so:
+
+```typescript
+const pagesClient = onenoteClient.pages;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get pages from sites | `GET /sites/{site-id}/onenote/pages` | `await pagesClient.list(params);` |
+| Create new navigation property to pages for sites | `POST /sites/{site-id}/onenote/pages` | `await pagesClient.create(params);` |
+| Get pages from sites | `GET /sites/{site-id}/onenote/pages/{onenotePage-id}` | `await pagesClient.get({"onenotePage-id": onenotePageId  });` |
+| Delete navigation property pages for sites | `DELETE /sites/{site-id}/onenote/pages/{onenotePage-id}` | `await pagesClient.delete({"onenotePage-id": onenotePageId  });` |
+| Update the navigation property pages in sites | `PATCH /sites/{site-id}/onenote/pages/{onenotePage-id}` | `await pagesClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/onenote/pages/{onenotePage-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await pagesClient.content(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property pages from sites | `GET /sites/{site-id}/onenote/pages/{onenotePage-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property pages in sites | `PUT /sites/{site-id}/onenote/pages/{onenotePage-id}/content` | `await contentClient.set(body, {"onenotePage-id": onenotePageId  });` |
+
+## CopyToSectionClient Endpoints
+
+The CopyToSectionClient instance gives access to the following `/sites/{site-id}/onenote/pages/{onenotePage-id}/copyToSection` endpoints. You can get a `CopyToSectionClient` instance like so:
+
+```typescript
+const copyToSectionClient = await pagesClient.copyToSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSection | `POST /sites/{site-id}/onenote/pages/{onenotePage-id}/copyToSection` | `await copyToSectionClient.create(params);` |
+
+## OnenotePatchContentClient Endpoints
+
+The OnenotePatchContentClient instance gives access to the following `/sites/{site-id}/onenote/pages/{onenotePage-id}/onenotePatchContent` endpoints. You can get a `OnenotePatchContentClient` instance like so:
+
+```typescript
+const onenotePatchContentClient = await pagesClient.onenotePatchContent(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action onenotePatchContent | `POST /sites/{site-id}/onenote/pages/{onenotePage-id}/onenotePatchContent` | `await onenotePatchContentClient.create(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/pages/{onenotePage-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await pagesClient.parentNotebook(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/pages/{onenotePage-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionClient Endpoints
+
+The ParentSectionClient instance gives access to the following `/sites/{site-id}/onenote/pages/{onenotePage-id}/parentSection` endpoints. You can get a `ParentSectionClient` instance like so:
+
+```typescript
+const parentSectionClient = await pagesClient.parentSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSection from sites | `GET /sites/{site-id}/onenote/pages/{onenotePage-id}/parentSection` | `await parentSectionClient.list(params);` |
+
+## ResourcesClient Endpoints
+
+The ResourcesClient instance gives access to the following `/sites/{site-id}/onenote/resources` endpoints. You can get a `ResourcesClient` instance like so:
+
+```typescript
+const resourcesClient = onenoteClient.resources;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get resources from sites | `GET /sites/{site-id}/onenote/resources` | `await resourcesClient.list(params);` |
+| Create new navigation property to resources for sites | `POST /sites/{site-id}/onenote/resources` | `await resourcesClient.create(params);` |
+| Get resources from sites | `GET /sites/{site-id}/onenote/resources/{onenoteResource-id}` | `await resourcesClient.get({"onenoteResource-id": onenoteResourceId  });` |
+| Delete navigation property resources for sites | `DELETE /sites/{site-id}/onenote/resources/{onenoteResource-id}` | `await resourcesClient.delete({"onenoteResource-id": onenoteResourceId  });` |
+| Update the navigation property resources in sites | `PATCH /sites/{site-id}/onenote/resources/{onenoteResource-id}` | `await resourcesClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/onenote/resources/{onenoteResource-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await resourcesClient.content(onenoteResourceId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property resources from sites | `GET /sites/{site-id}/onenote/resources/{onenoteResource-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property resources in sites | `PUT /sites/{site-id}/onenote/resources/{onenoteResource-id}/content` | `await contentClient.set(body, {"onenoteResource-id": onenoteResourceId  });` |
+
+## SectionGroupsClient Endpoints
+
+The SectionGroupsClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups` endpoints. You can get a `SectionGroupsClient` instance like so:
+
+```typescript
+const sectionGroupsClient = onenoteClient.sectionGroups;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/sectionGroups` | `await sectionGroupsClient.list(params);` |
+| Create new navigation property to sectionGroups for sites | `POST /sites/{site-id}/onenote/sectionGroups` | `await sectionGroupsClient.create(params);` |
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}` | `await sectionGroupsClient.get({"sectionGroup-id": sectionGroupId  });` |
+| Delete navigation property sectionGroups for sites | `DELETE /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}` | `await sectionGroupsClient.delete({"sectionGroup-id": sectionGroupId  });` |
+| Update the navigation property sectionGroups in sites | `PATCH /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}` | `await sectionGroupsClient.update(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await sectionGroupsClient.parentNotebook(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionGroupClient Endpoints
+
+The ParentSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/parentSectionGroup` endpoints. You can get a `ParentSectionGroupClient` instance like so:
+
+```typescript
+const parentSectionGroupClient = await sectionGroupsClient.parentSectionGroup(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSectionGroup from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/parentSectionGroup` | `await parentSectionGroupClient.list(params);` |
+
+## SectionGroupsClient Endpoints
+
+The SectionGroupsClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sectionGroups` endpoints. You can get a `SectionGroupsClient` instance like so:
+
+```typescript
+const sectionGroupsClient = await sectionGroupsClient.sectionGroups(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sectionGroups` | `await sectionGroupsClient.list(params);` |
+| Get sectionGroups from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sectionGroups/{sectionGroup-id1}` | `await sectionGroupsClient.get({"sectionGroup-id1": sectionGroupId1  });` |
+
+## SectionsClient Endpoints
+
+The SectionsClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections` endpoints. You can get a `SectionsClient` instance like so:
+
+```typescript
+const sectionsClient = await sectionGroupsClient.sections(sectionGroupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sections from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections` | `await sectionsClient.list(params);` |
+| Create new navigation property to sections for sites | `POST /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections` | `await sectionsClient.create(params);` |
+| Get sections from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}` | `await sectionsClient.get({"onenoteSection-id": onenoteSectionId  });` |
+| Delete navigation property sections for sites | `DELETE /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}` | `await sectionsClient.delete({"onenoteSection-id": onenoteSectionId  });` |
+| Update the navigation property sections in sites | `PATCH /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}` | `await sectionsClient.update(params);` |
+
+## CopyToNotebookClient Endpoints
+
+The CopyToNotebookClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToNotebook` endpoints. You can get a `CopyToNotebookClient` instance like so:
+
+```typescript
+const copyToNotebookClient = await sectionsClient.copyToNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToNotebook | `POST /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToNotebook` | `await copyToNotebookClient.create(params);` |
+
+## CopyToSectionGroupClient Endpoints
+
+The CopyToSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToSectionGroup` endpoints. You can get a `CopyToSectionGroupClient` instance like so:
+
+```typescript
+const copyToSectionGroupClient = await sectionsClient.copyToSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSectionGroup | `POST /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/copyToSectionGroup` | `await copyToSectionGroupClient.create(params);` |
+
+## PagesClient Endpoints
+
+The PagesClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages` endpoints. You can get a `PagesClient` instance like so:
+
+```typescript
+const pagesClient = await sectionsClient.pages(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get pages from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages` | `await pagesClient.list(params);` |
+| Create new navigation property to pages for sites | `POST /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages` | `await pagesClient.create(params);` |
+| Get pages from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.get({"onenotePage-id": onenotePageId  });` |
+| Delete navigation property pages for sites | `DELETE /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.delete({"onenotePage-id": onenotePageId  });` |
+| Update the navigation property pages in sites | `PATCH /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await pagesClient.content(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property pages from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property pages in sites | `PUT /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.set(body, {"onenotePage-id": onenotePageId  });` |
+
+## CopyToSectionClient Endpoints
+
+The CopyToSectionClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` endpoints. You can get a `CopyToSectionClient` instance like so:
+
+```typescript
+const copyToSectionClient = await pagesClient.copyToSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSection | `POST /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` | `await copyToSectionClient.create(params);` |
+
+## OnenotePatchContentClient Endpoints
+
+The OnenotePatchContentClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` endpoints. You can get a `OnenotePatchContentClient` instance like so:
+
+```typescript
+const onenotePatchContentClient = await pagesClient.onenotePatchContent(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action onenotePatchContent | `POST /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` | `await onenotePatchContentClient.create(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await pagesClient.parentNotebook(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionClient Endpoints
+
+The ParentSectionClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` endpoints. You can get a `ParentSectionClient` instance like so:
+
+```typescript
+const parentSectionClient = await pagesClient.parentSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSection from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` | `await parentSectionClient.list(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await sectionsClient.parentNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionGroupClient Endpoints
+
+The ParentSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentSectionGroup` endpoints. You can get a `ParentSectionGroupClient` instance like so:
+
+```typescript
+const parentSectionGroupClient = await sectionsClient.parentSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSectionGroup from sites | `GET /sites/{site-id}/onenote/sectionGroups/{sectionGroup-id}/sections/{onenoteSection-id}/parentSectionGroup` | `await parentSectionGroupClient.list(params);` |
+
+## SectionsClient Endpoints
+
+The SectionsClient instance gives access to the following `/sites/{site-id}/onenote/sections` endpoints. You can get a `SectionsClient` instance like so:
+
+```typescript
+const sectionsClient = onenoteClient.sections;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sections from sites | `GET /sites/{site-id}/onenote/sections` | `await sectionsClient.list(params);` |
+| Create new navigation property to sections for sites | `POST /sites/{site-id}/onenote/sections` | `await sectionsClient.create(params);` |
+| Get sections from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}` | `await sectionsClient.get({"onenoteSection-id": onenoteSectionId  });` |
+| Delete navigation property sections for sites | `DELETE /sites/{site-id}/onenote/sections/{onenoteSection-id}` | `await sectionsClient.delete({"onenoteSection-id": onenoteSectionId  });` |
+| Update the navigation property sections in sites | `PATCH /sites/{site-id}/onenote/sections/{onenoteSection-id}` | `await sectionsClient.update(params);` |
+
+## CopyToNotebookClient Endpoints
+
+The CopyToNotebookClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/copyToNotebook` endpoints. You can get a `CopyToNotebookClient` instance like so:
+
+```typescript
+const copyToNotebookClient = await sectionsClient.copyToNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToNotebook | `POST /sites/{site-id}/onenote/sections/{onenoteSection-id}/copyToNotebook` | `await copyToNotebookClient.create(params);` |
+
+## CopyToSectionGroupClient Endpoints
+
+The CopyToSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/copyToSectionGroup` endpoints. You can get a `CopyToSectionGroupClient` instance like so:
+
+```typescript
+const copyToSectionGroupClient = await sectionsClient.copyToSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSectionGroup | `POST /sites/{site-id}/onenote/sections/{onenoteSection-id}/copyToSectionGroup` | `await copyToSectionGroupClient.create(params);` |
+
+## PagesClient Endpoints
+
+The PagesClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/pages` endpoints. You can get a `PagesClient` instance like so:
+
+```typescript
+const pagesClient = await sectionsClient.pages(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get pages from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages` | `await pagesClient.list(params);` |
+| Create new navigation property to pages for sites | `POST /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages` | `await pagesClient.create(params);` |
+| Get pages from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.get({"onenotePage-id": onenotePageId  });` |
+| Delete navigation property pages for sites | `DELETE /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.delete({"onenotePage-id": onenotePageId  });` |
+| Update the navigation property pages in sites | `PATCH /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}` | `await pagesClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await pagesClient.content(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property pages from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property pages in sites | `PUT /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/content` | `await contentClient.set(body, {"onenotePage-id": onenotePageId  });` |
+
+## CopyToSectionClient Endpoints
+
+The CopyToSectionClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` endpoints. You can get a `CopyToSectionClient` instance like so:
+
+```typescript
+const copyToSectionClient = await pagesClient.copyToSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action copyToSection | `POST /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/copyToSection` | `await copyToSectionClient.create(params);` |
+
+## OnenotePatchContentClient Endpoints
+
+The OnenotePatchContentClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` endpoints. You can get a `OnenotePatchContentClient` instance like so:
+
+```typescript
+const onenotePatchContentClient = await pagesClient.onenotePatchContent(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action onenotePatchContent | `POST /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/onenotePatchContent` | `await onenotePatchContentClient.create(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await pagesClient.parentNotebook(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionClient Endpoints
+
+The ParentSectionClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` endpoints. You can get a `ParentSectionClient` instance like so:
+
+```typescript
+const parentSectionClient = await pagesClient.parentSection(onenotePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSection from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}/pages/{onenotePage-id}/parentSection` | `await parentSectionClient.list(params);` |
+
+## ParentNotebookClient Endpoints
+
+The ParentNotebookClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/parentNotebook` endpoints. You can get a `ParentNotebookClient` instance like so:
+
+```typescript
+const parentNotebookClient = await sectionsClient.parentNotebook(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentNotebook from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}/parentNotebook` | `await parentNotebookClient.list(params);` |
+
+## ParentSectionGroupClient Endpoints
+
+The ParentSectionGroupClient instance gives access to the following `/sites/{site-id}/onenote/sections/{onenoteSection-id}/parentSectionGroup` endpoints. You can get a `ParentSectionGroupClient` instance like so:
+
+```typescript
+const parentSectionGroupClient = await sectionsClient.parentSectionGroup(onenoteSectionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentSectionGroup from sites | `GET /sites/{site-id}/onenote/sections/{onenoteSection-id}/parentSectionGroup` | `await parentSectionGroupClient.list(params);` |
+
+## OperationsClient Endpoints
+
+The OperationsClient instance gives access to the following `/sites/{site-id}/operations` endpoints. You can get a `OperationsClient` instance like so:
+
+```typescript
+const operationsClient = await sitesClient.operations(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List operations on a site | `GET /sites/{site-id}/operations` | `await operationsClient.list(params);` |
+| Create new navigation property to operations for sites | `POST /sites/{site-id}/operations` | `await operationsClient.create(params);` |
+| Get richLongRunningOperation | `GET /sites/{site-id}/operations/{richLongRunningOperation-id}` | `await operationsClient.get({"richLongRunningOperation-id": richLongRunningOperationId  });` |
+| Delete navigation property operations for sites | `DELETE /sites/{site-id}/operations/{richLongRunningOperation-id}` | `await operationsClient.delete({"richLongRunningOperation-id": richLongRunningOperationId  });` |
+| Update the navigation property operations in sites | `PATCH /sites/{site-id}/operations/{richLongRunningOperation-id}` | `await operationsClient.update(params);` |
+
+## PagesClient Endpoints
+
+The PagesClient instance gives access to the following `/sites/{site-id}/pages` endpoints. You can get a `PagesClient` instance like so:
+
+```typescript
+const pagesClient = await sitesClient.pages(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List baseSitePages | `GET /sites/{site-id}/pages` | `await pagesClient.list(params);` |
+| Create a page in the site pages list of a site | `POST /sites/{site-id}/pages` | `await pagesClient.create(params);` |
+| Get baseSitePage | `GET /sites/{site-id}/pages/{baseSitePage-id}` | `await pagesClient.get({"baseSitePage-id": baseSitePageId  });` |
+| Delete baseSitePage | `DELETE /sites/{site-id}/pages/{baseSitePage-id}` | `await pagesClient.delete({"baseSitePage-id": baseSitePageId  });` |
+| Update the navigation property pages in sites | `PATCH /sites/{site-id}/pages/{baseSitePage-id}` | `await pagesClient.update(params);` |
+
+## CreatedByUserClient Endpoints
+
+The CreatedByUserClient instance gives access to the following `/sites/{site-id}/pages/{baseSitePage-id}/createdByUser` endpoints. You can get a `CreatedByUserClient` instance like so:
+
+```typescript
+const createdByUserClient = await pagesClient.createdByUser(baseSitePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get createdByUser from sites | `GET /sites/{site-id}/pages/{baseSitePage-id}/createdByUser` | `await createdByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/pages/{baseSitePage-id}/createdByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = createdByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/pages/{baseSitePage-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/pages/{baseSitePage-id}/createdByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/pages/{baseSitePage-id}/createdByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = createdByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/pages/{baseSitePage-id}/createdByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## LastModifiedByUserClient Endpoints
+
+The LastModifiedByUserClient instance gives access to the following `/sites/{site-id}/pages/{baseSitePage-id}/lastModifiedByUser` endpoints. You can get a `LastModifiedByUserClient` instance like so:
+
+```typescript
+const lastModifiedByUserClient = await pagesClient.lastModifiedByUser(baseSitePageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastModifiedByUser from sites | `GET /sites/{site-id}/pages/{baseSitePage-id}/lastModifiedByUser` | `await lastModifiedByUserClient.list(params);` |
+
+## MailboxSettingsClient Endpoints
+
+The MailboxSettingsClient instance gives access to the following `/sites/{site-id}/pages/{baseSitePage-id}/lastModifiedByUser/mailboxSettings` endpoints. You can get a `MailboxSettingsClient` instance like so:
+
+```typescript
+const mailboxSettingsClient = lastModifiedByUserClient.mailboxSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxSettings property value | `GET /sites/{site-id}/pages/{baseSitePage-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.list(params);` |
+| Update property mailboxSettings value. | `PATCH /sites/{site-id}/pages/{baseSitePage-id}/lastModifiedByUser/mailboxSettings` | `await mailboxSettingsClient.update(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/sites/{site-id}/pages/{baseSitePage-id}/lastModifiedByUser/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = lastModifiedByUserClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /sites/{site-id}/pages/{baseSitePage-id}/lastModifiedByUser/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## PermissionsClient Endpoints
+
+The PermissionsClient instance gives access to the following `/sites/{site-id}/permissions` endpoints. You can get a `PermissionsClient` instance like so:
+
+```typescript
+const permissionsClient = await sitesClient.permissions(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List permissions | `GET /sites/{site-id}/permissions` | `await permissionsClient.list(params);` |
+| Create permission | `POST /sites/{site-id}/permissions` | `await permissionsClient.create(params);` |
+| Get permission | `GET /sites/{site-id}/permissions/{permission-id}` | `await permissionsClient.get({"permission-id": permissionId  });` |
+| Delete permission | `DELETE /sites/{site-id}/permissions/{permission-id}` | `await permissionsClient.delete({"permission-id": permissionId  });` |
+| Update permission | `PATCH /sites/{site-id}/permissions/{permission-id}` | `await permissionsClient.update(params);` |
+
+## GrantClient Endpoints
+
+The GrantClient instance gives access to the following `/sites/{site-id}/permissions/{permission-id}/grant` endpoints. You can get a `GrantClient` instance like so:
+
+```typescript
+const grantClient = await permissionsClient.grant(permissionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action grant | `POST /sites/{site-id}/permissions/{permission-id}/grant` | `await grantClient.create(params);` |
+
+## SitesClient Endpoints
+
+The SitesClient instance gives access to the following `/sites/{site-id}/sites` endpoints. You can get a `SitesClient` instance like so:
+
+```typescript
+const sitesClient = await sitesClient.sites(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List subsites for a site | `GET /sites/{site-id}/sites` | `await sitesClient.list(params);` |
+| Get sites from sites | `GET /sites/{site-id}/sites/{site-id1}` | `await sitesClient.get({"site-id1": siteId1  });` |
+
+## TermStoreClient Endpoints
+
+The TermStoreClient instance gives access to the following `/sites/{site-id}/termStore` endpoints. You can get a `TermStoreClient` instance like so:
+
+```typescript
+const termStoreClient = await sitesClient.termStore(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get store | `GET /sites/{site-id}/termStore` | `await termStoreClient.list(params);` |
+| Delete navigation property termStore for sites | `DELETE /sites/{site-id}/termStore` | `await termStoreClient.delete({"site-id": siteId  });` |
+| Update store | `PATCH /sites/{site-id}/termStore` | `await termStoreClient.update(params);` |
+
+## GroupsClient Endpoints
+
+The GroupsClient instance gives access to the following `/sites/{site-id}/termStore/groups` endpoints. You can get a `GroupsClient` instance like so:
+
+```typescript
+const groupsClient = termStoreClient.groups;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List termStore groups | `GET /sites/{site-id}/termStore/groups` | `await groupsClient.list(params);` |
+| Create termStore group | `POST /sites/{site-id}/termStore/groups` | `await groupsClient.create(params);` |
+| Get group | `GET /sites/{site-id}/termStore/groups/{group-id}` | `await groupsClient.get({"group-id": groupId  });` |
+| Delete group | `DELETE /sites/{site-id}/termStore/groups/{group-id}` | `await groupsClient.delete({"group-id": groupId  });` |
+| Update the navigation property groups in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}` | `await groupsClient.update(params);` |
+
+## SetsClient Endpoints
+
+The SetsClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets` endpoints. You can get a `SetsClient` instance like so:
+
+```typescript
+const setsClient = await groupsClient.sets(groupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List sets | `GET /sites/{site-id}/termStore/groups/{group-id}/sets` | `await setsClient.list(params);` |
+| Create new navigation property to sets for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets` | `await setsClient.create(params);` |
+| Get sets from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}` | `await setsClient.get({"set-id": setId  });` |
+| Delete navigation property sets for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}` | `await setsClient.delete({"set-id": setId  });` |
+| Update the navigation property sets in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}` | `await setsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await setsClient.children(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.get({"term-id": termId  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.delete({"term-id": termId  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await childrenClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/children/{term-id}/set` | `await setClient.list(params);` |
+
+## ParentGroupClient Endpoints
+
+The ParentGroupClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/parentGroup` endpoints. You can get a `ParentGroupClient` instance like so:
+
+```typescript
+const parentGroupClient = await setsClient.parentGroup(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentGroup from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.list(params);` |
+| Delete navigation property parentGroup for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.delete({"set-id": setId  });` |
+| Update the navigation property parentGroup in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await setsClient.relations(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## TermsClient Endpoints
+
+The TermsClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms` endpoints. You can get a `TermsClient` instance like so:
+
+```typescript
+const termsClient = await setsClient.terms(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get term | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms` | `await termsClient.list(params);` |
+| Create new navigation property to terms for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms` | `await termsClient.create(params);` |
+| Get term | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.get({"term-id": termId  });` |
+| Delete navigation property terms for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.delete({"term-id": termId  });` |
+| Update the navigation property terms in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await termsClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await termsClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await termsClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/groups/{group-id}/sets/{set-id}/terms/{term-id}/set` | `await setClient.list(params);` |
+
+## SetsClient Endpoints
+
+The SetsClient instance gives access to the following `/sites/{site-id}/termStore/sets` endpoints. You can get a `SetsClient` instance like so:
+
+```typescript
+const setsClient = termStoreClient.sets;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set | `GET /sites/{site-id}/termStore/sets` | `await setsClient.list(params);` |
+| Create termStore set | `POST /sites/{site-id}/termStore/sets` | `await setsClient.create(params);` |
+| Get set | `GET /sites/{site-id}/termStore/sets/{set-id}` | `await setsClient.get({"set-id": setId  });` |
+| Delete set | `DELETE /sites/{site-id}/termStore/sets/{set-id}` | `await setsClient.delete({"set-id": setId  });` |
+| Update set | `PATCH /sites/{site-id}/termStore/sets/{set-id}` | `await setsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await setsClient.children(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List children | `GET /sites/{site-id}/termStore/sets/{set-id}/children` | `await childrenClient.list(params);` |
+| Create term | `POST /sites/{site-id}/termStore/sets/{set-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}` | `await childrenClient.get({"term-id": termId  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}` | `await childrenClient.delete({"term-id": termId  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}` | `await childrenClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await childrenClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/children/{term-id}/set` | `await setClient.list(params);` |
+
+## ParentGroupClient Endpoints
+
+The ParentGroupClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup` endpoints. You can get a `ParentGroupClient` instance like so:
+
+```typescript
+const parentGroupClient = await setsClient.parentGroup(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentGroup from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup` | `await parentGroupClient.list(params);` |
+| Delete navigation property parentGroup for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup` | `await parentGroupClient.delete({"set-id": setId  });` |
+| Update the navigation property parentGroup in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup` | `await parentGroupClient.update(params);` |
+
+## SetsClient Endpoints
+
+The SetsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets` endpoints. You can get a `SetsClient` instance like so:
+
+```typescript
+const setsClient = parentGroupClient.sets;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sets from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets` | `await setsClient.list(params);` |
+| Create new navigation property to sets for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets` | `await setsClient.create(params);` |
+| Get sets from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}` | `await setsClient.get({"set-id1": setId1  });` |
+| Delete navigation property sets for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}` | `await setsClient.delete({"set-id1": setId1  });` |
+| Update the navigation property sets in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}` | `await setsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await setsClient.children(setId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}` | `await childrenClient.get({"term-id": termId  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}` | `await childrenClient.delete({"term-id": termId  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}` | `await childrenClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await childrenClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await setsClient.relations(setId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## TermsClient Endpoints
+
+The TermsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms` endpoints. You can get a `TermsClient` instance like so:
+
+```typescript
+const termsClient = await setsClient.terms(setId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get terms from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms` | `await termsClient.list(params);` |
+| Create new navigation property to terms for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms` | `await termsClient.create(params);` |
+| Get terms from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}` | `await termsClient.get({"term-id": termId  });` |
+| Delete navigation property terms for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}` | `await termsClient.delete({"term-id": termId  });` |
+| Update the navigation property terms in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}` | `await termsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await termsClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await termsClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await termsClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await setsClient.relations(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List relations | `GET /sites/{site-id}/termStore/sets/{set-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## TermsClient Endpoints
+
+The TermsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms` endpoints. You can get a `TermsClient` instance like so:
+
+```typescript
+const termsClient = await setsClient.terms(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get terms from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms` | `await termsClient.list(params);` |
+| Create new navigation property to terms for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/terms` | `await termsClient.create(params);` |
+| Get terms from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}` | `await termsClient.get({"term-id": termId  });` |
+| Delete term | `DELETE /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}` | `await termsClient.delete({"term-id": termId  });` |
+| Update term | `PATCH /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}` | `await termsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await termsClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await termsClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await termsClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStore/sets/{set-id}/terms/{term-id}/set` | `await setClient.list(params);` |
+
+## TermStoresClient Endpoints
+
+The TermStoresClient instance gives access to the following `/sites/{site-id}/termStores` endpoints. You can get a `TermStoresClient` instance like so:
+
+```typescript
+const termStoresClient = await sitesClient.termStores(siteId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get termStores from sites | `GET /sites/{site-id}/termStores` | `await termStoresClient.list(params);` |
+| Create new navigation property to termStores for sites | `POST /sites/{site-id}/termStores` | `await termStoresClient.create(params);` |
+| Get termStores from sites | `GET /sites/{site-id}/termStores/{store-id}` | `await termStoresClient.get({"store-id": storeId  });` |
+| Delete navigation property termStores for sites | `DELETE /sites/{site-id}/termStores/{store-id}` | `await termStoresClient.delete({"store-id": storeId  });` |
+| Update the navigation property termStores in sites | `PATCH /sites/{site-id}/termStores/{store-id}` | `await termStoresClient.update(params);` |
+
+## GroupsClient Endpoints
+
+The GroupsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups` endpoints. You can get a `GroupsClient` instance like so:
+
+```typescript
+const groupsClient = await termStoresClient.groups(storeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get groups from sites | `GET /sites/{site-id}/termStores/{store-id}/groups` | `await groupsClient.list(params);` |
+| Create new navigation property to groups for sites | `POST /sites/{site-id}/termStores/{store-id}/groups` | `await groupsClient.create(params);` |
+| Get groups from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}` | `await groupsClient.get({"group-id": groupId  });` |
+| Delete navigation property groups for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}` | `await groupsClient.delete({"group-id": groupId  });` |
+| Update the navigation property groups in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}` | `await groupsClient.update(params);` |
+
+## SetsClient Endpoints
+
+The SetsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets` endpoints. You can get a `SetsClient` instance like so:
+
+```typescript
+const setsClient = await groupsClient.sets(groupId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sets from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets` | `await setsClient.list(params);` |
+| Create new navigation property to sets for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets` | `await setsClient.create(params);` |
+| Get sets from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}` | `await setsClient.get({"set-id": setId  });` |
+| Delete navigation property sets for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}` | `await setsClient.delete({"set-id": setId  });` |
+| Update the navigation property sets in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}` | `await setsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await setsClient.children(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.get({"term-id": termId  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.delete({"term-id": termId  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await childrenClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/children/{term-id}/set` | `await setClient.list(params);` |
+
+## ParentGroupClient Endpoints
+
+The ParentGroupClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/parentGroup` endpoints. You can get a `ParentGroupClient` instance like so:
+
+```typescript
+const parentGroupClient = await setsClient.parentGroup(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentGroup from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.list(params);` |
+| Delete navigation property parentGroup for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.delete({"set-id": setId  });` |
+| Update the navigation property parentGroup in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await setsClient.relations(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## TermsClient Endpoints
+
+The TermsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms` endpoints. You can get a `TermsClient` instance like so:
+
+```typescript
+const termsClient = await setsClient.terms(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get terms from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms` | `await termsClient.list(params);` |
+| Create new navigation property to terms for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms` | `await termsClient.create(params);` |
+| Get terms from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.get({"term-id": termId  });` |
+| Delete navigation property terms for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.delete({"term-id": termId  });` |
+| Update the navigation property terms in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await termsClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await termsClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await termsClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/groups/{group-id}/sets/{set-id}/terms/{term-id}/set` | `await setClient.list(params);` |
+
+## SetsClient Endpoints
+
+The SetsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets` endpoints. You can get a `SetsClient` instance like so:
+
+```typescript
+const setsClient = await termStoresClient.sets(storeId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sets from sites | `GET /sites/{site-id}/termStores/{store-id}/sets` | `await setsClient.list(params);` |
+| Create new navigation property to sets for sites | `POST /sites/{site-id}/termStores/{store-id}/sets` | `await setsClient.create(params);` |
+| Get sets from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}` | `await setsClient.get({"set-id": setId  });` |
+| Delete navigation property sets for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}` | `await setsClient.delete({"set-id": setId  });` |
+| Update the navigation property sets in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}` | `await setsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await setsClient.children(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.get({"term-id": termId  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.delete({"term-id": termId  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}` | `await childrenClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await childrenClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/children/{term-id}/set` | `await setClient.list(params);` |
+
+## ParentGroupClient Endpoints
+
+The ParentGroupClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup` endpoints. You can get a `ParentGroupClient` instance like so:
+
+```typescript
+const parentGroupClient = await setsClient.parentGroup(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get parentGroup from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.list(params);` |
+| Delete navigation property parentGroup for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.delete({"set-id": setId  });` |
+| Update the navigation property parentGroup in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup` | `await parentGroupClient.update(params);` |
+
+## SetsClient Endpoints
+
+The SetsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets` endpoints. You can get a `SetsClient` instance like so:
+
+```typescript
+const setsClient = parentGroupClient.sets;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sets from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets` | `await setsClient.list(params);` |
+| Create new navigation property to sets for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets` | `await setsClient.create(params);` |
+| Get sets from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}` | `await setsClient.get({"set-id1": setId1  });` |
+| Delete navigation property sets for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}` | `await setsClient.delete({"set-id1": setId1  });` |
+| Update the navigation property sets in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}` | `await setsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await setsClient.children(setId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}` | `await childrenClient.get({"term-id": termId  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}` | `await childrenClient.delete({"term-id": termId  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}` | `await childrenClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await childrenClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/children/{term-id}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await setsClient.relations(setId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## TermsClient Endpoints
+
+The TermsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms` endpoints. You can get a `TermsClient` instance like so:
+
+```typescript
+const termsClient = await setsClient.terms(setId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get terms from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms` | `await termsClient.list(params);` |
+| Create new navigation property to terms for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms` | `await termsClient.create(params);` |
+| Get terms from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}` | `await termsClient.get({"term-id": termId  });` |
+| Delete navigation property terms for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}` | `await termsClient.delete({"term-id": termId  });` |
+| Update the navigation property terms in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}` | `await termsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await termsClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await termsClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await termsClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/parentGroup/sets/{set-id1}/terms/{term-id}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await setsClient.relations(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## TermsClient Endpoints
+
+The TermsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms` endpoints. You can get a `TermsClient` instance like so:
+
+```typescript
+const termsClient = await setsClient.terms(setId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get terms from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms` | `await termsClient.list(params);` |
+| Create new navigation property to terms for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms` | `await termsClient.create(params);` |
+| Get terms from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.get({"term-id": termId  });` |
+| Delete navigation property terms for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.delete({"term-id": termId  });` |
+| Update the navigation property terms in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}` | `await termsClient.update(params);` |
+
+## ChildrenClient Endpoints
+
+The ChildrenClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children` endpoints. You can get a `ChildrenClient` instance like so:
+
+```typescript
+const childrenClient = await termsClient.children(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.list(params);` |
+| Create new navigation property to children for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children` | `await childrenClient.create(params);` |
+| Get children from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.get({"term-id1": termId1  });` |
+| Delete navigation property children for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.delete({"term-id1": termId1  });` |
+| Update the navigation property children in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}` | `await childrenClient.update(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await childrenClient.relations(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await childrenClient.set(termId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/children/{term-id1}/set` | `await setClient.list(params);` |
+
+## RelationsClient Endpoints
+
+The RelationsClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations` endpoints. You can get a `RelationsClient` instance like so:
+
+```typescript
+const relationsClient = await termsClient.relations(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.list(params);` |
+| Create new navigation property to relations for sites | `POST /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations` | `await relationsClient.create(params);` |
+| Get relations from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.get({"relation-id": relationId  });` |
+| Delete navigation property relations for sites | `DELETE /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.delete({"relation-id": relationId  });` |
+| Update the navigation property relations in sites | `PATCH /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}` | `await relationsClient.update(params);` |
+
+## FromTermClient Endpoints
+
+The FromTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` endpoints. You can get a `FromTermClient` instance like so:
+
+```typescript
+const fromTermClient = await relationsClient.fromTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get fromTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/fromTerm` | `await fromTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await relationsClient.set(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/set` | `await setClient.list(params);` |
+
+## ToTermClient Endpoints
+
+The ToTermClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` endpoints. You can get a `ToTermClient` instance like so:
+
+```typescript
+const toTermClient = await relationsClient.toTerm(relationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get toTerm from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/relations/{relation-id}/toTerm` | `await toTermClient.list(params);` |
+
+## SetClient Endpoints
+
+The SetClient instance gives access to the following `/sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/set` endpoints. You can get a `SetClient` instance like so:
+
+```typescript
+const setClient = await termsClient.set(termId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get set from sites | `GET /sites/{site-id}/termStores/{store-id}/sets/{set-id}/terms/{term-id}/set` | `await setClient.list(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/sites/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = sitesClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /sites/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/sites/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = sitesClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /sites/remove` | `await removeClient.create(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/solutions.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/solutions.md
@@ -1,0 +1,1063 @@
+# Solutions
+
+This page lists all the `/solutions` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/solutions` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## SolutionsClient Endpoints
+
+The SolutionsClient instance gives access to the following `/solutions` endpoints. You can get a `SolutionsClient` instance like so:
+
+```typescript
+const solutionsClient = graphClient.solutions;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get solutions | `GET /solutions` | `await solutionsClient.list(params);` |
+| Update solutions | `PATCH /solutions` | `await solutionsClient.update(params);` |
+
+## BackupRestoreClient Endpoints
+
+The BackupRestoreClient instance gives access to the following `/solutions/backupRestore` endpoints. You can get a `BackupRestoreClient` instance like so:
+
+```typescript
+const backupRestoreClient = solutionsClient.backupRestore;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get backupRestoreRoot | `GET /solutions/backupRestore` | `await backupRestoreClient.list(params);` |
+| Delete navigation property backupRestore for solutions | `DELETE /solutions/backupRestore` | `await backupRestoreClient.delete({"":   });` |
+| Update the navigation property backupRestore in solutions | `PATCH /solutions/backupRestore` | `await backupRestoreClient.update(params);` |
+
+## DriveInclusionRulesClient Endpoints
+
+The DriveInclusionRulesClient instance gives access to the following `/solutions/backupRestore/driveInclusionRules` endpoints. You can get a `DriveInclusionRulesClient` instance like so:
+
+```typescript
+const driveInclusionRulesClient = backupRestoreClient.driveInclusionRules;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get driveInclusionRules from solutions | `GET /solutions/backupRestore/driveInclusionRules` | `await driveInclusionRulesClient.list(params);` |
+| Create new navigation property to driveInclusionRules for solutions | `POST /solutions/backupRestore/driveInclusionRules` | `await driveInclusionRulesClient.create(params);` |
+| Get driveInclusionRules from solutions | `GET /solutions/backupRestore/driveInclusionRules/{driveProtectionRule-id}` | `await driveInclusionRulesClient.get({"driveProtectionRule-id": driveProtectionRuleId  });` |
+| Delete navigation property driveInclusionRules for solutions | `DELETE /solutions/backupRestore/driveInclusionRules/{driveProtectionRule-id}` | `await driveInclusionRulesClient.delete({"driveProtectionRule-id": driveProtectionRuleId  });` |
+| Update the navigation property driveInclusionRules in solutions | `PATCH /solutions/backupRestore/driveInclusionRules/{driveProtectionRule-id}` | `await driveInclusionRulesClient.update(params);` |
+
+## DriveProtectionUnitsClient Endpoints
+
+The DriveProtectionUnitsClient instance gives access to the following `/solutions/backupRestore/driveProtectionUnits` endpoints. You can get a `DriveProtectionUnitsClient` instance like so:
+
+```typescript
+const driveProtectionUnitsClient = backupRestoreClient.driveProtectionUnits;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get driveProtectionUnits from solutions | `GET /solutions/backupRestore/driveProtectionUnits` | `await driveProtectionUnitsClient.list(params);` |
+| Create new navigation property to driveProtectionUnits for solutions | `POST /solutions/backupRestore/driveProtectionUnits` | `await driveProtectionUnitsClient.create(params);` |
+| Get driveProtectionUnits from solutions | `GET /solutions/backupRestore/driveProtectionUnits/{driveProtectionUnit-id}` | `await driveProtectionUnitsClient.get({"driveProtectionUnit-id": driveProtectionUnitId  });` |
+| Delete navigation property driveProtectionUnits for solutions | `DELETE /solutions/backupRestore/driveProtectionUnits/{driveProtectionUnit-id}` | `await driveProtectionUnitsClient.delete({"driveProtectionUnit-id": driveProtectionUnitId  });` |
+| Update the navigation property driveProtectionUnits in solutions | `PATCH /solutions/backupRestore/driveProtectionUnits/{driveProtectionUnit-id}` | `await driveProtectionUnitsClient.update(params);` |
+
+## ExchangeProtectionPoliciesClient Endpoints
+
+The ExchangeProtectionPoliciesClient instance gives access to the following `/solutions/backupRestore/exchangeProtectionPolicies` endpoints. You can get a `ExchangeProtectionPoliciesClient` instance like so:
+
+```typescript
+const exchangeProtectionPoliciesClient = backupRestoreClient.exchangeProtectionPolicies;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get exchangeProtectionPolicies from solutions | `GET /solutions/backupRestore/exchangeProtectionPolicies` | `await exchangeProtectionPoliciesClient.list(params);` |
+| Create exchangeProtectionPolicy | `POST /solutions/backupRestore/exchangeProtectionPolicies` | `await exchangeProtectionPoliciesClient.create(params);` |
+| Get exchangeProtectionPolicies from solutions | `GET /solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}` | `await exchangeProtectionPoliciesClient.get({"exchangeProtectionPolicy-id": exchangeProtectionPolicyId  });` |
+| Delete navigation property exchangeProtectionPolicies for solutions | `DELETE /solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}` | `await exchangeProtectionPoliciesClient.delete({"exchangeProtectionPolicy-id": exchangeProtectionPolicyId  });` |
+| Update exchangeProtectionPolicy | `PATCH /solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}` | `await exchangeProtectionPoliciesClient.update(params);` |
+
+## MailboxInclusionRulesClient Endpoints
+
+The MailboxInclusionRulesClient instance gives access to the following `/solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxInclusionRules` endpoints. You can get a `MailboxInclusionRulesClient` instance like so:
+
+```typescript
+const mailboxInclusionRulesClient = await exchangeProtectionPoliciesClient.mailboxInclusionRules(exchangeProtectionPolicyId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List mailboxInclusionRules | `GET /solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxInclusionRules` | `await mailboxInclusionRulesClient.list(params);` |
+| Get protectionRuleBase | `GET /solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxInclusionRules/{mailboxProtectionRule-id}` | `await mailboxInclusionRulesClient.get({"mailboxProtectionRule-id": mailboxProtectionRuleId  });` |
+
+## MailboxProtectionUnitsClient Endpoints
+
+The MailboxProtectionUnitsClient instance gives access to the following `/solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxProtectionUnits` endpoints. You can get a `MailboxProtectionUnitsClient` instance like so:
+
+```typescript
+const mailboxProtectionUnitsClient = await exchangeProtectionPoliciesClient.mailboxProtectionUnits(exchangeProtectionPolicyId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxProtectionUnits from solutions | `GET /solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxProtectionUnits` | `await mailboxProtectionUnitsClient.list(params);` |
+| Get mailboxProtectionUnits from solutions | `GET /solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxProtectionUnits/{mailboxProtectionUnit-id}` | `await mailboxProtectionUnitsClient.get({"mailboxProtectionUnit-id": mailboxProtectionUnitId  });` |
+
+## ExchangeRestoreSessionsClient Endpoints
+
+The ExchangeRestoreSessionsClient instance gives access to the following `/solutions/backupRestore/exchangeRestoreSessions` endpoints. You can get a `ExchangeRestoreSessionsClient` instance like so:
+
+```typescript
+const exchangeRestoreSessionsClient = backupRestoreClient.exchangeRestoreSessions;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get exchangeRestoreSessions from solutions | `GET /solutions/backupRestore/exchangeRestoreSessions` | `await exchangeRestoreSessionsClient.list(params);` |
+| Create new navigation property to exchangeRestoreSessions for solutions | `POST /solutions/backupRestore/exchangeRestoreSessions` | `await exchangeRestoreSessionsClient.create(params);` |
+| Get exchangeRestoreSessions from solutions | `GET /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}` | `await exchangeRestoreSessionsClient.get({"exchangeRestoreSession-id": exchangeRestoreSessionId  });` |
+| Delete navigation property exchangeRestoreSessions for solutions | `DELETE /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}` | `await exchangeRestoreSessionsClient.delete({"exchangeRestoreSession-id": exchangeRestoreSessionId  });` |
+| Update exchangeRestoreSession | `PATCH /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}` | `await exchangeRestoreSessionsClient.update(params);` |
+
+## GranularMailboxRestoreArtifactsClient Endpoints
+
+The GranularMailboxRestoreArtifactsClient instance gives access to the following `/solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts` endpoints. You can get a `GranularMailboxRestoreArtifactsClient` instance like so:
+
+```typescript
+const granularMailboxRestoreArtifactsClient = await exchangeRestoreSessionsClient.granularMailboxRestoreArtifacts(exchangeRestoreSessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get granularMailboxRestoreArtifacts from solutions | `GET /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts` | `await granularMailboxRestoreArtifactsClient.list(params);` |
+| Create new navigation property to granularMailboxRestoreArtifacts for solutions | `POST /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts` | `await granularMailboxRestoreArtifactsClient.create(params);` |
+| Get granularMailboxRestoreArtifacts from solutions | `GET /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts/{granularMailboxRestoreArtifact-id}` | `await granularMailboxRestoreArtifactsClient.get({"granularMailboxRestoreArtifact-id": granularMailboxRestoreArtifactId  });` |
+| Delete navigation property granularMailboxRestoreArtifacts for solutions | `DELETE /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts/{granularMailboxRestoreArtifact-id}` | `await granularMailboxRestoreArtifactsClient.delete({"granularMailboxRestoreArtifact-id": granularMailboxRestoreArtifactId  });` |
+| Update the navigation property granularMailboxRestoreArtifacts in solutions | `PATCH /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts/{granularMailboxRestoreArtifact-id}` | `await granularMailboxRestoreArtifactsClient.update(params);` |
+
+## RestorePointClient Endpoints
+
+The RestorePointClient instance gives access to the following `/solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts/{granularMailboxRestoreArtifact-id}/restorePoint` endpoints. You can get a `RestorePointClient` instance like so:
+
+```typescript
+const restorePointClient = await granularMailboxRestoreArtifactsClient.restorePoint(granularMailboxRestoreArtifactId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get restorePoint from solutions | `GET /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts/{granularMailboxRestoreArtifact-id}/restorePoint` | `await restorePointClient.list(params);` |
+
+## MailboxRestoreArtifactsClient Endpoints
+
+The MailboxRestoreArtifactsClient instance gives access to the following `/solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts` endpoints. You can get a `MailboxRestoreArtifactsClient` instance like so:
+
+```typescript
+const mailboxRestoreArtifactsClient = await exchangeRestoreSessionsClient.mailboxRestoreArtifacts(exchangeRestoreSessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List mailboxRestoreArtifacts | `GET /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts` | `await mailboxRestoreArtifactsClient.list(params);` |
+| Create new navigation property to mailboxRestoreArtifacts for solutions | `POST /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts` | `await mailboxRestoreArtifactsClient.create(params);` |
+| Get mailboxRestoreArtifacts from solutions | `GET /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts/{mailboxRestoreArtifact-id}` | `await mailboxRestoreArtifactsClient.get({"mailboxRestoreArtifact-id": mailboxRestoreArtifactId  });` |
+| Delete navigation property mailboxRestoreArtifacts for solutions | `DELETE /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts/{mailboxRestoreArtifact-id}` | `await mailboxRestoreArtifactsClient.delete({"mailboxRestoreArtifact-id": mailboxRestoreArtifactId  });` |
+| Update the navigation property mailboxRestoreArtifacts in solutions | `PATCH /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts/{mailboxRestoreArtifact-id}` | `await mailboxRestoreArtifactsClient.update(params);` |
+
+## RestorePointClient Endpoints
+
+The RestorePointClient instance gives access to the following `/solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts/{mailboxRestoreArtifact-id}/restorePoint` endpoints. You can get a `RestorePointClient` instance like so:
+
+```typescript
+const restorePointClient = await mailboxRestoreArtifactsClient.restorePoint(mailboxRestoreArtifactId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get restorePoint from solutions | `GET /solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts/{mailboxRestoreArtifact-id}/restorePoint` | `await restorePointClient.list(params);` |
+
+## MailboxInclusionRulesClient Endpoints
+
+The MailboxInclusionRulesClient instance gives access to the following `/solutions/backupRestore/mailboxInclusionRules` endpoints. You can get a `MailboxInclusionRulesClient` instance like so:
+
+```typescript
+const mailboxInclusionRulesClient = backupRestoreClient.mailboxInclusionRules;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxInclusionRules from solutions | `GET /solutions/backupRestore/mailboxInclusionRules` | `await mailboxInclusionRulesClient.list(params);` |
+| Create new navigation property to mailboxInclusionRules for solutions | `POST /solutions/backupRestore/mailboxInclusionRules` | `await mailboxInclusionRulesClient.create(params);` |
+| Get mailboxInclusionRules from solutions | `GET /solutions/backupRestore/mailboxInclusionRules/{mailboxProtectionRule-id}` | `await mailboxInclusionRulesClient.get({"mailboxProtectionRule-id": mailboxProtectionRuleId  });` |
+| Delete navigation property mailboxInclusionRules for solutions | `DELETE /solutions/backupRestore/mailboxInclusionRules/{mailboxProtectionRule-id}` | `await mailboxInclusionRulesClient.delete({"mailboxProtectionRule-id": mailboxProtectionRuleId  });` |
+| Update the navigation property mailboxInclusionRules in solutions | `PATCH /solutions/backupRestore/mailboxInclusionRules/{mailboxProtectionRule-id}` | `await mailboxInclusionRulesClient.update(params);` |
+
+## MailboxProtectionUnitsClient Endpoints
+
+The MailboxProtectionUnitsClient instance gives access to the following `/solutions/backupRestore/mailboxProtectionUnits` endpoints. You can get a `MailboxProtectionUnitsClient` instance like so:
+
+```typescript
+const mailboxProtectionUnitsClient = backupRestoreClient.mailboxProtectionUnits;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get mailboxProtectionUnits from solutions | `GET /solutions/backupRestore/mailboxProtectionUnits` | `await mailboxProtectionUnitsClient.list(params);` |
+| Create new navigation property to mailboxProtectionUnits for solutions | `POST /solutions/backupRestore/mailboxProtectionUnits` | `await mailboxProtectionUnitsClient.create(params);` |
+| Get mailboxProtectionUnits from solutions | `GET /solutions/backupRestore/mailboxProtectionUnits/{mailboxProtectionUnit-id}` | `await mailboxProtectionUnitsClient.get({"mailboxProtectionUnit-id": mailboxProtectionUnitId  });` |
+| Delete navigation property mailboxProtectionUnits for solutions | `DELETE /solutions/backupRestore/mailboxProtectionUnits/{mailboxProtectionUnit-id}` | `await mailboxProtectionUnitsClient.delete({"mailboxProtectionUnit-id": mailboxProtectionUnitId  });` |
+| Update the navigation property mailboxProtectionUnits in solutions | `PATCH /solutions/backupRestore/mailboxProtectionUnits/{mailboxProtectionUnit-id}` | `await mailboxProtectionUnitsClient.update(params);` |
+
+## EnableClient Endpoints
+
+The EnableClient instance gives access to the following `/solutions/backupRestore/enable` endpoints. You can get a `EnableClient` instance like so:
+
+```typescript
+const enableClient = backupRestoreClient.enable;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action enable | `POST /solutions/backupRestore/enable` | `await enableClient.create(params);` |
+
+## OneDriveForBusinessProtectionPoliciesClient Endpoints
+
+The OneDriveForBusinessProtectionPoliciesClient instance gives access to the following `/solutions/backupRestore/oneDriveForBusinessProtectionPolicies` endpoints. You can get a `OneDriveForBusinessProtectionPoliciesClient` instance like so:
+
+```typescript
+const oneDriveForBusinessProtectionPoliciesClient = backupRestoreClient.oneDriveForBusinessProtectionPolicies;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get oneDriveForBusinessProtectionPolicies from solutions | `GET /solutions/backupRestore/oneDriveForBusinessProtectionPolicies` | `await oneDriveForBusinessProtectionPoliciesClient.list(params);` |
+| Create oneDriveForBusinessProtectionPolicy | `POST /solutions/backupRestore/oneDriveForBusinessProtectionPolicies` | `await oneDriveForBusinessProtectionPoliciesClient.create(params);` |
+| Get oneDriveForBusinessProtectionPolicies from solutions | `GET /solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}` | `await oneDriveForBusinessProtectionPoliciesClient.get({"oneDriveForBusinessProtectionPolicy-id": oneDriveForBusinessProtectionPolicyId  });` |
+| Delete navigation property oneDriveForBusinessProtectionPolicies for solutions | `DELETE /solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}` | `await oneDriveForBusinessProtectionPoliciesClient.delete({"oneDriveForBusinessProtectionPolicy-id": oneDriveForBusinessProtectionPolicyId  });` |
+| Update oneDriveForBusinessProtectionPolicy | `PATCH /solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}` | `await oneDriveForBusinessProtectionPoliciesClient.update(params);` |
+
+## DriveInclusionRulesClient Endpoints
+
+The DriveInclusionRulesClient instance gives access to the following `/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveInclusionRules` endpoints. You can get a `DriveInclusionRulesClient` instance like so:
+
+```typescript
+const driveInclusionRulesClient = await oneDriveForBusinessProtectionPoliciesClient.driveInclusionRules(oneDriveForBusinessProtectionPolicyId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List driveInclusionRules | `GET /solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveInclusionRules` | `await driveInclusionRulesClient.list(params);` |
+| Get protectionRuleBase | `GET /solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveInclusionRules/{driveProtectionRule-id}` | `await driveInclusionRulesClient.get({"driveProtectionRule-id": driveProtectionRuleId  });` |
+
+## DriveProtectionUnitsClient Endpoints
+
+The DriveProtectionUnitsClient instance gives access to the following `/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveProtectionUnits` endpoints. You can get a `DriveProtectionUnitsClient` instance like so:
+
+```typescript
+const driveProtectionUnitsClient = await oneDriveForBusinessProtectionPoliciesClient.driveProtectionUnits(oneDriveForBusinessProtectionPolicyId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List driveProtectionUnits | `GET /solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveProtectionUnits` | `await driveProtectionUnitsClient.list(params);` |
+| Get driveProtectionUnits from solutions | `GET /solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveProtectionUnits/{driveProtectionUnit-id}` | `await driveProtectionUnitsClient.get({"driveProtectionUnit-id": driveProtectionUnitId  });` |
+
+## OneDriveForBusinessRestoreSessionsClient Endpoints
+
+The OneDriveForBusinessRestoreSessionsClient instance gives access to the following `/solutions/backupRestore/oneDriveForBusinessRestoreSessions` endpoints. You can get a `OneDriveForBusinessRestoreSessionsClient` instance like so:
+
+```typescript
+const oneDriveForBusinessRestoreSessionsClient = backupRestoreClient.oneDriveForBusinessRestoreSessions;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get oneDriveForBusinessRestoreSessions from solutions | `GET /solutions/backupRestore/oneDriveForBusinessRestoreSessions` | `await oneDriveForBusinessRestoreSessionsClient.list(params);` |
+| Create new navigation property to oneDriveForBusinessRestoreSessions for solutions | `POST /solutions/backupRestore/oneDriveForBusinessRestoreSessions` | `await oneDriveForBusinessRestoreSessionsClient.create(params);` |
+| Get oneDriveForBusinessRestoreSessions from solutions | `GET /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}` | `await oneDriveForBusinessRestoreSessionsClient.get({"oneDriveForBusinessRestoreSession-id": oneDriveForBusinessRestoreSessionId  });` |
+| Delete navigation property oneDriveForBusinessRestoreSessions for solutions | `DELETE /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}` | `await oneDriveForBusinessRestoreSessionsClient.delete({"oneDriveForBusinessRestoreSession-id": oneDriveForBusinessRestoreSessionId  });` |
+| Update oneDriveForBusinessRestoreSession | `PATCH /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}` | `await oneDriveForBusinessRestoreSessionsClient.update(params);` |
+
+## DriveRestoreArtifactsClient Endpoints
+
+The DriveRestoreArtifactsClient instance gives access to the following `/solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts` endpoints. You can get a `DriveRestoreArtifactsClient` instance like so:
+
+```typescript
+const driveRestoreArtifactsClient = await oneDriveForBusinessRestoreSessionsClient.driveRestoreArtifacts(oneDriveForBusinessRestoreSessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List driveRestoreArtifacts | `GET /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts` | `await driveRestoreArtifactsClient.list(params);` |
+| Create new navigation property to driveRestoreArtifacts for solutions | `POST /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts` | `await driveRestoreArtifactsClient.create(params);` |
+| Get driveRestoreArtifacts from solutions | `GET /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts/{driveRestoreArtifact-id}` | `await driveRestoreArtifactsClient.get({"driveRestoreArtifact-id": driveRestoreArtifactId  });` |
+| Delete navigation property driveRestoreArtifacts for solutions | `DELETE /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts/{driveRestoreArtifact-id}` | `await driveRestoreArtifactsClient.delete({"driveRestoreArtifact-id": driveRestoreArtifactId  });` |
+| Update the navigation property driveRestoreArtifacts in solutions | `PATCH /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts/{driveRestoreArtifact-id}` | `await driveRestoreArtifactsClient.update(params);` |
+
+## RestorePointClient Endpoints
+
+The RestorePointClient instance gives access to the following `/solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts/{driveRestoreArtifact-id}/restorePoint` endpoints. You can get a `RestorePointClient` instance like so:
+
+```typescript
+const restorePointClient = await driveRestoreArtifactsClient.restorePoint(driveRestoreArtifactId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get restorePoint from solutions | `GET /solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts/{driveRestoreArtifact-id}/restorePoint` | `await restorePointClient.list(params);` |
+
+## ProtectionPoliciesClient Endpoints
+
+The ProtectionPoliciesClient instance gives access to the following `/solutions/backupRestore/protectionPolicies` endpoints. You can get a `ProtectionPoliciesClient` instance like so:
+
+```typescript
+const protectionPoliciesClient = backupRestoreClient.protectionPolicies;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get protectionPolicies from solutions | `GET /solutions/backupRestore/protectionPolicies` | `await protectionPoliciesClient.list(params);` |
+| Create new navigation property to protectionPolicies for solutions | `POST /solutions/backupRestore/protectionPolicies` | `await protectionPoliciesClient.create(params);` |
+| Get protectionPolicies from solutions | `GET /solutions/backupRestore/protectionPolicies/{protectionPolicyBase-id}` | `await protectionPoliciesClient.get({"protectionPolicyBase-id": protectionPolicyBaseId  });` |
+| Delete protectionPolicyBase | `DELETE /solutions/backupRestore/protectionPolicies/{protectionPolicyBase-id}` | `await protectionPoliciesClient.delete({"protectionPolicyBase-id": protectionPolicyBaseId  });` |
+| Update the navigation property protectionPolicies in solutions | `PATCH /solutions/backupRestore/protectionPolicies/{protectionPolicyBase-id}` | `await protectionPoliciesClient.update(params);` |
+
+## ActivateClient Endpoints
+
+The ActivateClient instance gives access to the following `/solutions/backupRestore/protectionPolicies/{protectionPolicyBase-id}/activate` endpoints. You can get a `ActivateClient` instance like so:
+
+```typescript
+const activateClient = await protectionPoliciesClient.activate(protectionPolicyBaseId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action activate | `POST /solutions/backupRestore/protectionPolicies/{protectionPolicyBase-id}/activate` | `await activateClient.create(params);` |
+
+## DeactivateClient Endpoints
+
+The DeactivateClient instance gives access to the following `/solutions/backupRestore/protectionPolicies/{protectionPolicyBase-id}/deactivate` endpoints. You can get a `DeactivateClient` instance like so:
+
+```typescript
+const deactivateClient = await protectionPoliciesClient.deactivate(protectionPolicyBaseId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action deactivate | `POST /solutions/backupRestore/protectionPolicies/{protectionPolicyBase-id}/deactivate` | `await deactivateClient.create(params);` |
+
+## ProtectionUnitsClient Endpoints
+
+The ProtectionUnitsClient instance gives access to the following `/solutions/backupRestore/protectionUnits` endpoints. You can get a `ProtectionUnitsClient` instance like so:
+
+```typescript
+const protectionUnitsClient = backupRestoreClient.protectionUnits;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get protectionUnitBase | `GET /solutions/backupRestore/protectionUnits` | `await protectionUnitsClient.list(params);` |
+| Get protectionUnitBase | `GET /solutions/backupRestore/protectionUnits/{protectionUnitBase-id}` | `await protectionUnitsClient.get({"protectionUnitBase-id": protectionUnitBaseId  });` |
+
+## RestorePointsClient Endpoints
+
+The RestorePointsClient instance gives access to the following `/solutions/backupRestore/restorePoints` endpoints. You can get a `RestorePointsClient` instance like so:
+
+```typescript
+const restorePointsClient = backupRestoreClient.restorePoints;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get restorePoints from solutions | `GET /solutions/backupRestore/restorePoints` | `await restorePointsClient.list(params);` |
+| Create new navigation property to restorePoints for solutions | `POST /solutions/backupRestore/restorePoints` | `await restorePointsClient.create(params);` |
+| Get restorePoints from solutions | `GET /solutions/backupRestore/restorePoints/{restorePoint-id}` | `await restorePointsClient.get({"restorePoint-id": restorePointId  });` |
+| Delete navigation property restorePoints for solutions | `DELETE /solutions/backupRestore/restorePoints/{restorePoint-id}` | `await restorePointsClient.delete({"restorePoint-id": restorePointId  });` |
+| Update the navigation property restorePoints in solutions | `PATCH /solutions/backupRestore/restorePoints/{restorePoint-id}` | `await restorePointsClient.update(params);` |
+
+## ProtectionUnitClient Endpoints
+
+The ProtectionUnitClient instance gives access to the following `/solutions/backupRestore/restorePoints/{restorePoint-id}/protectionUnit` endpoints. You can get a `ProtectionUnitClient` instance like so:
+
+```typescript
+const protectionUnitClient = await restorePointsClient.protectionUnit(restorePointId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get protectionUnit from solutions | `GET /solutions/backupRestore/restorePoints/{restorePoint-id}/protectionUnit` | `await protectionUnitClient.list(params);` |
+
+## SearchClient Endpoints
+
+The SearchClient instance gives access to the following `/solutions/backupRestore/restorePoints/search` endpoints. You can get a `SearchClient` instance like so:
+
+```typescript
+const searchClient = restorePointsClient.search;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action search | `POST /solutions/backupRestore/restorePoints/search` | `await searchClient.create(params);` |
+
+## RestoreSessionsClient Endpoints
+
+The RestoreSessionsClient instance gives access to the following `/solutions/backupRestore/restoreSessions` endpoints. You can get a `RestoreSessionsClient` instance like so:
+
+```typescript
+const restoreSessionsClient = backupRestoreClient.restoreSessions;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List restoreSessionBase objects | `GET /solutions/backupRestore/restoreSessions` | `await restoreSessionsClient.list(params);` |
+| Create new navigation property to restoreSessions for solutions | `POST /solutions/backupRestore/restoreSessions` | `await restoreSessionsClient.create(params);` |
+| Get restoreSessionBase | `GET /solutions/backupRestore/restoreSessions/{restoreSessionBase-id}` | `await restoreSessionsClient.get({"restoreSessionBase-id": restoreSessionBaseId  });` |
+| Delete restoreSessionBase | `DELETE /solutions/backupRestore/restoreSessions/{restoreSessionBase-id}` | `await restoreSessionsClient.delete({"restoreSessionBase-id": restoreSessionBaseId  });` |
+| Update the navigation property restoreSessions in solutions | `PATCH /solutions/backupRestore/restoreSessions/{restoreSessionBase-id}` | `await restoreSessionsClient.update(params);` |
+
+## ActivateClient Endpoints
+
+The ActivateClient instance gives access to the following `/solutions/backupRestore/restoreSessions/{restoreSessionBase-id}/activate` endpoints. You can get a `ActivateClient` instance like so:
+
+```typescript
+const activateClient = await restoreSessionsClient.activate(restoreSessionBaseId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action activate | `POST /solutions/backupRestore/restoreSessions/{restoreSessionBase-id}/activate` | `await activateClient.create(params);` |
+
+## ServiceAppsClient Endpoints
+
+The ServiceAppsClient instance gives access to the following `/solutions/backupRestore/serviceApps` endpoints. You can get a `ServiceAppsClient` instance like so:
+
+```typescript
+const serviceAppsClient = backupRestoreClient.serviceApps;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List serviceApps | `GET /solutions/backupRestore/serviceApps` | `await serviceAppsClient.list(params);` |
+| Create serviceApp | `POST /solutions/backupRestore/serviceApps` | `await serviceAppsClient.create(params);` |
+| Get serviceApp | `GET /solutions/backupRestore/serviceApps/{serviceApp-id}` | `await serviceAppsClient.get({"serviceApp-id": serviceAppId  });` |
+| Delete serviceApp | `DELETE /solutions/backupRestore/serviceApps/{serviceApp-id}` | `await serviceAppsClient.delete({"serviceApp-id": serviceAppId  });` |
+| Update the navigation property serviceApps in solutions | `PATCH /solutions/backupRestore/serviceApps/{serviceApp-id}` | `await serviceAppsClient.update(params);` |
+
+## ActivateClient Endpoints
+
+The ActivateClient instance gives access to the following `/solutions/backupRestore/serviceApps/{serviceApp-id}/activate` endpoints. You can get a `ActivateClient` instance like so:
+
+```typescript
+const activateClient = await serviceAppsClient.activate(serviceAppId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action activate | `POST /solutions/backupRestore/serviceApps/{serviceApp-id}/activate` | `await activateClient.create(params);` |
+
+## DeactivateClient Endpoints
+
+The DeactivateClient instance gives access to the following `/solutions/backupRestore/serviceApps/{serviceApp-id}/deactivate` endpoints. You can get a `DeactivateClient` instance like so:
+
+```typescript
+const deactivateClient = await serviceAppsClient.deactivate(serviceAppId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action deactivate | `POST /solutions/backupRestore/serviceApps/{serviceApp-id}/deactivate` | `await deactivateClient.create(params);` |
+
+## SharePointProtectionPoliciesClient Endpoints
+
+The SharePointProtectionPoliciesClient instance gives access to the following `/solutions/backupRestore/sharePointProtectionPolicies` endpoints. You can get a `SharePointProtectionPoliciesClient` instance like so:
+
+```typescript
+const sharePointProtectionPoliciesClient = backupRestoreClient.sharePointProtectionPolicies;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sharePointProtectionPolicies from solutions | `GET /solutions/backupRestore/sharePointProtectionPolicies` | `await sharePointProtectionPoliciesClient.list(params);` |
+| Create sharePointProtectionPolicy | `POST /solutions/backupRestore/sharePointProtectionPolicies` | `await sharePointProtectionPoliciesClient.create(params);` |
+| Get sharePointProtectionPolicies from solutions | `GET /solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}` | `await sharePointProtectionPoliciesClient.get({"sharePointProtectionPolicy-id": sharePointProtectionPolicyId  });` |
+| Delete navigation property sharePointProtectionPolicies for solutions | `DELETE /solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}` | `await sharePointProtectionPoliciesClient.delete({"sharePointProtectionPolicy-id": sharePointProtectionPolicyId  });` |
+| Update sharePointProtectionPolicy | `PATCH /solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}` | `await sharePointProtectionPoliciesClient.update(params);` |
+
+## SiteInclusionRulesClient Endpoints
+
+The SiteInclusionRulesClient instance gives access to the following `/solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteInclusionRules` endpoints. You can get a `SiteInclusionRulesClient` instance like so:
+
+```typescript
+const siteInclusionRulesClient = await sharePointProtectionPoliciesClient.siteInclusionRules(sharePointProtectionPolicyId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List siteInclusionRules | `GET /solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteInclusionRules` | `await siteInclusionRulesClient.list(params);` |
+| Get protectionRuleBase | `GET /solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteInclusionRules/{siteProtectionRule-id}` | `await siteInclusionRulesClient.get({"siteProtectionRule-id": siteProtectionRuleId  });` |
+
+## SiteProtectionUnitsClient Endpoints
+
+The SiteProtectionUnitsClient instance gives access to the following `/solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteProtectionUnits` endpoints. You can get a `SiteProtectionUnitsClient` instance like so:
+
+```typescript
+const siteProtectionUnitsClient = await sharePointProtectionPoliciesClient.siteProtectionUnits(sharePointProtectionPolicyId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List siteProtectionUnits | `GET /solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteProtectionUnits` | `await siteProtectionUnitsClient.list(params);` |
+| Get siteProtectionUnits from solutions | `GET /solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteProtectionUnits/{siteProtectionUnit-id}` | `await siteProtectionUnitsClient.get({"siteProtectionUnit-id": siteProtectionUnitId  });` |
+
+## SharePointRestoreSessionsClient Endpoints
+
+The SharePointRestoreSessionsClient instance gives access to the following `/solutions/backupRestore/sharePointRestoreSessions` endpoints. You can get a `SharePointRestoreSessionsClient` instance like so:
+
+```typescript
+const sharePointRestoreSessionsClient = backupRestoreClient.sharePointRestoreSessions;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sharePointRestoreSessions from solutions | `GET /solutions/backupRestore/sharePointRestoreSessions` | `await sharePointRestoreSessionsClient.list(params);` |
+| Create sharePointRestoreSession | `POST /solutions/backupRestore/sharePointRestoreSessions` | `await sharePointRestoreSessionsClient.create(params);` |
+| Get sharePointRestoreSessions from solutions | `GET /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}` | `await sharePointRestoreSessionsClient.get({"sharePointRestoreSession-id": sharePointRestoreSessionId  });` |
+| Delete navigation property sharePointRestoreSessions for solutions | `DELETE /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}` | `await sharePointRestoreSessionsClient.delete({"sharePointRestoreSession-id": sharePointRestoreSessionId  });` |
+| Update the navigation property sharePointRestoreSessions in solutions | `PATCH /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}` | `await sharePointRestoreSessionsClient.update(params);` |
+
+## SiteRestoreArtifactsClient Endpoints
+
+The SiteRestoreArtifactsClient instance gives access to the following `/solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts` endpoints. You can get a `SiteRestoreArtifactsClient` instance like so:
+
+```typescript
+const siteRestoreArtifactsClient = await sharePointRestoreSessionsClient.siteRestoreArtifacts(sharePointRestoreSessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List siteRestoreArtifacts | `GET /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts` | `await siteRestoreArtifactsClient.list(params);` |
+| Create new navigation property to siteRestoreArtifacts for solutions | `POST /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts` | `await siteRestoreArtifactsClient.create(params);` |
+| Get siteRestoreArtifacts from solutions | `GET /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts/{siteRestoreArtifact-id}` | `await siteRestoreArtifactsClient.get({"siteRestoreArtifact-id": siteRestoreArtifactId  });` |
+| Delete navigation property siteRestoreArtifacts for solutions | `DELETE /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts/{siteRestoreArtifact-id}` | `await siteRestoreArtifactsClient.delete({"siteRestoreArtifact-id": siteRestoreArtifactId  });` |
+| Update the navigation property siteRestoreArtifacts in solutions | `PATCH /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts/{siteRestoreArtifact-id}` | `await siteRestoreArtifactsClient.update(params);` |
+
+## RestorePointClient Endpoints
+
+The RestorePointClient instance gives access to the following `/solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts/{siteRestoreArtifact-id}/restorePoint` endpoints. You can get a `RestorePointClient` instance like so:
+
+```typescript
+const restorePointClient = await siteRestoreArtifactsClient.restorePoint(siteRestoreArtifactId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get restorePoint from solutions | `GET /solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts/{siteRestoreArtifact-id}/restorePoint` | `await restorePointClient.list(params);` |
+
+## SiteInclusionRulesClient Endpoints
+
+The SiteInclusionRulesClient instance gives access to the following `/solutions/backupRestore/siteInclusionRules` endpoints. You can get a `SiteInclusionRulesClient` instance like so:
+
+```typescript
+const siteInclusionRulesClient = backupRestoreClient.siteInclusionRules;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get siteInclusionRules from solutions | `GET /solutions/backupRestore/siteInclusionRules` | `await siteInclusionRulesClient.list(params);` |
+| Create new navigation property to siteInclusionRules for solutions | `POST /solutions/backupRestore/siteInclusionRules` | `await siteInclusionRulesClient.create(params);` |
+| Get siteInclusionRules from solutions | `GET /solutions/backupRestore/siteInclusionRules/{siteProtectionRule-id}` | `await siteInclusionRulesClient.get({"siteProtectionRule-id": siteProtectionRuleId  });` |
+| Delete navigation property siteInclusionRules for solutions | `DELETE /solutions/backupRestore/siteInclusionRules/{siteProtectionRule-id}` | `await siteInclusionRulesClient.delete({"siteProtectionRule-id": siteProtectionRuleId  });` |
+| Update the navigation property siteInclusionRules in solutions | `PATCH /solutions/backupRestore/siteInclusionRules/{siteProtectionRule-id}` | `await siteInclusionRulesClient.update(params);` |
+
+## SiteProtectionUnitsClient Endpoints
+
+The SiteProtectionUnitsClient instance gives access to the following `/solutions/backupRestore/siteProtectionUnits` endpoints. You can get a `SiteProtectionUnitsClient` instance like so:
+
+```typescript
+const siteProtectionUnitsClient = backupRestoreClient.siteProtectionUnits;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get siteProtectionUnits from solutions | `GET /solutions/backupRestore/siteProtectionUnits` | `await siteProtectionUnitsClient.list(params);` |
+| Create new navigation property to siteProtectionUnits for solutions | `POST /solutions/backupRestore/siteProtectionUnits` | `await siteProtectionUnitsClient.create(params);` |
+| Get siteProtectionUnits from solutions | `GET /solutions/backupRestore/siteProtectionUnits/{siteProtectionUnit-id}` | `await siteProtectionUnitsClient.get({"siteProtectionUnit-id": siteProtectionUnitId  });` |
+| Delete navigation property siteProtectionUnits for solutions | `DELETE /solutions/backupRestore/siteProtectionUnits/{siteProtectionUnit-id}` | `await siteProtectionUnitsClient.delete({"siteProtectionUnit-id": siteProtectionUnitId  });` |
+| Update the navigation property siteProtectionUnits in solutions | `PATCH /solutions/backupRestore/siteProtectionUnits/{siteProtectionUnit-id}` | `await siteProtectionUnitsClient.update(params);` |
+
+## BookingBusinessesClient Endpoints
+
+The BookingBusinessesClient instance gives access to the following `/solutions/bookingBusinesses` endpoints. You can get a `BookingBusinessesClient` instance like so:
+
+```typescript
+const bookingBusinessesClient = solutionsClient.bookingBusinesses;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List bookingBusinesses | `GET /solutions/bookingBusinesses` | `await bookingBusinessesClient.list(params);` |
+| Create bookingBusiness | `POST /solutions/bookingBusinesses` | `await bookingBusinessesClient.create(params);` |
+| Get bookingBusiness | `GET /solutions/bookingBusinesses/{bookingBusiness-id}` | `await bookingBusinessesClient.get({"bookingBusiness-id": bookingBusinessId  });` |
+| Delete bookingBusiness | `DELETE /solutions/bookingBusinesses/{bookingBusiness-id}` | `await bookingBusinessesClient.delete({"bookingBusiness-id": bookingBusinessId  });` |
+| Update bookingbusiness | `PATCH /solutions/bookingBusinesses/{bookingBusiness-id}` | `await bookingBusinessesClient.update(params);` |
+
+## AppointmentsClient Endpoints
+
+The AppointmentsClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/appointments` endpoints. You can get a `AppointmentsClient` instance like so:
+
+```typescript
+const appointmentsClient = await bookingBusinessesClient.appointments(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List appointments | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/appointments` | `await appointmentsClient.list(params);` |
+| Create bookingAppointment | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/appointments` | `await appointmentsClient.create(params);` |
+| Get bookingAppointment | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/appointments/{bookingAppointment-id}` | `await appointmentsClient.get({"bookingAppointment-id": bookingAppointmentId  });` |
+| Delete bookingAppointment | `DELETE /solutions/bookingBusinesses/{bookingBusiness-id}/appointments/{bookingAppointment-id}` | `await appointmentsClient.delete({"bookingAppointment-id": bookingAppointmentId  });` |
+| Update bookingAppointment | `PATCH /solutions/bookingBusinesses/{bookingBusiness-id}/appointments/{bookingAppointment-id}` | `await appointmentsClient.update(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/appointments/{bookingAppointment-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await appointmentsClient.cancel(bookingAppointmentId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/appointments/{bookingAppointment-id}/cancel` | `await cancelClient.create(params);` |
+
+## CalendarViewClient Endpoints
+
+The CalendarViewClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/calendarView` endpoints. You can get a `CalendarViewClient` instance like so:
+
+```typescript
+const calendarViewClient = await bookingBusinessesClient.calendarView(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List business calendarView | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/calendarView` | `await calendarViewClient.list(params);` |
+| Create new navigation property to calendarView for solutions | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/calendarView` | `await calendarViewClient.create(params);` |
+| Get calendarView from solutions | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/calendarView/{bookingAppointment-id}` | `await calendarViewClient.get({"bookingAppointment-id": bookingAppointmentId  });` |
+| Delete navigation property calendarView for solutions | `DELETE /solutions/bookingBusinesses/{bookingBusiness-id}/calendarView/{bookingAppointment-id}` | `await calendarViewClient.delete({"bookingAppointment-id": bookingAppointmentId  });` |
+| Update the navigation property calendarView in solutions | `PATCH /solutions/bookingBusinesses/{bookingBusiness-id}/calendarView/{bookingAppointment-id}` | `await calendarViewClient.update(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/calendarView/{bookingAppointment-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await calendarViewClient.cancel(bookingAppointmentId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/calendarView/{bookingAppointment-id}/cancel` | `await cancelClient.create(params);` |
+
+## CustomersClient Endpoints
+
+The CustomersClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/customers` endpoints. You can get a `CustomersClient` instance like so:
+
+```typescript
+const customersClient = await bookingBusinessesClient.customers(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List customers | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/customers` | `await customersClient.list(params);` |
+| Create bookingCustomer | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/customers` | `await customersClient.create(params);` |
+| Get bookingCustomer | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/customers/{bookingCustomerBase-id}` | `await customersClient.get({"bookingCustomerBase-id": bookingCustomerBaseId  });` |
+| Delete bookingCustomer | `DELETE /solutions/bookingBusinesses/{bookingBusiness-id}/customers/{bookingCustomerBase-id}` | `await customersClient.delete({"bookingCustomerBase-id": bookingCustomerBaseId  });` |
+| Update bookingCustomer | `PATCH /solutions/bookingBusinesses/{bookingBusiness-id}/customers/{bookingCustomerBase-id}` | `await customersClient.update(params);` |
+
+## CustomQuestionsClient Endpoints
+
+The CustomQuestionsClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/customQuestions` endpoints. You can get a `CustomQuestionsClient` instance like so:
+
+```typescript
+const customQuestionsClient = await bookingBusinessesClient.customQuestions(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List customQuestions | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/customQuestions` | `await customQuestionsClient.list(params);` |
+| Create bookingCustomQuestion | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/customQuestions` | `await customQuestionsClient.create(params);` |
+| Get bookingCustomQuestion | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/customQuestions/{bookingCustomQuestion-id}` | `await customQuestionsClient.get({"bookingCustomQuestion-id": bookingCustomQuestionId  });` |
+| Delete bookingCustomQuestion | `DELETE /solutions/bookingBusinesses/{bookingBusiness-id}/customQuestions/{bookingCustomQuestion-id}` | `await customQuestionsClient.delete({"bookingCustomQuestion-id": bookingCustomQuestionId  });` |
+| Update bookingCustomQuestion | `PATCH /solutions/bookingBusinesses/{bookingBusiness-id}/customQuestions/{bookingCustomQuestion-id}` | `await customQuestionsClient.update(params);` |
+
+## GetStaffAvailabilityClient Endpoints
+
+The GetStaffAvailabilityClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/getStaffAvailability` endpoints. You can get a `GetStaffAvailabilityClient` instance like so:
+
+```typescript
+const getStaffAvailabilityClient = await bookingBusinessesClient.getStaffAvailability(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action getStaffAvailability | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/getStaffAvailability` | `await getStaffAvailabilityClient.create(params);` |
+
+## PublishClient Endpoints
+
+The PublishClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/publish` endpoints. You can get a `PublishClient` instance like so:
+
+```typescript
+const publishClient = await bookingBusinessesClient.publish(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action publish | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/publish` | `await publishClient.create(params);` |
+
+## UnpublishClient Endpoints
+
+The UnpublishClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/unpublish` endpoints. You can get a `UnpublishClient` instance like so:
+
+```typescript
+const unpublishClient = await bookingBusinessesClient.unpublish(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unpublish | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/unpublish` | `await unpublishClient.create(params);` |
+
+## ServicesClient Endpoints
+
+The ServicesClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/services` endpoints. You can get a `ServicesClient` instance like so:
+
+```typescript
+const servicesClient = await bookingBusinessesClient.services(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List services | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/services` | `await servicesClient.list(params);` |
+| Create bookingService | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/services` | `await servicesClient.create(params);` |
+| Get bookingService | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/services/{bookingService-id}` | `await servicesClient.get({"bookingService-id": bookingServiceId  });` |
+| Delete bookingService | `DELETE /solutions/bookingBusinesses/{bookingBusiness-id}/services/{bookingService-id}` | `await servicesClient.delete({"bookingService-id": bookingServiceId  });` |
+| Update bookingservice | `PATCH /solutions/bookingBusinesses/{bookingBusiness-id}/services/{bookingService-id}` | `await servicesClient.update(params);` |
+
+## StaffMembersClient Endpoints
+
+The StaffMembersClient instance gives access to the following `/solutions/bookingBusinesses/{bookingBusiness-id}/staffMembers` endpoints. You can get a `StaffMembersClient` instance like so:
+
+```typescript
+const staffMembersClient = await bookingBusinessesClient.staffMembers(bookingBusinessId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List staffMembers | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/staffMembers` | `await staffMembersClient.list(params);` |
+| Create bookingStaffMember | `POST /solutions/bookingBusinesses/{bookingBusiness-id}/staffMembers` | `await staffMembersClient.create(params);` |
+| Get bookingStaffMember | `GET /solutions/bookingBusinesses/{bookingBusiness-id}/staffMembers/{bookingStaffMemberBase-id}` | `await staffMembersClient.get({"bookingStaffMemberBase-id": bookingStaffMemberBaseId  });` |
+| Delete bookingStaffMember | `DELETE /solutions/bookingBusinesses/{bookingBusiness-id}/staffMembers/{bookingStaffMemberBase-id}` | `await staffMembersClient.delete({"bookingStaffMemberBase-id": bookingStaffMemberBaseId  });` |
+| Update bookingstaffmember | `PATCH /solutions/bookingBusinesses/{bookingBusiness-id}/staffMembers/{bookingStaffMemberBase-id}` | `await staffMembersClient.update(params);` |
+
+## BookingCurrenciesClient Endpoints
+
+The BookingCurrenciesClient instance gives access to the following `/solutions/bookingCurrencies` endpoints. You can get a `BookingCurrenciesClient` instance like so:
+
+```typescript
+const bookingCurrenciesClient = solutionsClient.bookingCurrencies;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List bookingCurrencies | `GET /solutions/bookingCurrencies` | `await bookingCurrenciesClient.list(params);` |
+| Create new navigation property to bookingCurrencies for solutions | `POST /solutions/bookingCurrencies` | `await bookingCurrenciesClient.create(params);` |
+| Get bookingCurrency | `GET /solutions/bookingCurrencies/{bookingCurrency-id}` | `await bookingCurrenciesClient.get({"bookingCurrency-id": bookingCurrencyId  });` |
+| Delete navigation property bookingCurrencies for solutions | `DELETE /solutions/bookingCurrencies/{bookingCurrency-id}` | `await bookingCurrenciesClient.delete({"bookingCurrency-id": bookingCurrencyId  });` |
+| Update the navigation property bookingCurrencies in solutions | `PATCH /solutions/bookingCurrencies/{bookingCurrency-id}` | `await bookingCurrenciesClient.update(params);` |
+
+## VirtualEventsClient Endpoints
+
+The VirtualEventsClient instance gives access to the following `/solutions/virtualEvents` endpoints. You can get a `VirtualEventsClient` instance like so:
+
+```typescript
+const virtualEventsClient = solutionsClient.virtualEvents;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get virtualEvents from solutions | `GET /solutions/virtualEvents` | `await virtualEventsClient.list(params);` |
+| Delete navigation property virtualEvents for solutions | `DELETE /solutions/virtualEvents` | `await virtualEventsClient.delete({"":   });` |
+| Update the navigation property virtualEvents in solutions | `PATCH /solutions/virtualEvents` | `await virtualEventsClient.update(params);` |
+
+## EventsClient Endpoints
+
+The EventsClient instance gives access to the following `/solutions/virtualEvents/events` endpoints. You can get a `EventsClient` instance like so:
+
+```typescript
+const eventsClient = virtualEventsClient.events;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get events from solutions | `GET /solutions/virtualEvents/events` | `await eventsClient.list(params);` |
+| Create new navigation property to events for solutions | `POST /solutions/virtualEvents/events` | `await eventsClient.create(params);` |
+| Get events from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}` | `await eventsClient.get({"virtualEvent-id": virtualEventId  });` |
+| Delete navigation property events for solutions | `DELETE /solutions/virtualEvents/events/{virtualEvent-id}` | `await eventsClient.delete({"virtualEvent-id": virtualEventId  });` |
+| Update the navigation property events in solutions | `PATCH /solutions/virtualEvents/events/{virtualEvent-id}` | `await eventsClient.update(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/solutions/virtualEvents/events/{virtualEvent-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await eventsClient.cancel(virtualEventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /solutions/virtualEvents/events/{virtualEvent-id}/cancel` | `await cancelClient.create(params);` |
+
+## PublishClient Endpoints
+
+The PublishClient instance gives access to the following `/solutions/virtualEvents/events/{virtualEvent-id}/publish` endpoints. You can get a `PublishClient` instance like so:
+
+```typescript
+const publishClient = await eventsClient.publish(virtualEventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action publish | `POST /solutions/virtualEvents/events/{virtualEvent-id}/publish` | `await publishClient.create(params);` |
+
+## SetExternalEventInformationClient Endpoints
+
+The SetExternalEventInformationClient instance gives access to the following `/solutions/virtualEvents/events/{virtualEvent-id}/setExternalEventInformation` endpoints. You can get a `SetExternalEventInformationClient` instance like so:
+
+```typescript
+const setExternalEventInformationClient = await eventsClient.setExternalEventInformation(virtualEventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setExternalEventInformation | `POST /solutions/virtualEvents/events/{virtualEvent-id}/setExternalEventInformation` | `await setExternalEventInformationClient.create(params);` |
+
+## PresentersClient Endpoints
+
+The PresentersClient instance gives access to the following `/solutions/virtualEvents/events/{virtualEvent-id}/presenters` endpoints. You can get a `PresentersClient` instance like so:
+
+```typescript
+const presentersClient = await eventsClient.presenters(virtualEventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get presenters from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/presenters` | `await presentersClient.list(params);` |
+| Create new navigation property to presenters for solutions | `POST /solutions/virtualEvents/events/{virtualEvent-id}/presenters` | `await presentersClient.create(params);` |
+| Get presenters from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.get({"virtualEventPresenter-id": virtualEventPresenterId  });` |
+| Delete navigation property presenters for solutions | `DELETE /solutions/virtualEvents/events/{virtualEvent-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.delete({"virtualEventPresenter-id": virtualEventPresenterId  });` |
+| Update the navigation property presenters in solutions | `PATCH /solutions/virtualEvents/events/{virtualEvent-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.update(params);` |
+
+## SessionsClient Endpoints
+
+The SessionsClient instance gives access to the following `/solutions/virtualEvents/events/{virtualEvent-id}/sessions` endpoints. You can get a `SessionsClient` instance like so:
+
+```typescript
+const sessionsClient = await eventsClient.sessions(virtualEventId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sessions from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/sessions` | `await sessionsClient.list(params);` |
+| Create new navigation property to sessions for solutions | `POST /solutions/virtualEvents/events/{virtualEvent-id}/sessions` | `await sessionsClient.create(params);` |
+| Get sessions from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.get({"virtualEventSession-id": virtualEventSessionId  });` |
+| Delete navigation property sessions for solutions | `DELETE /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.delete({"virtualEventSession-id": virtualEventSessionId  });` |
+| Update the navigation property sessions in solutions | `PATCH /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.update(params);` |
+
+## AttendanceReportsClient Endpoints
+
+The AttendanceReportsClient instance gives access to the following `/solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports` endpoints. You can get a `AttendanceReportsClient` instance like so:
+
+```typescript
+const attendanceReportsClient = await sessionsClient.attendanceReports(virtualEventSessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceReports from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports` | `await attendanceReportsClient.list(params);` |
+| Create new navigation property to attendanceReports for solutions | `POST /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports` | `await attendanceReportsClient.create(params);` |
+| Get attendanceReports from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.get({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Delete navigation property attendanceReports for solutions | `DELETE /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.delete({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Update the navigation property attendanceReports in solutions | `PATCH /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.update(params);` |
+
+## AttendanceRecordsClient Endpoints
+
+The AttendanceRecordsClient instance gives access to the following `/solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` endpoints. You can get a `AttendanceRecordsClient` instance like so:
+
+```typescript
+const attendanceRecordsClient = await attendanceReportsClient.attendanceRecords(meetingAttendanceReportId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceRecords from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.list(params);` |
+| Create new navigation property to attendanceRecords for solutions | `POST /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.create(params);` |
+| Get attendanceRecords from solutions | `GET /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.get({"attendanceRecord-id": attendanceRecordId  });` |
+| Delete navigation property attendanceRecords for solutions | `DELETE /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.delete({"attendanceRecord-id": attendanceRecordId  });` |
+| Update the navigation property attendanceRecords in solutions | `PATCH /solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.update(params);` |
+
+## TownhallsClient Endpoints
+
+The TownhallsClient instance gives access to the following `/solutions/virtualEvents/townhalls` endpoints. You can get a `TownhallsClient` instance like so:
+
+```typescript
+const townhallsClient = virtualEventsClient.townhalls;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get virtualEventTownhall | `GET /solutions/virtualEvents/townhalls` | `await townhallsClient.list(params);` |
+| Create virtualEventTownhall | `POST /solutions/virtualEvents/townhalls` | `await townhallsClient.create(params);` |
+| Get virtualEventTownhall | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}` | `await townhallsClient.get({"virtualEventTownhall-id": virtualEventTownhallId  });` |
+| Delete navigation property townhalls for solutions | `DELETE /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}` | `await townhallsClient.delete({"virtualEventTownhall-id": virtualEventTownhallId  });` |
+| Update virtualEventTownhall | `PATCH /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}` | `await townhallsClient.update(params);` |
+
+## PresentersClient Endpoints
+
+The PresentersClient instance gives access to the following `/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters` endpoints. You can get a `PresentersClient` instance like so:
+
+```typescript
+const presentersClient = await townhallsClient.presenters(virtualEventTownhallId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List presenters | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters` | `await presentersClient.list(params);` |
+| Create virtualEventPresenter | `POST /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters` | `await presentersClient.create(params);` |
+| Get virtualEventPresenter | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.get({"virtualEventPresenter-id": virtualEventPresenterId  });` |
+| Delete virtualEventPresenter | `DELETE /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.delete({"virtualEventPresenter-id": virtualEventPresenterId  });` |
+| Update the navigation property presenters in solutions | `PATCH /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.update(params);` |
+
+## SessionsClient Endpoints
+
+The SessionsClient instance gives access to the following `/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions` endpoints. You can get a `SessionsClient` instance like so:
+
+```typescript
+const sessionsClient = await townhallsClient.sessions(virtualEventTownhallId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sessions from solutions | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions` | `await sessionsClient.list(params);` |
+| Create new navigation property to sessions for solutions | `POST /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions` | `await sessionsClient.create(params);` |
+| Get sessions from solutions | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.get({"virtualEventSession-id": virtualEventSessionId  });` |
+| Delete navigation property sessions for solutions | `DELETE /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.delete({"virtualEventSession-id": virtualEventSessionId  });` |
+| Update the navigation property sessions in solutions | `PATCH /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.update(params);` |
+
+## AttendanceReportsClient Endpoints
+
+The AttendanceReportsClient instance gives access to the following `/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports` endpoints. You can get a `AttendanceReportsClient` instance like so:
+
+```typescript
+const attendanceReportsClient = await sessionsClient.attendanceReports(virtualEventSessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceReports from solutions | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports` | `await attendanceReportsClient.list(params);` |
+| Create new navigation property to attendanceReports for solutions | `POST /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports` | `await attendanceReportsClient.create(params);` |
+| Get attendanceReports from solutions | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.get({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Delete navigation property attendanceReports for solutions | `DELETE /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.delete({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Update the navigation property attendanceReports in solutions | `PATCH /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.update(params);` |
+
+## AttendanceRecordsClient Endpoints
+
+The AttendanceRecordsClient instance gives access to the following `/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` endpoints. You can get a `AttendanceRecordsClient` instance like so:
+
+```typescript
+const attendanceRecordsClient = await attendanceReportsClient.attendanceRecords(meetingAttendanceReportId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceRecords from solutions | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.list(params);` |
+| Create new navigation property to attendanceRecords for solutions | `POST /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.create(params);` |
+| Get attendanceRecords from solutions | `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.get({"attendanceRecord-id": attendanceRecordId  });` |
+| Delete navigation property attendanceRecords for solutions | `DELETE /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.delete({"attendanceRecord-id": attendanceRecordId  });` |
+| Update the navigation property attendanceRecords in solutions | `PATCH /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.update(params);` |
+
+## WebinarsClient Endpoints
+
+The WebinarsClient instance gives access to the following `/solutions/virtualEvents/webinars` endpoints. You can get a `WebinarsClient` instance like so:
+
+```typescript
+const webinarsClient = virtualEventsClient.webinars;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List webinars | `GET /solutions/virtualEvents/webinars` | `await webinarsClient.list(params);` |
+| Create virtualEventWebinar | `POST /solutions/virtualEvents/webinars` | `await webinarsClient.create(params);` |
+| Get virtualEventWebinar | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}` | `await webinarsClient.get({"virtualEventWebinar-id": virtualEventWebinarId  });` |
+| Delete navigation property webinars for solutions | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}` | `await webinarsClient.delete({"virtualEventWebinar-id": virtualEventWebinarId  });` |
+| Update virtualEventWebinar | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}` | `await webinarsClient.update(params);` |
+
+## PresentersClient Endpoints
+
+The PresentersClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters` endpoints. You can get a `PresentersClient` instance like so:
+
+```typescript
+const presentersClient = await webinarsClient.presenters(virtualEventWebinarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get presenters from solutions | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters` | `await presentersClient.list(params);` |
+| Create virtualEventPresenter | `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters` | `await presentersClient.create(params);` |
+| Get presenters from solutions | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.get({"virtualEventPresenter-id": virtualEventPresenterId  });` |
+| Delete navigation property presenters for solutions | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.delete({"virtualEventPresenter-id": virtualEventPresenterId  });` |
+| Update virtualEventPresenter | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters/{virtualEventPresenter-id}` | `await presentersClient.update(params);` |
+
+## RegistrationConfigurationClient Endpoints
+
+The RegistrationConfigurationClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration` endpoints. You can get a `RegistrationConfigurationClient` instance like so:
+
+```typescript
+const registrationConfigurationClient = await webinarsClient.registrationConfiguration(virtualEventWebinarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get virtualEventWebinarRegistrationConfiguration | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration` | `await registrationConfigurationClient.list(params);` |
+| Delete navigation property registrationConfiguration for solutions | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration` | `await registrationConfigurationClient.delete({"virtualEventWebinar-id": virtualEventWebinarId  });` |
+| Update the navigation property registrationConfiguration in solutions | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration` | `await registrationConfigurationClient.update(params);` |
+
+## QuestionsClient Endpoints
+
+The QuestionsClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration/questions` endpoints. You can get a `QuestionsClient` instance like so:
+
+```typescript
+const questionsClient = registrationConfigurationClient.questions;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List questions | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration/questions` | `await questionsClient.list(params);` |
+| Create virtualEventRegistrationCustomQuestion | `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration/questions` | `await questionsClient.create(params);` |
+| Get questions from solutions | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration/questions/{virtualEventRegistrationQuestionBase-id}` | `await questionsClient.get({"virtualEventRegistrationQuestionBase-id": virtualEventRegistrationQuestionBaseId  });` |
+| Delete virtualEventRegistrationQuestionBase | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration/questions/{virtualEventRegistrationQuestionBase-id}` | `await questionsClient.delete({"virtualEventRegistrationQuestionBase-id": virtualEventRegistrationQuestionBaseId  });` |
+| Update the navigation property questions in solutions | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration/questions/{virtualEventRegistrationQuestionBase-id}` | `await questionsClient.update(params);` |
+
+## RegistrationsClient Endpoints
+
+The RegistrationsClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations` endpoints. You can get a `RegistrationsClient` instance like so:
+
+```typescript
+const registrationsClient = await webinarsClient.registrations(virtualEventWebinarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List virtualEventRegistrations | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations` | `await registrationsClient.list(params);` |
+| Create virtualEventRegistration | `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations` | `await registrationsClient.create(params);` |
+| Get virtualEventRegistration | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}` | `await registrationsClient.get({"virtualEventRegistration-id": virtualEventRegistrationId  });` |
+| Delete navigation property registrations for solutions | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}` | `await registrationsClient.delete({"virtualEventRegistration-id": virtualEventRegistrationId  });` |
+| Update the navigation property registrations in solutions | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}` | `await registrationsClient.update(params);` |
+
+## CancelClient Endpoints
+
+The CancelClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}/cancel` endpoints. You can get a `CancelClient` instance like so:
+
+```typescript
+const cancelClient = await registrationsClient.cancel(virtualEventRegistrationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action cancel | `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}/cancel` | `await cancelClient.create(params);` |
+
+## SessionsClient Endpoints
+
+The SessionsClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}/sessions` endpoints. You can get a `SessionsClient` instance like so:
+
+```typescript
+const sessionsClient = await registrationsClient.sessions(virtualEventRegistrationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List sessions for a virtual event registration | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}/sessions` | `await sessionsClient.list(params);` |
+| Get sessions from solutions | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.get({"virtualEventSession-id": virtualEventSessionId  });` |
+
+## SessionsClient Endpoints
+
+The SessionsClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions` endpoints. You can get a `SessionsClient` instance like so:
+
+```typescript
+const sessionsClient = await webinarsClient.sessions(virtualEventWebinarId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List sessions for a virtual event | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions` | `await sessionsClient.list(params);` |
+| Create new navigation property to sessions for solutions | `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions` | `await sessionsClient.create(params);` |
+| Get virtualEventSession | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.get({"virtualEventSession-id": virtualEventSessionId  });` |
+| Delete navigation property sessions for solutions | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.delete({"virtualEventSession-id": virtualEventSessionId  });` |
+| Update the navigation property sessions in solutions | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}` | `await sessionsClient.update(params);` |
+
+## AttendanceReportsClient Endpoints
+
+The AttendanceReportsClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports` endpoints. You can get a `AttendanceReportsClient` instance like so:
+
+```typescript
+const attendanceReportsClient = await sessionsClient.attendanceReports(virtualEventSessionId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List meetingAttendanceReports | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports` | `await attendanceReportsClient.list(params);` |
+| Create new navigation property to attendanceReports for solutions | `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports` | `await attendanceReportsClient.create(params);` |
+| Get meetingAttendanceReport | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.get({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Delete navigation property attendanceReports for solutions | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.delete({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Update the navigation property attendanceReports in solutions | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.update(params);` |
+
+## AttendanceRecordsClient Endpoints
+
+The AttendanceRecordsClient instance gives access to the following `/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` endpoints. You can get a `AttendanceRecordsClient` instance like so:
+
+```typescript
+const attendanceRecordsClient = await attendanceReportsClient.attendanceRecords(meetingAttendanceReportId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceRecords from solutions | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.list(params);` |
+| Create new navigation property to attendanceRecords for solutions | `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.create(params);` |
+| Get attendanceRecords from solutions | `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.get({"attendanceRecord-id": attendanceRecordId  });` |
+| Delete navigation property attendanceRecords for solutions | `DELETE /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.delete({"attendanceRecord-id": attendanceRecordId  });` |
+| Update the navigation property attendanceRecords in solutions | `PATCH /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.update(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/teams-templates.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/teams-templates.md
@@ -1,0 +1,25 @@
+# Teams Templates
+
+This page lists all the `/teamsTemplates` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/teamsTemplates` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/microsoftteams/get-started-with-teams-templates), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## TeamsTemplatesClient Endpoints
+
+The TeamsTemplatesClient instance gives access to the following `/teamsTemplates` endpoints. You can get a `TeamsTemplatesClient` instance like so:
+
+```typescript
+const teamsTemplatesClient = graphClient.teamsTemplates;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get entities from teamsTemplates | `GET /teamsTemplates` | `await teamsTemplatesClient.list(params);` |
+| Add new entity to teamsTemplates | `POST /teamsTemplates` | `await teamsTemplatesClient.create(params);` |
+| Get entity from teamsTemplates by key | `GET /teamsTemplates/{teamsTemplate-id}` | `await teamsTemplatesClient.get({"teamsTemplate-id": teamsTemplateId  });` |
+| Delete entity from teamsTemplates | `DELETE /teamsTemplates/{teamsTemplate-id}` | `await teamsTemplatesClient.delete({"teamsTemplate-id": teamsTemplateId  });` |
+| Update entity in teamsTemplates | `PATCH /teamsTemplates/{teamsTemplate-id}` | `await teamsTemplatesClient.update(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/teams.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/teams.md
@@ -1,0 +1,1137 @@
+# Teams
+
+This page lists all the `/teams` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/teams` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/team?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## TeamsClient Endpoints
+
+The TeamsClient instance gives access to the following `/teams` endpoints. You can get a `TeamsClient` instance like so:
+
+```typescript
+const teamsClient = graphClient.teams;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List teams | `GET /teams` | `await teamsClient.list(params);` |
+| Create team | `POST /teams` | `await teamsClient.create(params);` |
+| Get team | `GET /teams/{team-id}` | `await teamsClient.get({"team-id": teamId  });` |
+| Delete entity from teams | `DELETE /teams/{team-id}` | `await teamsClient.delete({"team-id": teamId  });` |
+| Update team | `PATCH /teams/{team-id}` | `await teamsClient.update(params);` |
+
+## AllChannelsClient Endpoints
+
+The AllChannelsClient instance gives access to the following `/teams/{team-id}/allChannels` endpoints. You can get a `AllChannelsClient` instance like so:
+
+```typescript
+const allChannelsClient = await teamsClient.allChannels(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List allChannels | `GET /teams/{team-id}/allChannels` | `await allChannelsClient.list(params);` |
+| Get allChannels from teams | `GET /teams/{team-id}/allChannels/{channel-id}` | `await allChannelsClient.get({"channel-id": channelId  });` |
+
+## ChannelsClient Endpoints
+
+The ChannelsClient instance gives access to the following `/teams/{team-id}/channels` endpoints. You can get a `ChannelsClient` instance like so:
+
+```typescript
+const channelsClient = await teamsClient.channels(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List channels | `GET /teams/{team-id}/channels` | `await channelsClient.list(params);` |
+| Create channel | `POST /teams/{team-id}/channels` | `await channelsClient.create(params);` |
+| Get channel | `GET /teams/{team-id}/channels/{channel-id}` | `await channelsClient.get({"channel-id": channelId  });` |
+| Delete channel | `DELETE /teams/{team-id}/channels/{channel-id}` | `await channelsClient.delete({"channel-id": channelId  });` |
+| Patch channel | `PATCH /teams/{team-id}/channels/{channel-id}` | `await channelsClient.update(params);` |
+
+## FilesFolderClient Endpoints
+
+The FilesFolderClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/filesFolder` endpoints. You can get a `FilesFolderClient` instance like so:
+
+```typescript
+const filesFolderClient = await channelsClient.filesFolder(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get filesFolder | `GET /teams/{team-id}/channels/{channel-id}/filesFolder` | `await filesFolderClient.list(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/filesFolder/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = filesFolderClient.content;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property filesFolder from teams | `GET /teams/{team-id}/channels/{channel-id}/filesFolder/content` | `await contentClient.list(params);` |
+| Update content for the navigation property filesFolder in teams | `PUT /teams/{team-id}/channels/{channel-id}/filesFolder/content` | `await contentClient.set(body, {"":   });` |
+| Delete content for the navigation property filesFolder in teams | `DELETE /teams/{team-id}/channels/{channel-id}/filesFolder/content` | `await contentClient.delete({"":   });` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = await channelsClient.members(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List members of a channel | `GET /teams/{team-id}/channels/{channel-id}/members` | `await membersClient.list(params);` |
+| Add member to channel | `POST /teams/{team-id}/channels/{channel-id}/members` | `await membersClient.create(params);` |
+| Get member of channel | `GET /teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}` | `await membersClient.get({"conversationMember-id": conversationMemberId  });` |
+| Remove member from channel | `DELETE /teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}` | `await membersClient.delete({"conversationMember-id": conversationMemberId  });` |
+| Update conversationMember | `PATCH /teams/{team-id}/channels/{channel-id}/members/{conversationMember-id}` | `await membersClient.update(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/members/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = membersClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /teams/{team-id}/channels/{channel-id}/members/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/members/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = membersClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /teams/{team-id}/channels/{channel-id}/members/remove` | `await removeClient.create(params);` |
+
+## MessagesClient Endpoints
+
+The MessagesClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages` endpoints. You can get a `MessagesClient` instance like so:
+
+```typescript
+const messagesClient = await channelsClient.messages(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List channel messages | `GET /teams/{team-id}/channels/{channel-id}/messages` | `await messagesClient.list(params);` |
+| Send chatMessage in channel | `POST /teams/{team-id}/channels/{channel-id}/messages` | `await messagesClient.create(params);` |
+| Get chatMessage in a channel or chat | `GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}` | `await messagesClient.get({"chatMessage-id": chatMessageId  });` |
+| Delete navigation property messages for teams | `DELETE /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}` | `await messagesClient.delete({"chatMessage-id": chatMessageId  });` |
+| Update chatMessage | `PATCH /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}` | `await messagesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await messagesClient.hostedContents(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List hostedContents | `GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for teams | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from teams | `GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for teams | `DELETE /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in teams | `PATCH /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await messagesClient.setReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await messagesClient.softDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await messagesClient.undoSoftDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await messagesClient.unsetReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## RepliesClient Endpoints
+
+The RepliesClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies` endpoints. You can get a `RepliesClient` instance like so:
+
+```typescript
+const repliesClient = await messagesClient.replies(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List replies | `GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies` | `await repliesClient.list(params);` |
+| Send replies to a message in a channel | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies` | `await repliesClient.create(params);` |
+| Get chatMessage in a channel or chat | `GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.get({"chatMessage-id1": chatMessageId1  });` |
+| Delete navigation property replies for teams | `DELETE /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.delete({"chatMessage-id1": chatMessageId1  });` |
+| Update the navigation property replies in teams | `PATCH /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await repliesClient.hostedContents(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List hostedContents | `GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for teams | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from teams | `GET /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for teams | `DELETE /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in teams | `PATCH /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await repliesClient.setReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await repliesClient.softDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await repliesClient.undoSoftDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await repliesClient.unsetReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## ArchiveClient Endpoints
+
+The ArchiveClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/archive` endpoints. You can get a `ArchiveClient` instance like so:
+
+```typescript
+const archiveClient = await channelsClient.archive(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action archive | `POST /teams/{team-id}/channels/{channel-id}/archive` | `await archiveClient.create(params);` |
+
+## CompleteMigrationClient Endpoints
+
+The CompleteMigrationClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/completeMigration` endpoints. You can get a `CompleteMigrationClient` instance like so:
+
+```typescript
+const completeMigrationClient = await channelsClient.completeMigration(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action completeMigration | `POST /teams/{team-id}/channels/{channel-id}/completeMigration` | `await completeMigrationClient.create(params);` |
+
+## ProvisionEmailClient Endpoints
+
+The ProvisionEmailClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/provisionEmail` endpoints. You can get a `ProvisionEmailClient` instance like so:
+
+```typescript
+const provisionEmailClient = await channelsClient.provisionEmail(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action provisionEmail | `POST /teams/{team-id}/channels/{channel-id}/provisionEmail` | `await provisionEmailClient.create(params);` |
+
+## RemoveEmailClient Endpoints
+
+The RemoveEmailClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/removeEmail` endpoints. You can get a `RemoveEmailClient` instance like so:
+
+```typescript
+const removeEmailClient = await channelsClient.removeEmail(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action removeEmail | `POST /teams/{team-id}/channels/{channel-id}/removeEmail` | `await removeEmailClient.create(params);` |
+
+## UnarchiveClient Endpoints
+
+The UnarchiveClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/unarchive` endpoints. You can get a `UnarchiveClient` instance like so:
+
+```typescript
+const unarchiveClient = await channelsClient.unarchive(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unarchive | `POST /teams/{team-id}/channels/{channel-id}/unarchive` | `await unarchiveClient.create(params);` |
+
+## SharedWithTeamsClient Endpoints
+
+The SharedWithTeamsClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/sharedWithTeams` endpoints. You can get a `SharedWithTeamsClient` instance like so:
+
+```typescript
+const sharedWithTeamsClient = await channelsClient.sharedWithTeams(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List sharedWithChannelTeamInfo | `GET /teams/{team-id}/channels/{channel-id}/sharedWithTeams` | `await sharedWithTeamsClient.list(params);` |
+| Create new navigation property to sharedWithTeams for teams | `POST /teams/{team-id}/channels/{channel-id}/sharedWithTeams` | `await sharedWithTeamsClient.create(params);` |
+| Get sharedWithChannelTeamInfo | `GET /teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.get({"sharedWithChannelTeamInfo-id": sharedWithChannelTeamInfoId  });` |
+| Delete sharedWithChannelTeamInfo | `DELETE /teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.delete({"sharedWithChannelTeamInfo-id": sharedWithChannelTeamInfoId  });` |
+| Update the navigation property sharedWithTeams in teams | `PATCH /teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.update(params);` |
+
+## AllowedMembersClient Endpoints
+
+The AllowedMembersClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers` endpoints. You can get a `AllowedMembersClient` instance like so:
+
+```typescript
+const allowedMembersClient = await sharedWithTeamsClient.allowedMembers(sharedWithChannelTeamInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List allowedMembers | `GET /teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers` | `await allowedMembersClient.list(params);` |
+| Get allowedMembers from teams | `GET /teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers/{conversationMember-id}` | `await allowedMembersClient.get({"conversationMember-id": conversationMemberId  });` |
+
+## TeamClient Endpoints
+
+The TeamClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/team` endpoints. You can get a `TeamClient` instance like so:
+
+```typescript
+const teamClient = await sharedWithTeamsClient.team(sharedWithChannelTeamInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get team from teams | `GET /teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/team` | `await teamClient.list(params);` |
+
+## TabsClient Endpoints
+
+The TabsClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/tabs` endpoints. You can get a `TabsClient` instance like so:
+
+```typescript
+const tabsClient = await channelsClient.tabs(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List tabs in channel | `GET /teams/{team-id}/channels/{channel-id}/tabs` | `await tabsClient.list(params);` |
+| Add tab to channel | `POST /teams/{team-id}/channels/{channel-id}/tabs` | `await tabsClient.create(params);` |
+| Get tab | `GET /teams/{team-id}/channels/{channel-id}/tabs/{teamsTab-id}` | `await tabsClient.get({"teamsTab-id": teamsTabId  });` |
+| Delete tab from channel | `DELETE /teams/{team-id}/channels/{channel-id}/tabs/{teamsTab-id}` | `await tabsClient.delete({"teamsTab-id": teamsTabId  });` |
+| Update tab | `PATCH /teams/{team-id}/channels/{channel-id}/tabs/{teamsTab-id}` | `await tabsClient.update(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/teams/{team-id}/channels/{channel-id}/tabs/{teamsTab-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await tabsClient.teamsApp(teamsTabId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from teams | `GET /teams/{team-id}/channels/{channel-id}/tabs/{teamsTab-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## GroupClient Endpoints
+
+The GroupClient instance gives access to the following `/teams/{team-id}/group` endpoints. You can get a `GroupClient` instance like so:
+
+```typescript
+const groupClient = await teamsClient.group(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get group from teams | `GET /teams/{team-id}/group` | `await groupClient.list(params);` |
+
+## ServiceProvisioningErrorsClient Endpoints
+
+The ServiceProvisioningErrorsClient instance gives access to the following `/teams/{team-id}/group/serviceProvisioningErrors` endpoints. You can get a `ServiceProvisioningErrorsClient` instance like so:
+
+```typescript
+const serviceProvisioningErrorsClient = groupClient.serviceProvisioningErrors;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get serviceProvisioningErrors property value | `GET /teams/{team-id}/group/serviceProvisioningErrors` | `await serviceProvisioningErrorsClient.list(params);` |
+
+## IncomingChannelsClient Endpoints
+
+The IncomingChannelsClient instance gives access to the following `/teams/{team-id}/incomingChannels` endpoints. You can get a `IncomingChannelsClient` instance like so:
+
+```typescript
+const incomingChannelsClient = await teamsClient.incomingChannels(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List incomingChannels | `GET /teams/{team-id}/incomingChannels` | `await incomingChannelsClient.list(params);` |
+| Get incomingChannels from teams | `GET /teams/{team-id}/incomingChannels/{channel-id}` | `await incomingChannelsClient.get({"channel-id": channelId  });` |
+
+## InstalledAppsClient Endpoints
+
+The InstalledAppsClient instance gives access to the following `/teams/{team-id}/installedApps` endpoints. You can get a `InstalledAppsClient` instance like so:
+
+```typescript
+const installedAppsClient = await teamsClient.installedApps(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List apps in team | `GET /teams/{team-id}/installedApps` | `await installedAppsClient.list(params);` |
+| Add app to team | `POST /teams/{team-id}/installedApps` | `await installedAppsClient.create(params);` |
+| Get installed app in team | `GET /teams/{team-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.get({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Remove app from team | `DELETE /teams/{team-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.delete({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Update the navigation property installedApps in teams | `PATCH /teams/{team-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.update(params);` |
+
+## UpgradeClient Endpoints
+
+The UpgradeClient instance gives access to the following `/teams/{team-id}/installedApps/{teamsAppInstallation-id}/upgrade` endpoints. You can get a `UpgradeClient` instance like so:
+
+```typescript
+const upgradeClient = await installedAppsClient.upgrade(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action upgrade | `POST /teams/{team-id}/installedApps/{teamsAppInstallation-id}/upgrade` | `await upgradeClient.create(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/teams/{team-id}/installedApps/{teamsAppInstallation-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await installedAppsClient.teamsApp(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from teams | `GET /teams/{team-id}/installedApps/{teamsAppInstallation-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## TeamsAppDefinitionClient Endpoints
+
+The TeamsAppDefinitionClient instance gives access to the following `/teams/{team-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` endpoints. You can get a `TeamsAppDefinitionClient` instance like so:
+
+```typescript
+const teamsAppDefinitionClient = await installedAppsClient.teamsAppDefinition(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsAppDefinition from teams | `GET /teams/{team-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` | `await teamsAppDefinitionClient.list(params);` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/teams/{team-id}/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = await teamsClient.members(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List members of team | `GET /teams/{team-id}/members` | `await membersClient.list(params);` |
+| Add member to team | `POST /teams/{team-id}/members` | `await membersClient.create(params);` |
+| Get member of team | `GET /teams/{team-id}/members/{conversationMember-id}` | `await membersClient.get({"conversationMember-id": conversationMemberId  });` |
+| Remove member from team | `DELETE /teams/{team-id}/members/{conversationMember-id}` | `await membersClient.delete({"conversationMember-id": conversationMemberId  });` |
+| Update member in team | `PATCH /teams/{team-id}/members/{conversationMember-id}` | `await membersClient.update(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/teams/{team-id}/members/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = membersClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /teams/{team-id}/members/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/teams/{team-id}/members/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = membersClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /teams/{team-id}/members/remove` | `await removeClient.create(params);` |
+
+## ArchiveClient Endpoints
+
+The ArchiveClient instance gives access to the following `/teams/{team-id}/archive` endpoints. You can get a `ArchiveClient` instance like so:
+
+```typescript
+const archiveClient = await teamsClient.archive(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action archive | `POST /teams/{team-id}/archive` | `await archiveClient.create(params);` |
+
+## CloneClient Endpoints
+
+The CloneClient instance gives access to the following `/teams/{team-id}/clone` endpoints. You can get a `CloneClient` instance like so:
+
+```typescript
+const cloneClient = await teamsClient.clone(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action clone | `POST /teams/{team-id}/clone` | `await cloneClient.create(params);` |
+
+## CompleteMigrationClient Endpoints
+
+The CompleteMigrationClient instance gives access to the following `/teams/{team-id}/completeMigration` endpoints. You can get a `CompleteMigrationClient` instance like so:
+
+```typescript
+const completeMigrationClient = await teamsClient.completeMigration(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action completeMigration | `POST /teams/{team-id}/completeMigration` | `await completeMigrationClient.create(params);` |
+
+## SendActivityNotificationClient Endpoints
+
+The SendActivityNotificationClient instance gives access to the following `/teams/{team-id}/sendActivityNotification` endpoints. You can get a `SendActivityNotificationClient` instance like so:
+
+```typescript
+const sendActivityNotificationClient = await teamsClient.sendActivityNotification(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendActivityNotification | `POST /teams/{team-id}/sendActivityNotification` | `await sendActivityNotificationClient.create(params);` |
+
+## UnarchiveClient Endpoints
+
+The UnarchiveClient instance gives access to the following `/teams/{team-id}/unarchive` endpoints. You can get a `UnarchiveClient` instance like so:
+
+```typescript
+const unarchiveClient = await teamsClient.unarchive(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unarchive | `POST /teams/{team-id}/unarchive` | `await unarchiveClient.create(params);` |
+
+## OperationsClient Endpoints
+
+The OperationsClient instance gives access to the following `/teams/{team-id}/operations` endpoints. You can get a `OperationsClient` instance like so:
+
+```typescript
+const operationsClient = await teamsClient.operations(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get operations from teams | `GET /teams/{team-id}/operations` | `await operationsClient.list(params);` |
+| Create new navigation property to operations for teams | `POST /teams/{team-id}/operations` | `await operationsClient.create(params);` |
+| Get operations from teams | `GET /teams/{team-id}/operations/{teamsAsyncOperation-id}` | `await operationsClient.get({"teamsAsyncOperation-id": teamsAsyncOperationId  });` |
+| Delete navigation property operations for teams | `DELETE /teams/{team-id}/operations/{teamsAsyncOperation-id}` | `await operationsClient.delete({"teamsAsyncOperation-id": teamsAsyncOperationId  });` |
+| Update the navigation property operations in teams | `PATCH /teams/{team-id}/operations/{teamsAsyncOperation-id}` | `await operationsClient.update(params);` |
+
+## PermissionGrantsClient Endpoints
+
+The PermissionGrantsClient instance gives access to the following `/teams/{team-id}/permissionGrants` endpoints. You can get a `PermissionGrantsClient` instance like so:
+
+```typescript
+const permissionGrantsClient = await teamsClient.permissionGrants(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List permissionGrants of a team | `GET /teams/{team-id}/permissionGrants` | `await permissionGrantsClient.list(params);` |
+| Create new navigation property to permissionGrants for teams | `POST /teams/{team-id}/permissionGrants` | `await permissionGrantsClient.create(params);` |
+| Get permissionGrants from teams | `GET /teams/{team-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.get({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Delete navigation property permissionGrants for teams | `DELETE /teams/{team-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.delete({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Update the navigation property permissionGrants in teams | `PATCH /teams/{team-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.update(params);` |
+
+## PhotoClient Endpoints
+
+The PhotoClient instance gives access to the following `/teams/{team-id}/photo` endpoints. You can get a `PhotoClient` instance like so:
+
+```typescript
+const photoClient = await teamsClient.photo(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get profilePhoto | `GET /teams/{team-id}/photo` | `await photoClient.list(params);` |
+| Update profilePhoto | `PATCH /teams/{team-id}/photo` | `await photoClient.update(params);` |
+
+## PrimaryChannelClient Endpoints
+
+The PrimaryChannelClient instance gives access to the following `/teams/{team-id}/primaryChannel` endpoints. You can get a `PrimaryChannelClient` instance like so:
+
+```typescript
+const primaryChannelClient = await teamsClient.primaryChannel(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get primaryChannel | `GET /teams/{team-id}/primaryChannel` | `await primaryChannelClient.list(params);` |
+| Delete navigation property primaryChannel for teams | `DELETE /teams/{team-id}/primaryChannel` | `await primaryChannelClient.delete({"team-id": teamId  });` |
+| Update the navigation property primaryChannel in teams | `PATCH /teams/{team-id}/primaryChannel` | `await primaryChannelClient.update(params);` |
+
+## FilesFolderClient Endpoints
+
+The FilesFolderClient instance gives access to the following `/teams/{team-id}/primaryChannel/filesFolder` endpoints. You can get a `FilesFolderClient` instance like so:
+
+```typescript
+const filesFolderClient = primaryChannelClient.filesFolder;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get filesFolder from teams | `GET /teams/{team-id}/primaryChannel/filesFolder` | `await filesFolderClient.list(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/teams/{team-id}/primaryChannel/filesFolder/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = filesFolderClient.content;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property filesFolder from teams | `GET /teams/{team-id}/primaryChannel/filesFolder/content` | `await contentClient.list(params);` |
+| Update content for the navigation property filesFolder in teams | `PUT /teams/{team-id}/primaryChannel/filesFolder/content` | `await contentClient.set(body, {"":   });` |
+| Delete content for the navigation property filesFolder in teams | `DELETE /teams/{team-id}/primaryChannel/filesFolder/content` | `await contentClient.delete({"":   });` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/teams/{team-id}/primaryChannel/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = primaryChannelClient.members;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get members from teams | `GET /teams/{team-id}/primaryChannel/members` | `await membersClient.list(params);` |
+| Create new navigation property to members for teams | `POST /teams/{team-id}/primaryChannel/members` | `await membersClient.create(params);` |
+| Get members from teams | `GET /teams/{team-id}/primaryChannel/members/{conversationMember-id}` | `await membersClient.get({"conversationMember-id": conversationMemberId  });` |
+| Delete navigation property members for teams | `DELETE /teams/{team-id}/primaryChannel/members/{conversationMember-id}` | `await membersClient.delete({"conversationMember-id": conversationMemberId  });` |
+| Update the navigation property members in teams | `PATCH /teams/{team-id}/primaryChannel/members/{conversationMember-id}` | `await membersClient.update(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/teams/{team-id}/primaryChannel/members/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = membersClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /teams/{team-id}/primaryChannel/members/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/teams/{team-id}/primaryChannel/members/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = membersClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /teams/{team-id}/primaryChannel/members/remove` | `await removeClient.create(params);` |
+
+## MessagesClient Endpoints
+
+The MessagesClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages` endpoints. You can get a `MessagesClient` instance like so:
+
+```typescript
+const messagesClient = primaryChannelClient.messages;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get messages from teams | `GET /teams/{team-id}/primaryChannel/messages` | `await messagesClient.list(params);` |
+| Create new navigation property to messages for teams | `POST /teams/{team-id}/primaryChannel/messages` | `await messagesClient.create(params);` |
+| Get messages from teams | `GET /teams/{team-id}/primaryChannel/messages/{chatMessage-id}` | `await messagesClient.get({"chatMessage-id": chatMessageId  });` |
+| Delete navigation property messages for teams | `DELETE /teams/{team-id}/primaryChannel/messages/{chatMessage-id}` | `await messagesClient.delete({"chatMessage-id": chatMessageId  });` |
+| Update the navigation property messages in teams | `PATCH /teams/{team-id}/primaryChannel/messages/{chatMessage-id}` | `await messagesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await messagesClient.hostedContents(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from teams | `GET /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for teams | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from teams | `GET /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for teams | `DELETE /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in teams | `PATCH /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await messagesClient.setReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await messagesClient.softDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await messagesClient.undoSoftDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await messagesClient.unsetReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## RepliesClient Endpoints
+
+The RepliesClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies` endpoints. You can get a `RepliesClient` instance like so:
+
+```typescript
+const repliesClient = await messagesClient.replies(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get replies from teams | `GET /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies` | `await repliesClient.list(params);` |
+| Create new navigation property to replies for teams | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies` | `await repliesClient.create(params);` |
+| Get replies from teams | `GET /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.get({"chatMessage-id1": chatMessageId1  });` |
+| Delete navigation property replies for teams | `DELETE /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.delete({"chatMessage-id1": chatMessageId1  });` |
+| Update the navigation property replies in teams | `PATCH /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await repliesClient.hostedContents(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from teams | `GET /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for teams | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from teams | `GET /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for teams | `DELETE /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in teams | `PATCH /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await repliesClient.setReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await repliesClient.softDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await repliesClient.undoSoftDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await repliesClient.unsetReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## ArchiveClient Endpoints
+
+The ArchiveClient instance gives access to the following `/teams/{team-id}/primaryChannel/archive` endpoints. You can get a `ArchiveClient` instance like so:
+
+```typescript
+const archiveClient = primaryChannelClient.archive;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action archive | `POST /teams/{team-id}/primaryChannel/archive` | `await archiveClient.create(params);` |
+
+## CompleteMigrationClient Endpoints
+
+The CompleteMigrationClient instance gives access to the following `/teams/{team-id}/primaryChannel/completeMigration` endpoints. You can get a `CompleteMigrationClient` instance like so:
+
+```typescript
+const completeMigrationClient = primaryChannelClient.completeMigration;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action completeMigration | `POST /teams/{team-id}/primaryChannel/completeMigration` | `await completeMigrationClient.create(params);` |
+
+## ProvisionEmailClient Endpoints
+
+The ProvisionEmailClient instance gives access to the following `/teams/{team-id}/primaryChannel/provisionEmail` endpoints. You can get a `ProvisionEmailClient` instance like so:
+
+```typescript
+const provisionEmailClient = primaryChannelClient.provisionEmail;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action provisionEmail | `POST /teams/{team-id}/primaryChannel/provisionEmail` | `await provisionEmailClient.create(params);` |
+
+## RemoveEmailClient Endpoints
+
+The RemoveEmailClient instance gives access to the following `/teams/{team-id}/primaryChannel/removeEmail` endpoints. You can get a `RemoveEmailClient` instance like so:
+
+```typescript
+const removeEmailClient = primaryChannelClient.removeEmail;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action removeEmail | `POST /teams/{team-id}/primaryChannel/removeEmail` | `await removeEmailClient.create(params);` |
+
+## UnarchiveClient Endpoints
+
+The UnarchiveClient instance gives access to the following `/teams/{team-id}/primaryChannel/unarchive` endpoints. You can get a `UnarchiveClient` instance like so:
+
+```typescript
+const unarchiveClient = primaryChannelClient.unarchive;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unarchive | `POST /teams/{team-id}/primaryChannel/unarchive` | `await unarchiveClient.create(params);` |
+
+## SharedWithTeamsClient Endpoints
+
+The SharedWithTeamsClient instance gives access to the following `/teams/{team-id}/primaryChannel/sharedWithTeams` endpoints. You can get a `SharedWithTeamsClient` instance like so:
+
+```typescript
+const sharedWithTeamsClient = primaryChannelClient.sharedWithTeams;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sharedWithTeams from teams | `GET /teams/{team-id}/primaryChannel/sharedWithTeams` | `await sharedWithTeamsClient.list(params);` |
+| Create new navigation property to sharedWithTeams for teams | `POST /teams/{team-id}/primaryChannel/sharedWithTeams` | `await sharedWithTeamsClient.create(params);` |
+| Get sharedWithTeams from teams | `GET /teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.get({"sharedWithChannelTeamInfo-id": sharedWithChannelTeamInfoId  });` |
+| Delete navigation property sharedWithTeams for teams | `DELETE /teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.delete({"sharedWithChannelTeamInfo-id": sharedWithChannelTeamInfoId  });` |
+| Update the navigation property sharedWithTeams in teams | `PATCH /teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.update(params);` |
+
+## AllowedMembersClient Endpoints
+
+The AllowedMembersClient instance gives access to the following `/teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers` endpoints. You can get a `AllowedMembersClient` instance like so:
+
+```typescript
+const allowedMembersClient = await sharedWithTeamsClient.allowedMembers(sharedWithChannelTeamInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get allowedMembers from teams | `GET /teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers` | `await allowedMembersClient.list(params);` |
+| Get allowedMembers from teams | `GET /teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers/{conversationMember-id}` | `await allowedMembersClient.get({"conversationMember-id": conversationMemberId  });` |
+
+## TeamClient Endpoints
+
+The TeamClient instance gives access to the following `/teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}/team` endpoints. You can get a `TeamClient` instance like so:
+
+```typescript
+const teamClient = await sharedWithTeamsClient.team(sharedWithChannelTeamInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get team from teams | `GET /teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}/team` | `await teamClient.list(params);` |
+
+## TabsClient Endpoints
+
+The TabsClient instance gives access to the following `/teams/{team-id}/primaryChannel/tabs` endpoints. You can get a `TabsClient` instance like so:
+
+```typescript
+const tabsClient = primaryChannelClient.tabs;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get tabs from teams | `GET /teams/{team-id}/primaryChannel/tabs` | `await tabsClient.list(params);` |
+| Create new navigation property to tabs for teams | `POST /teams/{team-id}/primaryChannel/tabs` | `await tabsClient.create(params);` |
+| Get tabs from teams | `GET /teams/{team-id}/primaryChannel/tabs/{teamsTab-id}` | `await tabsClient.get({"teamsTab-id": teamsTabId  });` |
+| Delete navigation property tabs for teams | `DELETE /teams/{team-id}/primaryChannel/tabs/{teamsTab-id}` | `await tabsClient.delete({"teamsTab-id": teamsTabId  });` |
+| Update the navigation property tabs in teams | `PATCH /teams/{team-id}/primaryChannel/tabs/{teamsTab-id}` | `await tabsClient.update(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/teams/{team-id}/primaryChannel/tabs/{teamsTab-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await tabsClient.teamsApp(teamsTabId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from teams | `GET /teams/{team-id}/primaryChannel/tabs/{teamsTab-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## ScheduleClient Endpoints
+
+The ScheduleClient instance gives access to the following `/teams/{team-id}/schedule` endpoints. You can get a `ScheduleClient` instance like so:
+
+```typescript
+const scheduleClient = await teamsClient.schedule(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get schedule | `GET /teams/{team-id}/schedule` | `await scheduleClient.list(params);` |
+| Create or replace schedule | `PUT /teams/{team-id}/schedule` | `await scheduleClient.set(body, {"team-id": teamId  });` |
+| Delete navigation property schedule for teams | `DELETE /teams/{team-id}/schedule` | `await scheduleClient.delete({"team-id": teamId  });` |
+
+## ShareClient Endpoints
+
+The ShareClient instance gives access to the following `/teams/{team-id}/schedule/share` endpoints. You can get a `ShareClient` instance like so:
+
+```typescript
+const shareClient = scheduleClient.share;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action share | `POST /teams/{team-id}/schedule/share` | `await shareClient.create(params);` |
+
+## OfferShiftRequestsClient Endpoints
+
+The OfferShiftRequestsClient instance gives access to the following `/teams/{team-id}/schedule/offerShiftRequests` endpoints. You can get a `OfferShiftRequestsClient` instance like so:
+
+```typescript
+const offerShiftRequestsClient = scheduleClient.offerShiftRequests;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List offerShiftRequest | `GET /teams/{team-id}/schedule/offerShiftRequests` | `await offerShiftRequestsClient.list(params);` |
+| Create offerShiftRequest | `POST /teams/{team-id}/schedule/offerShiftRequests` | `await offerShiftRequestsClient.create(params);` |
+| Get offerShiftRequest | `GET /teams/{team-id}/schedule/offerShiftRequests/{offerShiftRequest-id}` | `await offerShiftRequestsClient.get({"offerShiftRequest-id": offerShiftRequestId  });` |
+| Delete navigation property offerShiftRequests for teams | `DELETE /teams/{team-id}/schedule/offerShiftRequests/{offerShiftRequest-id}` | `await offerShiftRequestsClient.delete({"offerShiftRequest-id": offerShiftRequestId  });` |
+| Update the navigation property offerShiftRequests in teams | `PATCH /teams/{team-id}/schedule/offerShiftRequests/{offerShiftRequest-id}` | `await offerShiftRequestsClient.update(params);` |
+
+## OpenShiftChangeRequestsClient Endpoints
+
+The OpenShiftChangeRequestsClient instance gives access to the following `/teams/{team-id}/schedule/openShiftChangeRequests` endpoints. You can get a `OpenShiftChangeRequestsClient` instance like so:
+
+```typescript
+const openShiftChangeRequestsClient = scheduleClient.openShiftChangeRequests;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List openShiftChangeRequests | `GET /teams/{team-id}/schedule/openShiftChangeRequests` | `await openShiftChangeRequestsClient.list(params);` |
+| Create openShiftChangeRequest | `POST /teams/{team-id}/schedule/openShiftChangeRequests` | `await openShiftChangeRequestsClient.create(params);` |
+| Get openShiftChangeRequest | `GET /teams/{team-id}/schedule/openShiftChangeRequests/{openShiftChangeRequest-id}` | `await openShiftChangeRequestsClient.get({"openShiftChangeRequest-id": openShiftChangeRequestId  });` |
+| Delete navigation property openShiftChangeRequests for teams | `DELETE /teams/{team-id}/schedule/openShiftChangeRequests/{openShiftChangeRequest-id}` | `await openShiftChangeRequestsClient.delete({"openShiftChangeRequest-id": openShiftChangeRequestId  });` |
+| Update the navigation property openShiftChangeRequests in teams | `PATCH /teams/{team-id}/schedule/openShiftChangeRequests/{openShiftChangeRequest-id}` | `await openShiftChangeRequestsClient.update(params);` |
+
+## OpenShiftsClient Endpoints
+
+The OpenShiftsClient instance gives access to the following `/teams/{team-id}/schedule/openShifts` endpoints. You can get a `OpenShiftsClient` instance like so:
+
+```typescript
+const openShiftsClient = scheduleClient.openShifts;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List openShifts | `GET /teams/{team-id}/schedule/openShifts` | `await openShiftsClient.list(params);` |
+| Create openShift | `POST /teams/{team-id}/schedule/openShifts` | `await openShiftsClient.create(params);` |
+| Get openShift | `GET /teams/{team-id}/schedule/openShifts/{openShift-id}` | `await openShiftsClient.get({"openShift-id": openShiftId  });` |
+| Delete openShift | `DELETE /teams/{team-id}/schedule/openShifts/{openShift-id}` | `await openShiftsClient.delete({"openShift-id": openShiftId  });` |
+| Update openShift | `PATCH /teams/{team-id}/schedule/openShifts/{openShift-id}` | `await openShiftsClient.update(params);` |
+
+## SchedulingGroupsClient Endpoints
+
+The SchedulingGroupsClient instance gives access to the following `/teams/{team-id}/schedule/schedulingGroups` endpoints. You can get a `SchedulingGroupsClient` instance like so:
+
+```typescript
+const schedulingGroupsClient = scheduleClient.schedulingGroups;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List scheduleGroups | `GET /teams/{team-id}/schedule/schedulingGroups` | `await schedulingGroupsClient.list(params);` |
+| Create schedulingGroup | `POST /teams/{team-id}/schedule/schedulingGroups` | `await schedulingGroupsClient.create(params);` |
+| Get schedulingGroup | `GET /teams/{team-id}/schedule/schedulingGroups/{schedulingGroup-id}` | `await schedulingGroupsClient.get({"schedulingGroup-id": schedulingGroupId  });` |
+| Delete schedulingGroup | `DELETE /teams/{team-id}/schedule/schedulingGroups/{schedulingGroup-id}` | `await schedulingGroupsClient.delete({"schedulingGroup-id": schedulingGroupId  });` |
+| Replace schedulingGroup | `PATCH /teams/{team-id}/schedule/schedulingGroups/{schedulingGroup-id}` | `await schedulingGroupsClient.update(params);` |
+
+## ShiftsClient Endpoints
+
+The ShiftsClient instance gives access to the following `/teams/{team-id}/schedule/shifts` endpoints. You can get a `ShiftsClient` instance like so:
+
+```typescript
+const shiftsClient = scheduleClient.shifts;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List shifts | `GET /teams/{team-id}/schedule/shifts` | `await shiftsClient.list(params);` |
+| Create shift | `POST /teams/{team-id}/schedule/shifts` | `await shiftsClient.create(params);` |
+| Get shift | `GET /teams/{team-id}/schedule/shifts/{shift-id}` | `await shiftsClient.get({"shift-id": shiftId  });` |
+| Delete shift | `DELETE /teams/{team-id}/schedule/shifts/{shift-id}` | `await shiftsClient.delete({"shift-id": shiftId  });` |
+| Replace shift | `PATCH /teams/{team-id}/schedule/shifts/{shift-id}` | `await shiftsClient.update(params);` |
+
+## SwapShiftsChangeRequestsClient Endpoints
+
+The SwapShiftsChangeRequestsClient instance gives access to the following `/teams/{team-id}/schedule/swapShiftsChangeRequests` endpoints. You can get a `SwapShiftsChangeRequestsClient` instance like so:
+
+```typescript
+const swapShiftsChangeRequestsClient = scheduleClient.swapShiftsChangeRequests;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List swapShiftsChangeRequest | `GET /teams/{team-id}/schedule/swapShiftsChangeRequests` | `await swapShiftsChangeRequestsClient.list(params);` |
+| Create swapShiftsChangeRequest | `POST /teams/{team-id}/schedule/swapShiftsChangeRequests` | `await swapShiftsChangeRequestsClient.create(params);` |
+| Get swapShiftsChangeRequest | `GET /teams/{team-id}/schedule/swapShiftsChangeRequests/{swapShiftsChangeRequest-id}` | `await swapShiftsChangeRequestsClient.get({"swapShiftsChangeRequest-id": swapShiftsChangeRequestId  });` |
+| Delete navigation property swapShiftsChangeRequests for teams | `DELETE /teams/{team-id}/schedule/swapShiftsChangeRequests/{swapShiftsChangeRequest-id}` | `await swapShiftsChangeRequestsClient.delete({"swapShiftsChangeRequest-id": swapShiftsChangeRequestId  });` |
+| Update the navigation property swapShiftsChangeRequests in teams | `PATCH /teams/{team-id}/schedule/swapShiftsChangeRequests/{swapShiftsChangeRequest-id}` | `await swapShiftsChangeRequestsClient.update(params);` |
+
+## TimeOffReasonsClient Endpoints
+
+The TimeOffReasonsClient instance gives access to the following `/teams/{team-id}/schedule/timeOffReasons` endpoints. You can get a `TimeOffReasonsClient` instance like so:
+
+```typescript
+const timeOffReasonsClient = scheduleClient.timeOffReasons;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List timeOffReasons | `GET /teams/{team-id}/schedule/timeOffReasons` | `await timeOffReasonsClient.list(params);` |
+| Create timeOffReason | `POST /teams/{team-id}/schedule/timeOffReasons` | `await timeOffReasonsClient.create(params);` |
+| Get timeOffReason | `GET /teams/{team-id}/schedule/timeOffReasons/{timeOffReason-id}` | `await timeOffReasonsClient.get({"timeOffReason-id": timeOffReasonId  });` |
+| Delete timeOffReason | `DELETE /teams/{team-id}/schedule/timeOffReasons/{timeOffReason-id}` | `await timeOffReasonsClient.delete({"timeOffReason-id": timeOffReasonId  });` |
+| Replace timeOffReason | `PATCH /teams/{team-id}/schedule/timeOffReasons/{timeOffReason-id}` | `await timeOffReasonsClient.update(params);` |
+
+## TimeOffRequestsClient Endpoints
+
+The TimeOffRequestsClient instance gives access to the following `/teams/{team-id}/schedule/timeOffRequests` endpoints. You can get a `TimeOffRequestsClient` instance like so:
+
+```typescript
+const timeOffRequestsClient = scheduleClient.timeOffRequests;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List timeOffRequest | `GET /teams/{team-id}/schedule/timeOffRequests` | `await timeOffRequestsClient.list(params);` |
+| Create new navigation property to timeOffRequests for teams | `POST /teams/{team-id}/schedule/timeOffRequests` | `await timeOffRequestsClient.create(params);` |
+| Get timeOffRequest | `GET /teams/{team-id}/schedule/timeOffRequests/{timeOffRequest-id}` | `await timeOffRequestsClient.get({"timeOffRequest-id": timeOffRequestId  });` |
+| Delete timeOffRequest | `DELETE /teams/{team-id}/schedule/timeOffRequests/{timeOffRequest-id}` | `await timeOffRequestsClient.delete({"timeOffRequest-id": timeOffRequestId  });` |
+| Update the navigation property timeOffRequests in teams | `PATCH /teams/{team-id}/schedule/timeOffRequests/{timeOffRequest-id}` | `await timeOffRequestsClient.update(params);` |
+
+## TimesOffClient Endpoints
+
+The TimesOffClient instance gives access to the following `/teams/{team-id}/schedule/timesOff` endpoints. You can get a `TimesOffClient` instance like so:
+
+```typescript
+const timesOffClient = scheduleClient.timesOff;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List timesOff | `GET /teams/{team-id}/schedule/timesOff` | `await timesOffClient.list(params);` |
+| Create timeOff | `POST /teams/{team-id}/schedule/timesOff` | `await timesOffClient.create(params);` |
+| Get timeOff | `GET /teams/{team-id}/schedule/timesOff/{timeOff-id}` | `await timesOffClient.get({"timeOff-id": timeOffId  });` |
+| Delete timeOff | `DELETE /teams/{team-id}/schedule/timesOff/{timeOff-id}` | `await timesOffClient.delete({"timeOff-id": timeOffId  });` |
+| Replace timeOff | `PATCH /teams/{team-id}/schedule/timesOff/{timeOff-id}` | `await timesOffClient.update(params);` |
+
+## TagsClient Endpoints
+
+The TagsClient instance gives access to the following `/teams/{team-id}/tags` endpoints. You can get a `TagsClient` instance like so:
+
+```typescript
+const tagsClient = await teamsClient.tags(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List teamworkTags | `GET /teams/{team-id}/tags` | `await tagsClient.list(params);` |
+| Create teamworkTag | `POST /teams/{team-id}/tags` | `await tagsClient.create(params);` |
+| Get teamworkTag | `GET /teams/{team-id}/tags/{teamworkTag-id}` | `await tagsClient.get({"teamworkTag-id": teamworkTagId  });` |
+| Delete teamworkTag | `DELETE /teams/{team-id}/tags/{teamworkTag-id}` | `await tagsClient.delete({"teamworkTag-id": teamworkTagId  });` |
+| Update teamworkTag | `PATCH /teams/{team-id}/tags/{teamworkTag-id}` | `await tagsClient.update(params);` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/teams/{team-id}/tags/{teamworkTag-id}/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = await tagsClient.members(teamworkTagId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List members in a teamworkTag | `GET /teams/{team-id}/tags/{teamworkTag-id}/members` | `await membersClient.list(params);` |
+| Create teamworkTagMember | `POST /teams/{team-id}/tags/{teamworkTag-id}/members` | `await membersClient.create(params);` |
+| Get teamworkTagMember | `GET /teams/{team-id}/tags/{teamworkTag-id}/members/{teamworkTagMember-id}` | `await membersClient.get({"teamworkTagMember-id": teamworkTagMemberId  });` |
+| Delete teamworkTagMember | `DELETE /teams/{team-id}/tags/{teamworkTag-id}/members/{teamworkTagMember-id}` | `await membersClient.delete({"teamworkTagMember-id": teamworkTagMemberId  });` |
+| Update the navigation property members in teams | `PATCH /teams/{team-id}/tags/{teamworkTag-id}/members/{teamworkTagMember-id}` | `await membersClient.update(params);` |
+
+## TemplateClient Endpoints
+
+The TemplateClient instance gives access to the following `/teams/{team-id}/template` endpoints. You can get a `TemplateClient` instance like so:
+
+```typescript
+const templateClient = await teamsClient.template(teamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get template from teams | `GET /teams/{team-id}/template` | `await templateClient.list(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/teamwork.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/teamwork.md
@@ -1,0 +1,445 @@
+# Teamwork
+
+This page lists all the `/teamwork` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/teamwork` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/teamwork?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## TeamworkClient Endpoints
+
+The TeamworkClient instance gives access to the following `/teamwork` endpoints. You can get a `TeamworkClient` instance like so:
+
+```typescript
+const teamworkClient = graphClient.teamwork;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamwork | `GET /teamwork` | `await teamworkClient.list(params);` |
+| Update teamwork | `PATCH /teamwork` | `await teamworkClient.update(params);` |
+
+## DeletedChatsClient Endpoints
+
+The DeletedChatsClient instance gives access to the following `/teamwork/deletedChats` endpoints. You can get a `DeletedChatsClient` instance like so:
+
+```typescript
+const deletedChatsClient = teamworkClient.deletedChats;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get deletedChat | `GET /teamwork/deletedChats` | `await deletedChatsClient.list(params);` |
+| Create new navigation property to deletedChats for teamwork | `POST /teamwork/deletedChats` | `await deletedChatsClient.create(params);` |
+| Get deletedChat | `GET /teamwork/deletedChats/{deletedChat-id}` | `await deletedChatsClient.get({"deletedChat-id": deletedChatId  });` |
+| Delete navigation property deletedChats for teamwork | `DELETE /teamwork/deletedChats/{deletedChat-id}` | `await deletedChatsClient.delete({"deletedChat-id": deletedChatId  });` |
+| Update the navigation property deletedChats in teamwork | `PATCH /teamwork/deletedChats/{deletedChat-id}` | `await deletedChatsClient.update(params);` |
+
+## UndoDeleteClient Endpoints
+
+The UndoDeleteClient instance gives access to the following `/teamwork/deletedChats/{deletedChat-id}/undoDelete` endpoints. You can get a `UndoDeleteClient` instance like so:
+
+```typescript
+const undoDeleteClient = await deletedChatsClient.undoDelete(deletedChatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoDelete | `POST /teamwork/deletedChats/{deletedChat-id}/undoDelete` | `await undoDeleteClient.create(params);` |
+
+## DeletedTeamsClient Endpoints
+
+The DeletedTeamsClient instance gives access to the following `/teamwork/deletedTeams` endpoints. You can get a `DeletedTeamsClient` instance like so:
+
+```typescript
+const deletedTeamsClient = teamworkClient.deletedTeams;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List deletedTeams | `GET /teamwork/deletedTeams` | `await deletedTeamsClient.list(params);` |
+| Create new navigation property to deletedTeams for teamwork | `POST /teamwork/deletedTeams` | `await deletedTeamsClient.create(params);` |
+| Get deletedTeams from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}` | `await deletedTeamsClient.get({"deletedTeam-id": deletedTeamId  });` |
+| Delete navigation property deletedTeams for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}` | `await deletedTeamsClient.delete({"deletedTeam-id": deletedTeamId  });` |
+| Update the navigation property deletedTeams in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}` | `await deletedTeamsClient.update(params);` |
+
+## ChannelsClient Endpoints
+
+The ChannelsClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels` endpoints. You can get a `ChannelsClient` instance like so:
+
+```typescript
+const channelsClient = await deletedTeamsClient.channels(deletedTeamId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get channels from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels` | `await channelsClient.list(params);` |
+| Create new navigation property to channels for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels` | `await channelsClient.create(params);` |
+| Get channels from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}` | `await channelsClient.get({"channel-id": channelId  });` |
+| Delete navigation property channels for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}` | `await channelsClient.delete({"channel-id": channelId  });` |
+| Update the navigation property channels in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}` | `await channelsClient.update(params);` |
+
+## FilesFolderClient Endpoints
+
+The FilesFolderClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/filesFolder` endpoints. You can get a `FilesFolderClient` instance like so:
+
+```typescript
+const filesFolderClient = await channelsClient.filesFolder(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get filesFolder from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/filesFolder` | `await filesFolderClient.list(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/filesFolder/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = filesFolderClient.content;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property filesFolder from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/filesFolder/content` | `await contentClient.list(params);` |
+| Update content for the navigation property filesFolder in teamwork | `PUT /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/filesFolder/content` | `await contentClient.set(body, {"":   });` |
+| Delete content for the navigation property filesFolder in teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/filesFolder/content` | `await contentClient.delete({"":   });` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = await channelsClient.members(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get members from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members` | `await membersClient.list(params);` |
+| Create new navigation property to members for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members` | `await membersClient.create(params);` |
+| Get members from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members/{conversationMember-id}` | `await membersClient.get({"conversationMember-id": conversationMemberId  });` |
+| Delete navigation property members for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members/{conversationMember-id}` | `await membersClient.delete({"conversationMember-id": conversationMemberId  });` |
+| Update the navigation property members in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members/{conversationMember-id}` | `await membersClient.update(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = membersClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = membersClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members/remove` | `await removeClient.create(params);` |
+
+## MessagesClient Endpoints
+
+The MessagesClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages` endpoints. You can get a `MessagesClient` instance like so:
+
+```typescript
+const messagesClient = await channelsClient.messages(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get messages from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages` | `await messagesClient.list(params);` |
+| Create new navigation property to messages for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages` | `await messagesClient.create(params);` |
+| Get messages from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}` | `await messagesClient.get({"chatMessage-id": chatMessageId  });` |
+| Delete navigation property messages for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}` | `await messagesClient.delete({"chatMessage-id": chatMessageId  });` |
+| Update the navigation property messages in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}` | `await messagesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await messagesClient.hostedContents(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await messagesClient.setReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await messagesClient.softDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await messagesClient.undoSoftDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await messagesClient.unsetReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## RepliesClient Endpoints
+
+The RepliesClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies` endpoints. You can get a `RepliesClient` instance like so:
+
+```typescript
+const repliesClient = await messagesClient.replies(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get replies from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies` | `await repliesClient.list(params);` |
+| Create new navigation property to replies for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies` | `await repliesClient.create(params);` |
+| Get replies from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.get({"chatMessage-id1": chatMessageId1  });` |
+| Delete navigation property replies for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.delete({"chatMessage-id1": chatMessageId1  });` |
+| Update the navigation property replies in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await repliesClient.hostedContents(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await repliesClient.setReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await repliesClient.softDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await repliesClient.undoSoftDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await repliesClient.unsetReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## ArchiveClient Endpoints
+
+The ArchiveClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/archive` endpoints. You can get a `ArchiveClient` instance like so:
+
+```typescript
+const archiveClient = await channelsClient.archive(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action archive | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/archive` | `await archiveClient.create(params);` |
+
+## CompleteMigrationClient Endpoints
+
+The CompleteMigrationClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/completeMigration` endpoints. You can get a `CompleteMigrationClient` instance like so:
+
+```typescript
+const completeMigrationClient = await channelsClient.completeMigration(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action completeMigration | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/completeMigration` | `await completeMigrationClient.create(params);` |
+
+## ProvisionEmailClient Endpoints
+
+The ProvisionEmailClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/provisionEmail` endpoints. You can get a `ProvisionEmailClient` instance like so:
+
+```typescript
+const provisionEmailClient = await channelsClient.provisionEmail(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action provisionEmail | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/provisionEmail` | `await provisionEmailClient.create(params);` |
+
+## RemoveEmailClient Endpoints
+
+The RemoveEmailClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/removeEmail` endpoints. You can get a `RemoveEmailClient` instance like so:
+
+```typescript
+const removeEmailClient = await channelsClient.removeEmail(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action removeEmail | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/removeEmail` | `await removeEmailClient.create(params);` |
+
+## UnarchiveClient Endpoints
+
+The UnarchiveClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/unarchive` endpoints. You can get a `UnarchiveClient` instance like so:
+
+```typescript
+const unarchiveClient = await channelsClient.unarchive(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unarchive | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/unarchive` | `await unarchiveClient.create(params);` |
+
+## SharedWithTeamsClient Endpoints
+
+The SharedWithTeamsClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams` endpoints. You can get a `SharedWithTeamsClient` instance like so:
+
+```typescript
+const sharedWithTeamsClient = await channelsClient.sharedWithTeams(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get sharedWithTeams from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams` | `await sharedWithTeamsClient.list(params);` |
+| Create new navigation property to sharedWithTeams for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams` | `await sharedWithTeamsClient.create(params);` |
+| Get sharedWithTeams from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.get({"sharedWithChannelTeamInfo-id": sharedWithChannelTeamInfoId  });` |
+| Delete navigation property sharedWithTeams for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.delete({"sharedWithChannelTeamInfo-id": sharedWithChannelTeamInfoId  });` |
+| Update the navigation property sharedWithTeams in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}` | `await sharedWithTeamsClient.update(params);` |
+
+## AllowedMembersClient Endpoints
+
+The AllowedMembersClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers` endpoints. You can get a `AllowedMembersClient` instance like so:
+
+```typescript
+const allowedMembersClient = await sharedWithTeamsClient.allowedMembers(sharedWithChannelTeamInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get allowedMembers from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers` | `await allowedMembersClient.list(params);` |
+| Get allowedMembers from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers/{conversationMember-id}` | `await allowedMembersClient.get({"conversationMember-id": conversationMemberId  });` |
+
+## TeamClient Endpoints
+
+The TeamClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/team` endpoints. You can get a `TeamClient` instance like so:
+
+```typescript
+const teamClient = await sharedWithTeamsClient.team(sharedWithChannelTeamInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get team from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/team` | `await teamClient.list(params);` |
+
+## TabsClient Endpoints
+
+The TabsClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs` endpoints. You can get a `TabsClient` instance like so:
+
+```typescript
+const tabsClient = await channelsClient.tabs(channelId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get tabs from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs` | `await tabsClient.list(params);` |
+| Create new navigation property to tabs for teamwork | `POST /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs` | `await tabsClient.create(params);` |
+| Get tabs from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs/{teamsTab-id}` | `await tabsClient.get({"teamsTab-id": teamsTabId  });` |
+| Delete navigation property tabs for teamwork | `DELETE /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs/{teamsTab-id}` | `await tabsClient.delete({"teamsTab-id": teamsTabId  });` |
+| Update the navigation property tabs in teamwork | `PATCH /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs/{teamsTab-id}` | `await tabsClient.update(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs/{teamsTab-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await tabsClient.teamsApp(teamsTabId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from teamwork | `GET /teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs/{teamsTab-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## SendActivityNotificationToRecipientsClient Endpoints
+
+The SendActivityNotificationToRecipientsClient instance gives access to the following `/teamwork/sendActivityNotificationToRecipients` endpoints. You can get a `SendActivityNotificationToRecipientsClient` instance like so:
+
+```typescript
+const sendActivityNotificationToRecipientsClient = teamworkClient.sendActivityNotificationToRecipients;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendActivityNotificationToRecipients | `POST /teamwork/sendActivityNotificationToRecipients` | `await sendActivityNotificationToRecipientsClient.create(params);` |
+
+## TeamsAppSettingsClient Endpoints
+
+The TeamsAppSettingsClient instance gives access to the following `/teamwork/teamsAppSettings` endpoints. You can get a `TeamsAppSettingsClient` instance like so:
+
+```typescript
+const teamsAppSettingsClient = teamworkClient.teamsAppSettings;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsAppSettings | `GET /teamwork/teamsAppSettings` | `await teamsAppSettingsClient.list(params);` |
+| Delete navigation property teamsAppSettings for teamwork | `DELETE /teamwork/teamsAppSettings` | `await teamsAppSettingsClient.delete({"":   });` |
+| Update teamsAppSettings | `PATCH /teamwork/teamsAppSettings` | `await teamsAppSettingsClient.update(params);` |
+
+## WorkforceIntegrationsClient Endpoints
+
+The WorkforceIntegrationsClient instance gives access to the following `/teamwork/workforceIntegrations` endpoints. You can get a `WorkforceIntegrationsClient` instance like so:
+
+```typescript
+const workforceIntegrationsClient = teamworkClient.workforceIntegrations;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List workforceIntegrations | `GET /teamwork/workforceIntegrations` | `await workforceIntegrationsClient.list(params);` |
+| Create workforceIntegration | `POST /teamwork/workforceIntegrations` | `await workforceIntegrationsClient.create(params);` |
+| Get workforceIntegration | `GET /teamwork/workforceIntegrations/{workforceIntegration-id}` | `await workforceIntegrationsClient.get({"workforceIntegration-id": workforceIntegrationId  });` |
+| Delete workforceIntegration | `DELETE /teamwork/workforceIntegrations/{workforceIntegration-id}` | `await workforceIntegrationsClient.delete({"workforceIntegration-id": workforceIntegrationId  });` |
+| Update workforceIntegration | `PATCH /teamwork/workforceIntegrations/{workforceIntegration-id}` | `await workforceIntegrationsClient.update(params);` |

--- a/teams.md/docs/typescript/in-depth-guides/graph/users.md
+++ b/teams.md/docs/typescript/in-depth-guides/graph/users.md
@@ -1,0 +1,734 @@
+# Users
+
+This page lists all the `/users` graph endpoints that are currently supported in the Graph API Client. The supported endpoints are made available as type-safe and convenient methods following a consistent pattern.
+
+You can find the full documentation for the `/users` endpoints in the [Microsoft Graph documentation](https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0), including details on input arguments, return data, required permissions, and endpoint availability.
+
+## Getting Started
+
+To get started with the Graph Client, please refer to the [Graph API Client Essentials](../../essentials/graph) page.
+
+
+## UsersClient Endpoints
+
+The UsersClient instance gives access to the following `/users` endpoints. You can get a `UsersClient` instance like so:
+
+```typescript
+const usersClient = graphClient.users;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List users | `GET /users` | `await usersClient.list(params);` |
+| Create User | `POST /users` | `await usersClient.create(params);` |
+| Get user | `GET /users/{user-id}` | `await usersClient.get({"user-id": userId  });` |
+| Delete user | `DELETE /users/{user-id}` | `await usersClient.delete({"user-id": userId  });` |
+| Update user | `PATCH /users/{user-id}` | `await usersClient.update(params);` |
+
+## ChatsClient Endpoints
+
+The ChatsClient instance gives access to the following `/users/{user-id}/chats` endpoints. You can get a `ChatsClient` instance like so:
+
+```typescript
+const chatsClient = await usersClient.chats(userId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List chats | `GET /users/{user-id}/chats` | `await chatsClient.list(params);` |
+| Create new navigation property to chats for users | `POST /users/{user-id}/chats` | `await chatsClient.create(params);` |
+| Get chat | `GET /users/{user-id}/chats/{chat-id}` | `await chatsClient.get({"chat-id": chatId  });` |
+| Delete navigation property chats for users | `DELETE /users/{user-id}/chats/{chat-id}` | `await chatsClient.delete({"chat-id": chatId  });` |
+| Update the navigation property chats in users | `PATCH /users/{user-id}/chats/{chat-id}` | `await chatsClient.update(params);` |
+
+## InstalledAppsClient Endpoints
+
+The InstalledAppsClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/installedApps` endpoints. You can get a `InstalledAppsClient` instance like so:
+
+```typescript
+const installedAppsClient = await chatsClient.installedApps(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get installedApps from users | `GET /users/{user-id}/chats/{chat-id}/installedApps` | `await installedAppsClient.list(params);` |
+| Create new navigation property to installedApps for users | `POST /users/{user-id}/chats/{chat-id}/installedApps` | `await installedAppsClient.create(params);` |
+| Get installedApps from users | `GET /users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.get({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Delete navigation property installedApps for users | `DELETE /users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.delete({"teamsAppInstallation-id": teamsAppInstallationId  });` |
+| Update the navigation property installedApps in users | `PATCH /users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}` | `await installedAppsClient.update(params);` |
+
+## UpgradeClient Endpoints
+
+The UpgradeClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/upgrade` endpoints. You can get a `UpgradeClient` instance like so:
+
+```typescript
+const upgradeClient = await installedAppsClient.upgrade(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action upgrade | `POST /users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/upgrade` | `await upgradeClient.create(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await installedAppsClient.teamsApp(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from users | `GET /users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## TeamsAppDefinitionClient Endpoints
+
+The TeamsAppDefinitionClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` endpoints. You can get a `TeamsAppDefinitionClient` instance like so:
+
+```typescript
+const teamsAppDefinitionClient = await installedAppsClient.teamsAppDefinition(teamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsAppDefinition from users | `GET /users/{user-id}/chats/{chat-id}/installedApps/{teamsAppInstallation-id}/teamsAppDefinition` | `await teamsAppDefinitionClient.list(params);` |
+
+## LastMessagePreviewClient Endpoints
+
+The LastMessagePreviewClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/lastMessagePreview` endpoints. You can get a `LastMessagePreviewClient` instance like so:
+
+```typescript
+const lastMessagePreviewClient = await chatsClient.lastMessagePreview(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get lastMessagePreview from users | `GET /users/{user-id}/chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.list(params);` |
+| Delete navigation property lastMessagePreview for users | `DELETE /users/{user-id}/chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.delete({"chat-id": chatId  });` |
+| Update the navigation property lastMessagePreview in users | `PATCH /users/{user-id}/chats/{chat-id}/lastMessagePreview` | `await lastMessagePreviewClient.update(params);` |
+
+## MembersClient Endpoints
+
+The MembersClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/members` endpoints. You can get a `MembersClient` instance like so:
+
+```typescript
+const membersClient = await chatsClient.members(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get members from users | `GET /users/{user-id}/chats/{chat-id}/members` | `await membersClient.list(params);` |
+| Create new navigation property to members for users | `POST /users/{user-id}/chats/{chat-id}/members` | `await membersClient.create(params);` |
+| Get members from users | `GET /users/{user-id}/chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.get({"conversationMember-id": conversationMemberId  });` |
+| Delete navigation property members for users | `DELETE /users/{user-id}/chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.delete({"conversationMember-id": conversationMemberId  });` |
+| Update the navigation property members in users | `PATCH /users/{user-id}/chats/{chat-id}/members/{conversationMember-id}` | `await membersClient.update(params);` |
+
+## AddClient Endpoints
+
+The AddClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/members/add` endpoints. You can get a `AddClient` instance like so:
+
+```typescript
+const addClient = membersClient.add;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action add | `POST /users/{user-id}/chats/{chat-id}/members/add` | `await addClient.create(params);` |
+
+## RemoveClient Endpoints
+
+The RemoveClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/members/remove` endpoints. You can get a `RemoveClient` instance like so:
+
+```typescript
+const removeClient = membersClient.remove;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action remove | `POST /users/{user-id}/chats/{chat-id}/members/remove` | `await removeClient.create(params);` |
+
+## MessagesClient Endpoints
+
+The MessagesClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages` endpoints. You can get a `MessagesClient` instance like so:
+
+```typescript
+const messagesClient = await chatsClient.messages(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get messages from users | `GET /users/{user-id}/chats/{chat-id}/messages` | `await messagesClient.list(params);` |
+| Create new navigation property to messages for users | `POST /users/{user-id}/chats/{chat-id}/messages` | `await messagesClient.create(params);` |
+| Get messages from users | `GET /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.get({"chatMessage-id": chatMessageId  });` |
+| Delete navigation property messages for users | `DELETE /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.delete({"chatMessage-id": chatMessageId  });` |
+| Update the navigation property messages in users | `PATCH /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}` | `await messagesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await messagesClient.hostedContents(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from users | `GET /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for users | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from users | `GET /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for users | `DELETE /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in users | `PATCH /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await messagesClient.setReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await messagesClient.softDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await messagesClient.undoSoftDelete(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await messagesClient.unsetReaction(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## RepliesClient Endpoints
+
+The RepliesClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies` endpoints. You can get a `RepliesClient` instance like so:
+
+```typescript
+const repliesClient = await messagesClient.replies(chatMessageId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get replies from users | `GET /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies` | `await repliesClient.list(params);` |
+| Create new navigation property to replies for users | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies` | `await repliesClient.create(params);` |
+| Get replies from users | `GET /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.get({"chatMessage-id1": chatMessageId1  });` |
+| Delete navigation property replies for users | `DELETE /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.delete({"chatMessage-id1": chatMessageId1  });` |
+| Update the navigation property replies in users | `PATCH /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}` | `await repliesClient.update(params);` |
+
+## HostedContentsClient Endpoints
+
+The HostedContentsClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` endpoints. You can get a `HostedContentsClient` instance like so:
+
+```typescript
+const hostedContentsClient = await repliesClient.hostedContents(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get hostedContents from users | `GET /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.list(params);` |
+| Create new navigation property to hostedContents for users | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents` | `await hostedContentsClient.create(params);` |
+| Get hostedContents from users | `GET /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.get({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Delete navigation property hostedContents for users | `DELETE /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.delete({"chatMessageHostedContent-id": chatMessageHostedContentId  });` |
+| Update the navigation property hostedContents in users | `PATCH /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents/{chatMessageHostedContent-id}` | `await hostedContentsClient.update(params);` |
+
+## SetReactionClient Endpoints
+
+The SetReactionClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` endpoints. You can get a `SetReactionClient` instance like so:
+
+```typescript
+const setReactionClient = await repliesClient.setReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setReaction | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/setReaction` | `await setReactionClient.create(params);` |
+
+## SoftDeleteClient Endpoints
+
+The SoftDeleteClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` endpoints. You can get a `SoftDeleteClient` instance like so:
+
+```typescript
+const softDeleteClient = await repliesClient.softDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action softDelete | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/softDelete` | `await softDeleteClient.create(params);` |
+
+## UndoSoftDeleteClient Endpoints
+
+The UndoSoftDeleteClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` endpoints. You can get a `UndoSoftDeleteClient` instance like so:
+
+```typescript
+const undoSoftDeleteClient = await repliesClient.undoSoftDelete(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action undoSoftDelete | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/undoSoftDelete` | `await undoSoftDeleteClient.create(params);` |
+
+## UnsetReactionClient Endpoints
+
+The UnsetReactionClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` endpoints. You can get a `UnsetReactionClient` instance like so:
+
+```typescript
+const unsetReactionClient = await repliesClient.unsetReaction(chatMessageId1);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unsetReaction | `POST /users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/unsetReaction` | `await unsetReactionClient.create(params);` |
+
+## HideForUserClient Endpoints
+
+The HideForUserClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/hideForUser` endpoints. You can get a `HideForUserClient` instance like so:
+
+```typescript
+const hideForUserClient = await chatsClient.hideForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action hideForUser | `POST /users/{user-id}/chats/{chat-id}/hideForUser` | `await hideForUserClient.create(params);` |
+
+## MarkChatReadForUserClient Endpoints
+
+The MarkChatReadForUserClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/markChatReadForUser` endpoints. You can get a `MarkChatReadForUserClient` instance like so:
+
+```typescript
+const markChatReadForUserClient = await chatsClient.markChatReadForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action markChatReadForUser | `POST /users/{user-id}/chats/{chat-id}/markChatReadForUser` | `await markChatReadForUserClient.create(params);` |
+
+## MarkChatUnreadForUserClient Endpoints
+
+The MarkChatUnreadForUserClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/markChatUnreadForUser` endpoints. You can get a `MarkChatUnreadForUserClient` instance like so:
+
+```typescript
+const markChatUnreadForUserClient = await chatsClient.markChatUnreadForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action markChatUnreadForUser | `POST /users/{user-id}/chats/{chat-id}/markChatUnreadForUser` | `await markChatUnreadForUserClient.create(params);` |
+
+## SendActivityNotificationClient Endpoints
+
+The SendActivityNotificationClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/sendActivityNotification` endpoints. You can get a `SendActivityNotificationClient` instance like so:
+
+```typescript
+const sendActivityNotificationClient = await chatsClient.sendActivityNotification(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendActivityNotification | `POST /users/{user-id}/chats/{chat-id}/sendActivityNotification` | `await sendActivityNotificationClient.create(params);` |
+
+## UnhideForUserClient Endpoints
+
+The UnhideForUserClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/unhideForUser` endpoints. You can get a `UnhideForUserClient` instance like so:
+
+```typescript
+const unhideForUserClient = await chatsClient.unhideForUser(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action unhideForUser | `POST /users/{user-id}/chats/{chat-id}/unhideForUser` | `await unhideForUserClient.create(params);` |
+
+## PermissionGrantsClient Endpoints
+
+The PermissionGrantsClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/permissionGrants` endpoints. You can get a `PermissionGrantsClient` instance like so:
+
+```typescript
+const permissionGrantsClient = await chatsClient.permissionGrants(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get permissionGrants from users | `GET /users/{user-id}/chats/{chat-id}/permissionGrants` | `await permissionGrantsClient.list(params);` |
+| Create new navigation property to permissionGrants for users | `POST /users/{user-id}/chats/{chat-id}/permissionGrants` | `await permissionGrantsClient.create(params);` |
+| Get permissionGrants from users | `GET /users/{user-id}/chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.get({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Delete navigation property permissionGrants for users | `DELETE /users/{user-id}/chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.delete({"resourceSpecificPermissionGrant-id": resourceSpecificPermissionGrantId  });` |
+| Update the navigation property permissionGrants in users | `PATCH /users/{user-id}/chats/{chat-id}/permissionGrants/{resourceSpecificPermissionGrant-id}` | `await permissionGrantsClient.update(params);` |
+
+## PinnedMessagesClient Endpoints
+
+The PinnedMessagesClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/pinnedMessages` endpoints. You can get a `PinnedMessagesClient` instance like so:
+
+```typescript
+const pinnedMessagesClient = await chatsClient.pinnedMessages(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get pinnedMessages from users | `GET /users/{user-id}/chats/{chat-id}/pinnedMessages` | `await pinnedMessagesClient.list(params);` |
+| Create new navigation property to pinnedMessages for users | `POST /users/{user-id}/chats/{chat-id}/pinnedMessages` | `await pinnedMessagesClient.create(params);` |
+| Get pinnedMessages from users | `GET /users/{user-id}/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.get({"pinnedChatMessageInfo-id": pinnedChatMessageInfoId  });` |
+| Delete navigation property pinnedMessages for users | `DELETE /users/{user-id}/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.delete({"pinnedChatMessageInfo-id": pinnedChatMessageInfoId  });` |
+| Update the navigation property pinnedMessages in users | `PATCH /users/{user-id}/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}` | `await pinnedMessagesClient.update(params);` |
+
+## MessageClient Endpoints
+
+The MessageClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}/message` endpoints. You can get a `MessageClient` instance like so:
+
+```typescript
+const messageClient = await pinnedMessagesClient.message(pinnedChatMessageInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get message from users | `GET /users/{user-id}/chats/{chat-id}/pinnedMessages/{pinnedChatMessageInfo-id}/message` | `await messageClient.list(params);` |
+
+## TabsClient Endpoints
+
+The TabsClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/tabs` endpoints. You can get a `TabsClient` instance like so:
+
+```typescript
+const tabsClient = await chatsClient.tabs(chatId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get tabs from users | `GET /users/{user-id}/chats/{chat-id}/tabs` | `await tabsClient.list(params);` |
+| Create new navigation property to tabs for users | `POST /users/{user-id}/chats/{chat-id}/tabs` | `await tabsClient.create(params);` |
+| Get tabs from users | `GET /users/{user-id}/chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.get({"teamsTab-id": teamsTabId  });` |
+| Delete navigation property tabs for users | `DELETE /users/{user-id}/chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.delete({"teamsTab-id": teamsTabId  });` |
+| Update the navigation property tabs in users | `PATCH /users/{user-id}/chats/{chat-id}/tabs/{teamsTab-id}` | `await tabsClient.update(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/users/{user-id}/chats/{chat-id}/tabs/{teamsTab-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await tabsClient.teamsApp(teamsTabId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from users | `GET /users/{user-id}/chats/{chat-id}/tabs/{teamsTab-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## OnlineMeetingsClient Endpoints
+
+The OnlineMeetingsClient instance gives access to the following `/users/{user-id}/onlineMeetings` endpoints. You can get a `OnlineMeetingsClient` instance like so:
+
+```typescript
+const onlineMeetingsClient = await usersClient.onlineMeetings(userId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get onlineMeetings from users | `GET /users/{user-id}/onlineMeetings` | `await onlineMeetingsClient.list(params);` |
+| Create new navigation property to onlineMeetings for users | `POST /users/{user-id}/onlineMeetings` | `await onlineMeetingsClient.create(params);` |
+| Get onlineMeetings from users | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}` | `await onlineMeetingsClient.get({"onlineMeeting-id": onlineMeetingId  });` |
+| Delete navigation property onlineMeetings for users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}` | `await onlineMeetingsClient.delete({"onlineMeeting-id": onlineMeetingId  });` |
+| Update the navigation property onlineMeetings in users | `PATCH /users/{user-id}/onlineMeetings/{onlineMeeting-id}` | `await onlineMeetingsClient.update(params);` |
+
+## AttendanceReportsClient Endpoints
+
+The AttendanceReportsClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports` endpoints. You can get a `AttendanceReportsClient` instance like so:
+
+```typescript
+const attendanceReportsClient = await onlineMeetingsClient.attendanceReports(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceReports from users | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports` | `await attendanceReportsClient.list(params);` |
+| Create new navigation property to attendanceReports for users | `POST /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports` | `await attendanceReportsClient.create(params);` |
+| Get attendanceReports from users | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.get({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Delete navigation property attendanceReports for users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.delete({"meetingAttendanceReport-id": meetingAttendanceReportId  });` |
+| Update the navigation property attendanceReports in users | `PATCH /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}` | `await attendanceReportsClient.update(params);` |
+
+## AttendanceRecordsClient Endpoints
+
+The AttendanceRecordsClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` endpoints. You can get a `AttendanceRecordsClient` instance like so:
+
+```typescript
+const attendanceRecordsClient = await attendanceReportsClient.attendanceRecords(meetingAttendanceReportId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendanceRecords from users | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.list(params);` |
+| Create new navigation property to attendanceRecords for users | `POST /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords` | `await attendanceRecordsClient.create(params);` |
+| Get attendanceRecords from users | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.get({"attendanceRecord-id": attendanceRecordId  });` |
+| Delete navigation property attendanceRecords for users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.delete({"attendanceRecord-id": attendanceRecordId  });` |
+| Update the navigation property attendanceRecords in users | `PATCH /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords/{attendanceRecord-id}` | `await attendanceRecordsClient.update(params);` |
+
+## AttendeeReportClient Endpoints
+
+The AttendeeReportClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendeeReport` endpoints. You can get a `AttendeeReportClient` instance like so:
+
+```typescript
+const attendeeReportClient = await onlineMeetingsClient.attendeeReport(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get attendeeReport for the navigation property onlineMeetings from users | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendeeReport` | `await attendeeReportClient.list(params);` |
+| Update attendeeReport for the navigation property onlineMeetings in users | `PUT /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendeeReport` | `await attendeeReportClient.set(body, {"onlineMeeting-id": onlineMeetingId  });` |
+| Delete attendeeReport for the navigation property onlineMeetings in users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendeeReport` | `await attendeeReportClient.delete({"onlineMeeting-id": onlineMeetingId  });` |
+
+## SendVirtualAppointmentReminderSmsClient Endpoints
+
+The SendVirtualAppointmentReminderSmsClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentReminderSms` endpoints. You can get a `SendVirtualAppointmentReminderSmsClient` instance like so:
+
+```typescript
+const sendVirtualAppointmentReminderSmsClient = await onlineMeetingsClient.sendVirtualAppointmentReminderSms(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendVirtualAppointmentReminderSms | `POST /users/{user-id}/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentReminderSms` | `await sendVirtualAppointmentReminderSmsClient.create(params);` |
+
+## SendVirtualAppointmentSmsClient Endpoints
+
+The SendVirtualAppointmentSmsClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentSms` endpoints. You can get a `SendVirtualAppointmentSmsClient` instance like so:
+
+```typescript
+const sendVirtualAppointmentSmsClient = await onlineMeetingsClient.sendVirtualAppointmentSms(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendVirtualAppointmentSms | `POST /users/{user-id}/onlineMeetings/{onlineMeeting-id}/sendVirtualAppointmentSms` | `await sendVirtualAppointmentSmsClient.create(params);` |
+
+## RecordingsClient Endpoints
+
+The RecordingsClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings` endpoints. You can get a `RecordingsClient` instance like so:
+
+```typescript
+const recordingsClient = await onlineMeetingsClient.recordings(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get callRecording | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings` | `await recordingsClient.list(params);` |
+| Create new navigation property to recordings for users | `POST /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings` | `await recordingsClient.create(params);` |
+| Get callRecording | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}` | `await recordingsClient.get({"callRecording-id": callRecordingId  });` |
+| Delete navigation property recordings for users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}` | `await recordingsClient.delete({"callRecording-id": callRecordingId  });` |
+| Update the navigation property recordings in users | `PATCH /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}` | `await recordingsClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await recordingsClient.content(callRecordingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get content for the navigation property recordings from users | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property recordings in users | `PUT /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` | `await contentClient.set(body, {"callRecording-id": callRecordingId  });` |
+| Delete content for the navigation property recordings in users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings/{callRecording-id}/content` | `await contentClient.delete({"callRecording-id": callRecordingId  });` |
+
+## TranscriptsClient Endpoints
+
+The TranscriptsClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts` endpoints. You can get a `TranscriptsClient` instance like so:
+
+```typescript
+const transcriptsClient = await onlineMeetingsClient.transcripts(onlineMeetingId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List transcripts | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts` | `await transcriptsClient.list(params);` |
+| Create new navigation property to transcripts for users | `POST /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts` | `await transcriptsClient.create(params);` |
+| Get callTranscript | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}` | `await transcriptsClient.get({"callTranscript-id": callTranscriptId  });` |
+| Delete navigation property transcripts for users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}` | `await transcriptsClient.delete({"callTranscript-id": callTranscriptId  });` |
+| Update the navigation property transcripts in users | `PATCH /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}` | `await transcriptsClient.update(params);` |
+
+## ContentClient Endpoints
+
+The ContentClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` endpoints. You can get a `ContentClient` instance like so:
+
+```typescript
+const contentClient = await transcriptsClient.content(callTranscriptId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get callTranscript | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` | `await contentClient.list(params);` |
+| Update content for the navigation property transcripts in users | `PUT /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` | `await contentClient.set(body, {"callTranscript-id": callTranscriptId  });` |
+| Delete content for the navigation property transcripts in users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/content` | `await contentClient.delete({"callTranscript-id": callTranscriptId  });` |
+
+## MetadataContentClient Endpoints
+
+The MetadataContentClient instance gives access to the following `/users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` endpoints. You can get a `MetadataContentClient` instance like so:
+
+```typescript
+const metadataContentClient = await transcriptsClient.metadataContent(callTranscriptId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get callTranscript | `GET /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` | `await metadataContentClient.list(params);` |
+| Update metadataContent for the navigation property transcripts in users | `PUT /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` | `await metadataContentClient.set(body, {"callTranscript-id": callTranscriptId  });` |
+| Delete metadataContent for the navigation property transcripts in users | `DELETE /users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts/{callTranscript-id}/metadataContent` | `await metadataContentClient.delete({"callTranscript-id": callTranscriptId  });` |
+
+## CreateOrGetClient Endpoints
+
+The CreateOrGetClient instance gives access to the following `/users/{user-id}/onlineMeetings/createOrGet` endpoints. You can get a `CreateOrGetClient` instance like so:
+
+```typescript
+const createOrGetClient = onlineMeetingsClient.createOrGet;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action createOrGet | `POST /users/{user-id}/onlineMeetings/createOrGet` | `await createOrGetClient.create(params);` |
+
+## PresenceClient Endpoints
+
+The PresenceClient instance gives access to the following `/users/{user-id}/presence` endpoints. You can get a `PresenceClient` instance like so:
+
+```typescript
+const presenceClient = await usersClient.presence(userId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get presence | `GET /users/{user-id}/presence` | `await presenceClient.list(params);` |
+| Delete navigation property presence for users | `DELETE /users/{user-id}/presence` | `await presenceClient.delete({"user-id": userId  });` |
+| Update the navigation property presence in users | `PATCH /users/{user-id}/presence` | `await presenceClient.update(params);` |
+
+## ClearPresenceClient Endpoints
+
+The ClearPresenceClient instance gives access to the following `/users/{user-id}/presence/clearPresence` endpoints. You can get a `ClearPresenceClient` instance like so:
+
+```typescript
+const clearPresenceClient = presenceClient.clearPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action clearPresence | `POST /users/{user-id}/presence/clearPresence` | `await clearPresenceClient.create(params);` |
+
+## ClearUserPreferredPresenceClient Endpoints
+
+The ClearUserPreferredPresenceClient instance gives access to the following `/users/{user-id}/presence/clearUserPreferredPresence` endpoints. You can get a `ClearUserPreferredPresenceClient` instance like so:
+
+```typescript
+const clearUserPreferredPresenceClient = presenceClient.clearUserPreferredPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action clearUserPreferredPresence | `POST /users/{user-id}/presence/clearUserPreferredPresence` | `await clearUserPreferredPresenceClient.create(params);` |
+
+## SetPresenceClient Endpoints
+
+The SetPresenceClient instance gives access to the following `/users/{user-id}/presence/setPresence` endpoints. You can get a `SetPresenceClient` instance like so:
+
+```typescript
+const setPresenceClient = presenceClient.setPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setPresence | `POST /users/{user-id}/presence/setPresence` | `await setPresenceClient.create(params);` |
+
+## SetStatusMessageClient Endpoints
+
+The SetStatusMessageClient instance gives access to the following `/users/{user-id}/presence/setStatusMessage` endpoints. You can get a `SetStatusMessageClient` instance like so:
+
+```typescript
+const setStatusMessageClient = presenceClient.setStatusMessage;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setStatusMessage | `POST /users/{user-id}/presence/setStatusMessage` | `await setStatusMessageClient.create(params);` |
+
+## SetUserPreferredPresenceClient Endpoints
+
+The SetUserPreferredPresenceClient instance gives access to the following `/users/{user-id}/presence/setUserPreferredPresence` endpoints. You can get a `SetUserPreferredPresenceClient` instance like so:
+
+```typescript
+const setUserPreferredPresenceClient = presenceClient.setUserPreferredPresence;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action setUserPreferredPresence | `POST /users/{user-id}/presence/setUserPreferredPresence` | `await setUserPreferredPresenceClient.create(params);` |
+
+## TeamworkClient Endpoints
+
+The TeamworkClient instance gives access to the following `/users/{user-id}/teamwork` endpoints. You can get a `TeamworkClient` instance like so:
+
+```typescript
+const teamworkClient = await usersClient.teamwork(userId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get userTeamwork | `GET /users/{user-id}/teamwork` | `await teamworkClient.list(params);` |
+| Delete navigation property teamwork for users | `DELETE /users/{user-id}/teamwork` | `await teamworkClient.delete({"user-id": userId  });` |
+| Update the navigation property teamwork in users | `PATCH /users/{user-id}/teamwork` | `await teamworkClient.update(params);` |
+
+## AssociatedTeamsClient Endpoints
+
+The AssociatedTeamsClient instance gives access to the following `/users/{user-id}/teamwork/associatedTeams` endpoints. You can get a `AssociatedTeamsClient` instance like so:
+
+```typescript
+const associatedTeamsClient = teamworkClient.associatedTeams;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get associatedTeams from users | `GET /users/{user-id}/teamwork/associatedTeams` | `await associatedTeamsClient.list(params);` |
+| Create new navigation property to associatedTeams for users | `POST /users/{user-id}/teamwork/associatedTeams` | `await associatedTeamsClient.create(params);` |
+| Get associatedTeams from users | `GET /users/{user-id}/teamwork/associatedTeams/{associatedTeamInfo-id}` | `await associatedTeamsClient.get({"associatedTeamInfo-id": associatedTeamInfoId  });` |
+| Delete navigation property associatedTeams for users | `DELETE /users/{user-id}/teamwork/associatedTeams/{associatedTeamInfo-id}` | `await associatedTeamsClient.delete({"associatedTeamInfo-id": associatedTeamInfoId  });` |
+| Update the navigation property associatedTeams in users | `PATCH /users/{user-id}/teamwork/associatedTeams/{associatedTeamInfo-id}` | `await associatedTeamsClient.update(params);` |
+
+## TeamClient Endpoints
+
+The TeamClient instance gives access to the following `/users/{user-id}/teamwork/associatedTeams/{associatedTeamInfo-id}/team` endpoints. You can get a `TeamClient` instance like so:
+
+```typescript
+const teamClient = await associatedTeamsClient.team(associatedTeamInfoId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get team from users | `GET /users/{user-id}/teamwork/associatedTeams/{associatedTeamInfo-id}/team` | `await teamClient.list(params);` |
+
+## InstalledAppsClient Endpoints
+
+The InstalledAppsClient instance gives access to the following `/users/{user-id}/teamwork/installedApps` endpoints. You can get a `InstalledAppsClient` instance like so:
+
+```typescript
+const installedAppsClient = teamworkClient.installedApps;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| List apps installed for user | `GET /users/{user-id}/teamwork/installedApps` | `await installedAppsClient.list(params);` |
+| Install app for user | `POST /users/{user-id}/teamwork/installedApps` | `await installedAppsClient.create(params);` |
+| Get installed app for user | `GET /users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}` | `await installedAppsClient.get({"userScopeTeamsAppInstallation-id": userScopeTeamsAppInstallationId  });` |
+| Uninstall app for user | `DELETE /users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}` | `await installedAppsClient.delete({"userScopeTeamsAppInstallation-id": userScopeTeamsAppInstallationId  });` |
+| Update the navigation property installedApps in users | `PATCH /users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}` | `await installedAppsClient.update(params);` |
+
+## ChatClient Endpoints
+
+The ChatClient instance gives access to the following `/users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}/chat` endpoints. You can get a `ChatClient` instance like so:
+
+```typescript
+const chatClient = await installedAppsClient.chat(userScopeTeamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get chat between user and teamsApp | `GET /users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}/chat` | `await chatClient.list(params);` |
+
+## TeamsAppClient Endpoints
+
+The TeamsAppClient instance gives access to the following `/users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}/teamsApp` endpoints. You can get a `TeamsAppClient` instance like so:
+
+```typescript
+const teamsAppClient = await installedAppsClient.teamsApp(userScopeTeamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsApp from users | `GET /users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}/teamsApp` | `await teamsAppClient.list(params);` |
+
+## TeamsAppDefinitionClient Endpoints
+
+The TeamsAppDefinitionClient instance gives access to the following `/users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}/teamsAppDefinition` endpoints. You can get a `TeamsAppDefinitionClient` instance like so:
+
+```typescript
+const teamsAppDefinitionClient = await installedAppsClient.teamsAppDefinition(userScopeTeamsAppInstallationId);
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Get teamsAppDefinition from users | `GET /users/{user-id}/teamwork/installedApps/{userScopeTeamsAppInstallation-id}/teamsAppDefinition` | `await teamsAppDefinitionClient.list(params);` |
+
+## SendActivityNotificationClient Endpoints
+
+The SendActivityNotificationClient instance gives access to the following `/users/{user-id}/teamwork/sendActivityNotification` endpoints. You can get a `SendActivityNotificationClient` instance like so:
+
+```typescript
+const sendActivityNotificationClient = teamworkClient.sendActivityNotification;
+```
+| Description | Endpoint | Usage | 
+|--|--|--|
+| Invoke action sendActivityNotification | `POST /users/{user-id}/teamwork/sendActivityNotification` | `await sendActivityNotificationClient.create(params);` |


### PR DESCRIPTION
## Linked issues

Related to: https://github.com/microsoft/teams-ai/issues/2480

## Details

The Graph API client does not support the full and entire Microsoft Graph API surface. It's difficult for developers to understand which endpoints are actually supported and how to access them. 

As a first step towards improving the graph client, this PR adds in-depth guides to show exactly which endpoints are currently supported. 

#### Change details
The change here adds a new in-depth overview page for the graph client, and subpages for each area that is supported. The main audience for this change is someone who's already familiar with the Graph API surface and needs to understand what this library provides and how to access those features. 

The documentation stops short at showing input parameter types and return values. We should add that too in the future, but this is a good start.

**screenshots**:
New readme.md start page:
![image](https://github.com/user-attachments/assets/f0369045-94cf-4204-9890-163292b5c946)

Child page:
![image](https://github.com/user-attachments/assets/e772e242-8049-4948-8df9-4f0929ab83f2)


## Attestation Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have checked for/fixed spelling, linting, and other errors
- [ x ] My changes generate no new warnings
