### PR TITLE
Add scripts to generate llmstxt files

### DIFF
--- a/.github/workflows/deploy-teams-docs.yml
+++ b/.github/workflows/deploy-teams-docs.yml
@@ -31,6 +31,10 @@ jobs:
         working-directory: teams.md
         run: npm install
 
+      - name: Generate llms.txt files
+        working-directory: teams.md
+        run: npm run generate:llms
+
       - name: Build static site
         working-directory: teams.md
         run: npm run build

--- a/teams.md/docs/csharp/getting-started/LLMs.md
+++ b/teams.md/docs/csharp/getting-started/LLMs.md
@@ -1,0 +1,7 @@
+# LLMs.txt
+
+Using Coding Assistants is a common practice now to help speed up development. To aid with this, you can provide your coding assistant sufficient context about this library by linking it to its llms.txt files:
+
+Small: [llms_csharp.txt](/llms_csharp.txt) - This file contains an index of the various pages in the C# documentation. The agent needs to selectively read the relevant pages to answer questions and help with development.
+
+Large: [llms_csharp_fill.txt](/llms_csharp_fill.txt) - This file contains the full content of the C# documentation, including all pages and code snippets. The agent can keep the entire documentation in memory to answer questions and help with development.

--- a/teams.md/docs/typescript/getting-started/LLMs.md
+++ b/teams.md/docs/typescript/getting-started/LLMs.md
@@ -1,0 +1,7 @@
+# LLMs.txt
+
+Using Coding Assistants is a common practice now to help speed up development. To aid with this, you can provide your coding assistant sufficient context about this library by linking it to its llms.txt files:
+
+Small: [llm_typescript.txt](/llms_typescript.txt) - This file contains an index of the various pages in the TypeScript documentation. The agent needs to selectively read the relevant pages to answer questions and help with development.
+
+Large: [llm_typescript_fill.txt](/llms_typescript_fill.txt) - This file contains the full content of the TypeScript documentation, including all pages and code snippets. The agent can keep the entire documentation in memory to answer questions and help with development.

--- a/teams.md/package.json
+++ b/teams.md/package.json
@@ -15,7 +15,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "generate:llms": "node scripts/generate-llms-txt.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.7.0",

--- a/teams.md/scripts/generate-llms-txt.js
+++ b/teams.md/scripts/generate-llms-txt.js
@@ -1,0 +1,461 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { collectFiles, getHierarchicalFiles } = require('./lib/file-collector');
+const { processContent, extractSummary } = require('./lib/content-processor');
+
+/**
+ * Reads Docusaurus config to get base URL
+ * @param {string} baseDir - Base directory path
+ * @returns {Object} Config object with url and baseUrl
+ */
+function getDocusaurusConfig(baseDir) {
+    try {
+        // Read the docusaurus.config.ts file
+        const configPath = path.join(baseDir, 'docusaurus.config.ts');
+        const configContent = fs.readFileSync(configPath, 'utf8');
+        
+        // Extract URL and baseUrl using regex (simple approach)
+        const urlMatch = configContent.match(/url:\s*['"]([^'"]+)['"]/);
+        const baseUrlMatch = configContent.match(/baseUrl\s*=\s*['"]([^'"]+)['"]/) || 
+                            configContent.match(/baseUrl:\s*['"]([^'"]+)['"]/);
+        
+        const url = urlMatch ? urlMatch[1] : 'https://microsoft.github.io';
+        const baseUrl = baseUrlMatch ? baseUrlMatch[1] : '/teams-ai/';
+        
+        return { url, baseUrl };
+    } catch (error) {
+        console.warn('⚠️ Could not read Docusaurus config, using defaults');
+        return { url: 'https://microsoft.github.io', baseUrl: '/teams-ai/' };
+    }
+}
+
+/**
+ * Generates llms.txt files for Teams AI documentation
+ * Creates both small and full versions for TypeScript and C# docs
+ */
+async function generateLlmsTxt() {
+    console.log('🚀 Starting llms.txt generation...');
+    
+    const baseDir = path.join(__dirname, '..');
+    const outputDir = path.join(baseDir, 'static');
+    
+    // Get Docusaurus configuration
+    const config = getDocusaurusConfig(baseDir);
+    const cleanUrl = config.url.replace(/\/$/, '');
+    const cleanBaseUrl = config.baseUrl.startsWith('/') ? config.baseUrl : '/' + config.baseUrl;
+    console.log(`📍 Using base URL: ${cleanUrl}${cleanBaseUrl}`);
+    
+    // Ensure output directory exists
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+    }
+    
+    try {
+        // Generate TypeScript version (main + typescript)
+        console.log('📝 Generating TypeScript llms.txt files...');
+        await generateLanguageFiles('typescript', baseDir, outputDir, config);
+        
+        // Generate C# version (main + csharp)
+        console.log('📝 Generating C# llms.txt files...');
+        await generateLanguageFiles('csharp', baseDir, outputDir, config);
+        
+        console.log('✅ Successfully generated all llms.txt files!');
+        
+    } catch (error) {
+        console.error('❌ Error generating llms.txt files:', error);
+        process.exit(1);
+    }
+}
+
+/**
+ * Generates llms.txt files for a specific language
+ * @param {string} language - 'typescript' or 'csharp'
+ * @param {string} baseDir - Base directory path
+ * @param {string} outputDir - Output directory path
+ * @param {Object} config - Docusaurus config object
+ */
+async function generateLanguageFiles(language, baseDir, outputDir, config) {
+    // Collect all relevant files
+    const mainFiles = collectFiles(path.join(baseDir, 'docs', 'main'));
+    const langFiles = collectFiles(path.join(baseDir, 'docs', language));
+    
+    // Process all files to get metadata
+    const processedFiles = await processAllFiles([...mainFiles, ...langFiles], baseDir);
+    
+    // Generate individual TXT files for each doc
+    await generateIndividualTxtFiles(processedFiles, outputDir, language);
+    
+    // Process content for small version (navigation index)
+    const smallContent = await generateSmallVersionHierarchical(language, baseDir, config);
+    
+    // Process content for full version (all documentation)
+    const fullContent = await generateFullVersion(language, processedFiles, baseDir);
+    
+    // Write main llms.txt files
+    const smallPath = path.join(outputDir, `llms_${language}.txt`);
+    const fullPath = path.join(outputDir, `llms_${language}_full.txt`);
+    
+    fs.writeFileSync(smallPath, smallContent, 'utf8');
+    fs.writeFileSync(fullPath, fullContent, 'utf8');
+    
+    console.log(`  ✓ Generated ${path.basename(smallPath)} (${formatBytes(smallContent.length)})`);
+    console.log(`  ✓ Generated ${path.basename(fullPath)} (${formatBytes(fullContent.length)})`);
+    console.log(`  ✓ Generated ${processedFiles.length} individual .txt files`);
+}
+
+/**
+ * Processes all files and returns structured data
+ * @param {Array<string>} allFiles - All file paths to process
+ * @param {string} baseDir - Base directory path
+ * @returns {Promise<Array>} Array of processed file objects
+ */
+async function processAllFiles(allFiles, baseDir) {
+    const processedFiles = [];
+    
+    for (const file of allFiles) {
+        const processed = await processContent(file, baseDir, true);
+        if (processed.title || processed.content) {
+            processedFiles.push(processed);
+        }
+    }
+    
+    // Sort by sidebar position, then by title
+    return processedFiles.sort((a, b) => {
+        const posA = a.sidebarPosition || 999;
+        const posB = b.sidebarPosition || 999;
+        
+        if (posA !== posB) {
+            return posA - posB;
+        }
+        
+        return (a.title || '').localeCompare(b.title || '');
+    });
+}
+
+/**
+ * Generates individual .txt files for each documentation file
+ * @param {Array} processedFiles - Array of processed file objects
+ * @param {string} outputDir - Output directory path
+ * @param {string} language - Language identifier
+ */
+async function generateIndividualTxtFiles(processedFiles, outputDir, language) {
+    const docsDir = path.join(outputDir, `docs_${language}`);
+    
+    // Create docs directory
+    if (!fs.existsSync(docsDir)) {
+        fs.mkdirSync(docsDir, { recursive: true });
+    }
+    
+    for (const file of processedFiles) {
+        if (!file.content) continue;
+        
+        // Generate safe filename from title or path
+        const fileName = generateSafeFileName(file.title || file.filePath);
+        const outputPath = path.join(docsDir, `${fileName}.txt`);
+        
+        // Create plain text content with metadata header
+        let txtContent = `# ${file.title}\n\n`;
+        if (file.frontmatter.sidebar_position) {
+            txtContent += `Sidebar Position: ${file.frontmatter.sidebar_position}\n`;
+        }
+        txtContent += `Source File: ${path.basename(file.filePath)}\n\n`;
+        txtContent += '---\n\n';
+        txtContent += file.content;
+        
+        fs.writeFileSync(outputPath, txtContent, 'utf8');
+    }
+}
+
+/**
+ * Generates the small version of llms.txt (navigation index)
+ * @param {string} language - Language identifier
+ * @param {Array} processedFiles - Array of processed file objects
+ * @param {string} baseDir - Base directory path
+ * @param {Object} config - Docusaurus config object
+ * @returns {string} Generated navigation content
+ */
+async function generateSmallVersionHierarchical(language, baseDir, config) {
+    const langName = language === 'typescript' ? 'TypeScript' : 'C#';
+    // Remove trailing slash from URL and ensure baseUrl starts with slash
+    const cleanUrl = config.url.replace(/\/$/, '');
+    const cleanBaseUrl = config.baseUrl.startsWith('/') ? config.baseUrl : '/' + config.baseUrl;
+    const fullBaseUrl = `${cleanUrl}${cleanBaseUrl}`;
+    
+    let content = `# Teams AI Library - ${langName} Documentation\n\n`;
+    content += `> Microsoft Teams AI Library (v2) - A comprehensive framework for building AI-powered Teams applications using ${langName}.\n\n`;
+    
+    // Get hierarchical structure
+    const hierarchical = getHierarchicalFiles(baseDir, language);
+    
+    // Add Main Documentation
+    content += `## Main Documentation\n\n`;
+    content += renderHierarchicalStructure(hierarchical.main, fullBaseUrl, language, 0);
+    
+    // Add Language-specific Documentation
+    content += `## ${langName} Specific Documentation\n\n`;
+    content += renderHierarchicalStructure(hierarchical.language, fullBaseUrl, language, 1);
+    
+    return content;
+}
+
+/**
+ * Renders hierarchical structure with proper indentation
+ * @param {Object} structure - Hierarchical structure object
+ * @param {string} baseUrl - Base URL for links
+ * @param {string} language - Language identifier
+ * @param {number} baseIndent - Base indentation level (0 for main, 1 for language-specific)
+ * @returns {string} Rendered content with proper hierarchy
+ */
+function renderHierarchicalStructure(structure, baseUrl, language, baseIndent = 0) {
+    let content = '';
+    
+    // Convert structure to sorted array
+    const folders = Object.entries(structure)
+        .map(([key, value]) => ({ key, ...value }))
+        .sort((a, b) => {
+            const orderA = a.order || 999;
+            const orderB = b.order || 999;
+            if (orderA !== orderB) return orderA - orderB;
+            return a.key.localeCompare(b.key);
+        });
+    
+    for (const folder of folders) {
+        const indent = '  '.repeat(baseIndent);
+        const fileIndent = '  '.repeat(baseIndent + 1);
+        
+        // Check if this folder has any content (files or children)
+        const hasFiles = folder.files && folder.files.length > 0;
+        const hasChildren = folder.children && Object.keys(folder.children).length > 0;
+        const hasContent = hasFiles || hasChildren;
+        
+        if (hasContent) {
+            // Add folder header with proper title
+            const displayTitle = folder.title && folder.title !== folder.key ? folder.title : formatFolderName(folder.key);
+            content += `${indent}### ${displayTitle}\n\n`;
+            
+            // Add files in this folder (sorted by order)
+            if (hasFiles) {
+                const sortedFiles = [...folder.files].sort((a, b) => {
+                    const orderA = a.order || 999;
+                    const orderB = b.order || 999;
+                    if (orderA !== orderB) return orderA - orderB;
+                    return a.name.localeCompare(b.name);
+                });
+                
+                for (const file of sortedFiles) {
+                    const fileName = generateSafeFileName(file.title || file.name);
+                    const summary = extractSummaryFromFile(file.path);
+                    
+                    content += `${fileIndent}- [${file.title}](${baseUrl}docs_${language}/${fileName}.txt)`;
+                    if (summary) {
+                        content += `: ${summary}`;
+                    }
+                    content += '\n';
+                }
+                
+                // Add extra spacing after files if there are children
+                if (hasChildren) {
+                    content += '\n';
+                }
+            }
+            
+            // Recursively render children with increased indentation
+            if (hasChildren) {
+                content += renderHierarchicalStructure(folder.children, baseUrl, language, baseIndent + 1);
+            }
+            
+            content += '\n';
+        }
+    }
+    
+    // Helper function for folder name formatting
+    function formatFolderName(name) {
+        return name
+            .replace(/[-_]/g, ' ')
+            .replace(/\b\w/g, l => l.toUpperCase());
+    }
+    
+    return content;
+}
+
+/**
+ * Extracts summary from a file (cached approach)
+ * @param {string} filePath - Path to the file
+ * @returns {string} File summary or empty string
+ */
+function extractSummaryFromFile(filePath) {
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        
+        // Remove frontmatter
+        const withoutFrontmatter = content.replace(/^---\s*\n[\s\S]*?\n---\s*\n/, '');
+        
+        // Extract first meaningful paragraph
+        const paragraphs = withoutFrontmatter.split('\n\n');
+        for (const paragraph of paragraphs) {
+            const clean = paragraph
+                .replace(/#+\s*/g, '') // Remove headers
+                .replace(/\*\*(.+?)\*\*/g, '$1') // Remove bold
+                .replace(/\*(.+?)\*/g, '$1') // Remove italic
+                .replace(/`(.+?)`/g, '$1') // Remove inline code
+                .replace(/\[(.+?)\]\(.+?\)/g, '$1') // Remove links, keep text
+                .trim();
+            
+            if (clean.length > 20 && !clean.startsWith('```') && !clean.startsWith('import')) {
+                return clean.length > 100 ? clean.substring(0, 100) + '...' : clean;
+            }
+        }
+    } catch (error) {
+        // Ignore file read errors
+    }
+    
+    return '';
+}
+
+/**
+ * Generates the full version of llms.txt (complete documentation)
+ * @param {string} language - Language identifier
+ * @param {Array} processedFiles - Array of processed file objects
+ * @param {string} baseDir - Base directory path
+ * @returns {string} Generated content
+ */
+async function generateFullVersion(language, processedFiles, baseDir) {
+    const langName = language === 'typescript' ? 'TypeScript' : 'C#';
+    
+    let content = `# Teams AI Library - ${langName} Documentation (Complete)\n\n`;
+    content += `> Complete documentation for Microsoft Teams AI Library (v2) - A comprehensive framework for building AI-powered Teams applications using ${langName}.\n\n`;
+    
+    // Group files by section
+    const sections = groupFilesBySection(processedFiles, baseDir);
+    
+    // Process all sections
+    for (const [sectionName, files] of Object.entries(sections)) {
+        if (!files || files.length === 0) continue;
+        
+        content += `## ${formatSectionName(sectionName)}\n\n`;
+        
+        for (const file of files) {
+            if (file.content) {
+                content += `### ${file.title}\n\n${file.content}\n\n---\n\n`;
+            }
+        }
+    }
+    
+    return content;
+}
+
+/**
+ * Groups files by their section based on file path
+ * @param {Array} processedFiles - Array of processed file objects
+ * @param {string} baseDir - Base directory path
+ * @returns {Object} Grouped files by section
+ */
+function groupFilesBySection(processedFiles, baseDir) {
+    const sections = {
+        main: [],
+        gettingStarted: [],
+        essentials: [],
+        inDepthGuides: [],
+        migrations: []
+    };
+    
+    for (const file of processedFiles) {
+        const relativePath = path.relative(path.join(baseDir, 'docs'), file.filePath);
+        
+        if (relativePath.startsWith('main/')) {
+            sections.main.push(file);
+        } else if (relativePath.includes('getting-started/')) {
+            sections.gettingStarted.push(file);
+        } else if (relativePath.includes('essentials/')) {
+            sections.essentials.push(file);
+        } else if (relativePath.includes('in-depth-guides/')) {
+            sections.inDepthGuides.push(file);
+        } else if (relativePath.includes('migrations/')) {
+            sections.migrations.push(file);
+        } else {
+            // Create dynamic section based on directory
+            const parts = relativePath.split('/');
+            if (parts.length > 1) {
+                const sectionKey = parts[1].replace(/[^a-zA-Z0-9]/g, '');
+                if (!sections[sectionKey]) {
+                    sections[sectionKey] = [];
+                }
+                sections[sectionKey].push(file);
+            }
+        }
+    }
+    
+    // Sort files within each section by sidebar position
+    for (const sectionFiles of Object.values(sections)) {
+        sectionFiles.sort((a, b) => {
+            const posA = a.sidebarPosition || 999;
+            const posB = b.sidebarPosition || 999;
+            
+            if (posA !== posB) {
+                return posA - posB;
+            }
+            
+            return (a.title || '').localeCompare(b.title || '');
+        });
+    }
+    
+    return sections;
+}
+
+/**
+ * Generates a safe filename from a title
+ * @param {string} title - Title to convert to filename
+ * @returns {string} Safe filename
+ */
+function generateSafeFileName(title) {
+    return title
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
+        .replace(/\s+/g, '-') // Replace spaces with hyphens
+        .replace(/-+/g, '-') // Replace multiple hyphens with single
+        .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
+        .substring(0, 50) // Limit length
+        || 'untitled';
+}
+
+/**
+ * Formats a section name for display
+ * @param {string} sectionName - Section name to format
+ * @returns {string} Formatted section name
+ */
+function formatSectionName(sectionName) {
+    const nameMap = {
+        main: 'Main Documentation',
+        gettingStarted: 'Getting Started',
+        essentials: 'Essentials',
+        inDepthGuides: 'In-Depth Guides',
+        migrations: 'Migrations'
+    };
+    
+    return nameMap[sectionName] || sectionName
+        .replace(/([A-Z])/g, ' $1') // Add spaces before capitals
+        .replace(/^./, str => str.toUpperCase()) // Capitalize first letter
+        .trim();
+}
+
+/**
+ * Formats bytes into human-readable format
+ * @param {number} bytes - Number of bytes
+ * @returns {string} Formatted string
+ */
+function formatBytes(bytes) {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+}
+
+// Run the generator if this file is executed directly
+if (require.main === module) {
+    generateLlmsTxt();
+}
+
+module.exports = { generateLlmsTxt };

--- a/teams.md/scripts/generate-llms-txt.js
+++ b/teams.md/scripts/generate-llms-txt.js
@@ -187,14 +187,8 @@ async function generateIndividualTxtFiles(processedFiles, outputDir, language, b
         
         const outputPath = path.join(docsDir, `${fileName}.txt`);
         
-        // Create plain text content with metadata header
-        let txtContent = `# ${file.title}\n\n`;
-        if (file.frontmatter.sidebar_position) {
-            txtContent += `Sidebar Position: ${file.frontmatter.sidebar_position}\n`;
-        }
-        txtContent += `Source File: ${path.basename(file.filePath)}\n\n`;
-        txtContent += '---\n\n';
-        txtContent += reprocessed.content || file.content; // Use reprocessed content with full URLs
+        // Use the reprocessed content directly without adding metadata header
+        let txtContent = reprocessed.content || file.content; // Use reprocessed content with full URLs
         
         fs.writeFileSync(outputPath, txtContent, 'utf8');
     }

--- a/teams.md/scripts/lib/content-processor.js
+++ b/teams.md/scripts/lib/content-processor.js
@@ -1,0 +1,303 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Processes a markdown/MDX file and extracts its content
+ * @param {string} filePath - Path to the file to process
+ * @param {string} baseDir - Base directory for resolving relative paths
+ * @param {boolean} includeCodeBlocks - Whether to include FileCodeBlock content
+ * @returns {Promise<Object>} Processed content with title, content, and metadata
+ */
+async function processContent(filePath, baseDir, includeCodeBlocks = false) {
+    try {
+        if (!fs.existsSync(filePath)) {
+            console.warn(`⚠️ File not found: ${filePath}`);
+            return { title: '', content: '', frontmatter: {} };
+        }
+
+        const rawContent = fs.readFileSync(filePath, 'utf8');
+        const { title, content, frontmatter } = await parseMarkdownContent(rawContent, baseDir, includeCodeBlocks);
+        
+        return {
+            title: title || generateTitleFromPath(filePath),
+            content: content || '',
+            frontmatter: frontmatter || {},
+            filePath,
+            sidebarPosition: frontmatter.sidebar_position || 999,
+            relativeUrl: generateRelativeUrl(filePath, baseDir)
+        };
+    } catch (error) {
+        console.error(`❌ Error processing file ${filePath}:`, error.message);
+        return { title: generateTitleFromPath(filePath), content: '', frontmatter: {}, filePath };
+    }
+}
+
+/**
+ * Parses markdown/MDX content and extracts title and content
+ * @param {string} rawContent - Raw file content
+ * @param {string} baseDir - Base directory for resolving paths
+ * @param {boolean} includeCodeBlocks - Whether to process FileCodeBlocks
+ * @returns {Promise<Object>} Parsed title, content, and frontmatter
+ */
+async function parseMarkdownContent(rawContent, baseDir, includeCodeBlocks) {
+    let content = rawContent;
+    let title = '';
+    let frontmatter = {};
+    
+    // Extract and remove frontmatter
+    const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
+    if (frontmatterMatch) {
+        frontmatter = parseFrontmatter(frontmatterMatch[1]);
+        title = frontmatter.title || frontmatter.sidebar_label || '';
+        content = content.replace(frontmatterMatch[0], '');
+    }
+    
+    // Extract title from first H1 if not found in frontmatter
+    if (!title) {
+        const h1Match = content.match(/^#\s+(.+)$/m);
+        if (h1Match) {
+            title = h1Match[1].trim();
+        }
+    }
+    
+    // Remove import statements
+    content = content.replace(/^import\s+.*$/gm, '');
+    
+    // Process FileCodeBlock components if requested
+    if (includeCodeBlocks) {
+        content = await processFileCodeBlocks(content, baseDir);
+    } else {
+        // Remove FileCodeBlock components for small version
+        content = content.replace(/<FileCodeBlock[\s\S]*?\/>/g, '[Code example removed for brevity]');
+    }
+    
+    // Clean up MDX-specific syntax while preserving markdown
+    content = cleanMdxSyntax(content);
+    
+    // Remove excessive whitespace
+    content = content.replace(/\n{3,}/g, '\n\n').trim();
+    
+    return { title, content, frontmatter };
+}
+
+/**
+ * Processes FileCodeBlock components and includes the referenced code
+ * @param {string} content - Content containing FileCodeBlock components
+ * @param {string} baseDir - Base directory for resolving paths
+ * @returns {Promise<string>} Content with FileCodeBlocks replaced by actual code
+ */
+async function processFileCodeBlocks(content, baseDir) {
+    const fileCodeBlockRegex = /<FileCodeBlock\s+([^>]+)\/>/g;
+    let processedContent = content;
+    let match;
+    
+    while ((match = fileCodeBlockRegex.exec(content)) !== null) {
+        const attributes = parseAttributes(match[1]);
+        const { src, lang } = attributes;
+        
+        if (src) {
+            try {
+                const codeContent = await loadCodeFile(src, baseDir);
+                const codeBlock = `\`\`\`${lang || 'typescript'}\n${codeContent}\n\`\`\``;
+                processedContent = processedContent.replace(match[0], codeBlock);
+            } catch (error) {
+                console.warn(`⚠️ Could not load code file ${src}:`, error.message);
+                processedContent = processedContent.replace(match[0], `[Code file not found: ${src}]`);
+            }
+        }
+    }
+    
+    return processedContent;
+}
+
+/**
+ * Loads code content from a file referenced by FileCodeBlock
+ * @param {string} src - Source path from FileCodeBlock (e.g., "/generated-snippets/ts/example.ts")
+ * @param {string} baseDir - Base directory
+ * @returns {Promise<string>} Code content
+ */
+async function loadCodeFile(src, baseDir) {
+    // Convert src path to local file path
+    let filePath;
+    if (src.startsWith('/')) {
+        filePath = path.join(baseDir, 'static', src.substring(1));
+    } else {
+        filePath = path.join(baseDir, 'static', src);
+    }
+    
+    if (fs.existsSync(filePath)) {
+        return fs.readFileSync(filePath, 'utf8').trim();
+    } else {
+        throw new Error(`File not found: ${filePath}`);
+    }
+}
+
+/**
+ * Parses attributes from JSX-style attribute string
+ * @param {string} attributeString - String containing attributes
+ * @returns {Object} Parsed attributes
+ */
+function parseAttributes(attributeString) {
+    const attributes = {};
+    const regex = /(\w+)=["']([^"']+)["']/g;
+    let match;
+    
+    while ((match = regex.exec(attributeString)) !== null) {
+        attributes[match[1]] = match[2];
+    }
+    
+    return attributes;
+}
+
+/**
+ * Parses YAML frontmatter into an object
+ * @param {string} frontmatterText - Raw frontmatter text
+ * @returns {Object} Parsed frontmatter
+ */
+function parseFrontmatter(frontmatterText) {
+    const frontmatter = {};
+    const lines = frontmatterText.split('\n');
+    
+    for (const line of lines) {
+        const match = line.match(/^(\w+):\s*(.+)$/);
+        if (match) {
+            const key = match[1];
+            let value = match[2].trim();
+            
+            // Remove quotes if present
+            if ((value.startsWith('"') && value.endsWith('"')) || 
+                (value.startsWith("'") && value.endsWith("'"))) {
+                value = value.slice(1, -1);
+            }
+            
+            frontmatter[key] = value;
+        }
+    }
+    
+    return frontmatter;
+}
+
+/**
+ * Cleans MDX-specific syntax while preserving standard markdown
+ * @param {string} content - Content to clean
+ * @returns {string} Cleaned content
+ */
+function cleanMdxSyntax(content) {
+    let cleaned = content;
+    
+    // Remove JSX components (except code blocks which are handled separately)
+    cleaned = cleaned.replace(/<\/?[A-Z][^>]*>/g, '');
+    
+    // Remove empty JSX fragments
+    cleaned = cleaned.replace(/<>\s*<\/>/g, '');
+    
+    // Remove JSX expressions but keep the content if it's simple text
+    cleaned = cleaned.replace(/\{([^{}]+)\}/g, (match, expr) => {
+        // Keep simple text expressions, remove complex ones
+        if (expr.includes('(') || expr.includes('.') || expr.includes('[')) {
+            return '';
+        }
+        return expr;
+    });
+    
+    // Clean up multiple empty lines
+    cleaned = cleaned.replace(/\n\s*\n\s*\n/g, '\n\n');
+    
+    return cleaned;
+}
+
+/**
+ * Generates a title from file path
+ * @param {string} filePath - File path
+ * @returns {string} Generated title
+ */
+function generateTitleFromPath(filePath) {
+    const fileName = path.basename(filePath, path.extname(filePath));
+    
+    // Convert README to parent directory name
+    if (fileName.toLowerCase() === 'readme') {
+        const parentDir = path.basename(path.dirname(filePath));
+        return formatTitle(parentDir);
+    }
+    
+    return formatTitle(fileName);
+}
+
+/**
+ * Formats a string into a proper title
+ * @param {string} str - String to format
+ * @returns {string} Formatted title
+ */
+function formatTitle(str) {
+    return str
+        .replace(/[-_]/g, ' ')
+        .replace(/\b\w/g, l => l.toUpperCase())
+        .trim();
+}
+
+/**
+ * Generates a relative URL for a documentation file
+ * @param {string} filePath - Full path to the file
+ * @param {string} baseDir - Base directory path
+ * @returns {string} Relative URL for the file
+ */
+function generateRelativeUrl(filePath, baseDir) {
+    const relativePath = path.relative(path.join(baseDir, 'docs'), filePath);
+    
+    // Convert file path to URL format
+    let url = relativePath
+        .replace(/\\/g, '/') // Convert Windows paths
+        .replace(/\.mdx?$/, '') // Remove .md/.mdx extension
+        .replace(/\/README$/i, '') // Remove /README from end
+        .replace(/\/index$/i, ''); // Remove /index from end
+    
+    // Add leading slash
+    if (!url.startsWith('/')) {
+        url = '/' + url;
+    }
+    
+    // Handle empty URL (root README)
+    if (url === '/') {
+        url = '';
+    }
+    
+    return url;
+}
+
+/**
+ * Extracts a summary from content (first paragraph or section)
+ * @param {string} content - Content to summarize
+ * @param {number} maxLength - Maximum length of summary
+ * @returns {string} Content summary
+ */
+function extractSummary(content, maxLength = 200) {
+    // Remove markdown formatting for summary
+    let summary = content
+        .replace(/#+\s*/g, '') // Remove headers
+        .replace(/\*\*(.+?)\*\*/g, '$1') // Remove bold
+        .replace(/\*(.+?)\*/g, '$1') // Remove italic
+        .replace(/`(.+?)`/g, '$1') // Remove inline code
+        .replace(/\[(.+?)\]\(.+?\)/g, '$1') // Remove links, keep text
+        .trim();
+    
+    // Get first paragraph
+    const firstParagraph = summary.split('\n\n')[0];
+    
+    // Truncate if too long
+    if (firstParagraph.length > maxLength) {
+        return firstParagraph.substring(0, maxLength).trim() + '...';
+    }
+    
+    return firstParagraph;
+}
+
+module.exports = {
+    processContent,
+    parseMarkdownContent,
+    processFileCodeBlocks,
+    loadCodeFile,
+    extractSummary,
+    generateTitleFromPath,
+    formatTitle,
+    generateRelativeUrl
+};

--- a/teams.md/scripts/lib/file-collector.js
+++ b/teams.md/scripts/lib/file-collector.js
@@ -1,0 +1,298 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Recursively collects all markdown and MDX files from a directory
+ * @param {string} dirPath - Directory path to search
+ * @param {Array<string>} extensions - File extensions to collect (default: ['.md', '.mdx'])
+ * @returns {Array<string>} Array of file paths
+ */
+function collectFiles(dirPath, extensions = ['.md', '.mdx']) {
+    const files = [];
+    
+    if (!fs.existsSync(dirPath)) {
+        console.warn(`⚠️ Directory not found: ${dirPath}`);
+        return files;
+    }
+    
+    /**
+     * Recursively traverse directory
+     * @param {string} currentPath - Current directory path
+     */
+    function traverse(currentPath) {
+        const items = fs.readdirSync(currentPath, { withFileTypes: true });
+        
+        for (const item of items) {
+            const fullPath = path.join(currentPath, item.name);
+            
+            if (item.isDirectory()) {
+                // Skip common directories that don't contain docs
+                if (!shouldSkipDirectory(item.name)) {
+                    traverse(fullPath);
+                }
+            } else if (item.isFile()) {
+                const ext = path.extname(item.name).toLowerCase();
+                if (extensions.includes(ext)) {
+                    files.push(fullPath);
+                }
+            }
+        }
+    }
+    
+    traverse(dirPath);
+    
+    // Sort files for consistent ordering
+    return files.sort();
+}
+
+/**
+ * Determines if a directory should be skipped during traversal
+ * @param {string} dirName - Directory name
+ * @returns {boolean} True if directory should be skipped
+ */
+function shouldSkipDirectory(dirName) {
+    const skipDirs = [
+        'node_modules',
+        '.git',
+        'build',
+        'dist',
+        '.next',
+        '.docusaurus',
+        'coverage',
+        '__pycache__'
+    ];
+    
+    return skipDirs.includes(dirName) || dirName.startsWith('.');
+}
+
+/**
+ * Gets files organized hierarchically based on folder structure and sidebar_position
+ * @param {string} basePath - Base documentation path
+ * @param {string} language - Language identifier ('typescript' or 'csharp')
+ * @returns {Object} Hierarchically organized file structure
+ */
+function getHierarchicalFiles(basePath, language) {
+    const mainPath = path.join(basePath, 'docs', 'main');
+    const langPath = path.join(basePath, 'docs', language);
+    
+    const structure = {
+        main: buildHierarchicalStructure(mainPath),
+        language: buildHierarchicalStructure(langPath)
+    };
+    
+    return structure;
+}
+
+/**
+ * Builds hierarchical structure for a directory
+ * @param {string} rootPath - Root directory path
+ * @returns {Object} Hierarchical structure with folders and files
+ */
+function buildHierarchicalStructure(rootPath) {
+    if (!fs.existsSync(rootPath)) {
+        return {};
+    }
+    
+    const structure = {};
+    
+    /**
+     * Recursively processes a directory
+     * @param {string} dirPath - Current directory path
+     * @param {Object} currentLevel - Current level in the structure
+     */
+    function processDirectory(dirPath, currentLevel) {
+        const items = fs.readdirSync(dirPath, { withFileTypes: true });
+        
+        // Collect folders and files separately
+        const folders = [];
+        const files = [];
+        
+        for (const item of items) {
+            const fullPath = path.join(dirPath, item.name);
+            
+            if (item.isDirectory() && !shouldSkipDirectory(item.name)) {
+                // Process subdirectory
+                const readmePath = path.join(fullPath, 'README.md');
+                let folderOrder = 999;
+                let folderTitle = item.name;
+                
+                // Get folder ordering from README.md
+                if (fs.existsSync(readmePath)) {
+                    try {
+                        const readmeContent = fs.readFileSync(readmePath, 'utf8');
+                        const frontmatterMatch = readmeContent.match(/^---\s*\n([\s\S]*?)\n---/);
+                        if (frontmatterMatch) {
+                            const frontmatter = parseFrontmatter(frontmatterMatch[1]);
+                            folderOrder = frontmatter.sidebar_position || 999;
+                            folderTitle = frontmatter.title || frontmatter.sidebar_label || formatFolderName(item.name);
+                        }
+                    } catch (error) {
+                        // Ignore errors reading README
+                    }
+                }
+                
+                folders.push({
+                    name: item.name,
+                    title: folderTitle,
+                    path: fullPath,
+                    order: folderOrder
+                });
+            } else if (item.isFile() && (item.name.endsWith('.md') || item.name.endsWith('.mdx'))) {
+                // Process file
+                let fileOrder = 999;
+                let fileTitle = item.name;
+                
+                try {
+                    const content = fs.readFileSync(fullPath, 'utf8');
+                    const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+                    if (frontmatterMatch) {
+                        const frontmatter = parseFrontmatter(frontmatterMatch[1]);
+                        fileOrder = frontmatter.sidebar_position || 999;
+                        fileTitle = frontmatter.title || frontmatter.sidebar_label || formatFileName(item.name);
+                    }
+                } catch (error) {
+                    // Ignore errors reading file
+                }
+                
+                files.push({
+                    name: item.name,
+                    title: fileTitle,
+                    path: fullPath,
+                    order: fileOrder
+                });
+            }
+        }
+        
+        // Sort files by order and add to current level
+        files.sort((a, b) => {
+            if (a.order !== b.order) return a.order - b.order;
+            return a.name.localeCompare(b.name);
+        });
+        
+        if (files.length > 0) {
+            if (!currentLevel.files) currentLevel.files = [];
+            currentLevel.files.push(...files);
+        }
+        
+        // Sort folders by order and process each one
+        folders.sort((a, b) => {
+            if (a.order !== b.order) return a.order - b.order;
+            return a.name.localeCompare(b.name);
+        });
+        
+        if (!currentLevel.children) currentLevel.children = {};
+        
+        for (const folder of folders) {
+            currentLevel.children[folder.name] = {
+                title: folder.title,
+                order: folder.order,
+                path: folder.path,
+                files: [],
+                children: {}
+            };
+            
+            // Recursively process subdirectory
+            processDirectory(folder.path, currentLevel.children[folder.name]);
+        }
+    }
+    
+    // Create a temporary wrapper to handle the root properly
+    const tempWrapper = { files: [], children: {} };
+    processDirectory(rootPath, tempWrapper);
+    
+    // Return the children (which contain the actual folder structure)
+    return tempWrapper.children;
+}
+
+/**
+ * Parses simple frontmatter
+ * @param {string} frontmatterText - Frontmatter content
+ * @returns {Object} Parsed frontmatter
+ */
+function parseFrontmatter(frontmatterText) {
+    const frontmatter = {};
+    const lines = frontmatterText.split('\n');
+    
+    for (const line of lines) {
+        const match = line.match(/^(\w+):\s*(.+)$/);
+        if (match) {
+            let value = match[2].trim();
+            
+            // Remove quotes
+            if ((value.startsWith('"') && value.endsWith('"')) || 
+                (value.startsWith("'") && value.endsWith("'"))) {
+                value = value.slice(1, -1);
+            }
+            
+            // Convert numbers
+            if (/^\d+$/.test(value)) {
+                value = parseInt(value, 10);
+            }
+            
+            frontmatter[match[1]] = value;
+        }
+    }
+    
+    return frontmatter;
+}
+
+/**
+ * Formats folder name for display
+ * @param {string} folderName - Raw folder name
+ * @returns {string} Formatted folder name
+ */
+function formatFolderName(folderName) {
+    return folderName
+        .replace(/[-_]/g, ' ')
+        .replace(/\b\w/g, l => l.toUpperCase());
+}
+
+/**
+ * Formats file name for display
+ * @param {string} fileName - Raw file name
+ * @returns {string} Formatted file name
+ */
+function formatFileName(fileName) {
+    return path.basename(fileName, path.extname(fileName))
+        .replace(/[-_]/g, ' ')
+        .replace(/\b\w/g, l => l.toUpperCase());
+}
+
+/**
+ * Gets priority files for small version generation
+ * @param {Object} organized - Organized file structure from getOrganizedFiles
+ * @returns {Array<string>} Priority files for small version
+ */
+function getPriorityFiles(organized) {
+    const priorityFiles = [];
+    
+    // Add welcome/overview files
+    priorityFiles.push(...organized.main.welcome);
+    
+    // Add key team concepts
+    const keyTeamFiles = organized.main.teams.filter(file => 
+        file.includes('core-concepts') || 
+        file.includes('README.md')
+    );
+    priorityFiles.push(...keyTeamFiles);
+    
+    // Add getting started files
+    priorityFiles.push(...organized.language.gettingStarted);
+    
+    // Add essential README files
+    const essentialReadmes = organized.language.essentials.filter(file => 
+        file.includes('README.md') || 
+        file.includes('app-basics')
+    );
+    priorityFiles.push(...essentialReadmes);
+    
+    return priorityFiles;
+}
+
+module.exports = {
+    collectFiles,
+    getHierarchicalFiles,
+    getPriorityFiles,
+    shouldSkipDirectory,
+    buildHierarchicalStructure
+};


### PR DESCRIPTION
LLMs txt (https://llmstxt.org/#format) is a format that's being adopted in the industry to help coding assistants leverage the library effectively. 

This PR introduces a script to generate llms.txt (small) and llms.txt (full) for both typescript and C#. In addition it generates a txt file for each document.
llms.txt (small) - this is essentially an index file that contains links to other txt files
llms.txt (full) - this is essentially a full dump of the entire documentation all concatenated together.

The files get generated when the deploy is happening. 
Also added an actual documentation to help folks discover these files.

The scripts are basically vibecoded, but I've gone through it and they seem to be correct, and doing what I want.