### PR TITLE
[JS] feat: #2560 Add max_completion_tokens handling for gpt-5

### DIFF
--- a/js/packages/teams-ai/src/models/OpenAIModel.ts
+++ b/js/packages/teams-ai/src/models/OpenAIModel.ts
@@ -169,14 +169,14 @@ export interface AzureOpenAIModelOptions extends BaseOpenAIModelOptions {
  * @remarks
  * The model has been updated to support calling OpenAI's new o1 family of models. That currently
  * comes with a few constraints. These constraints are mostly handled for you but are worth noting:
- * - The o1 models introduce a new `max_completion_tokens` parameter and they've deprecated the
+ * - The o1 and gpt-5 models introduce a new `max_completion_tokens` parameter and they've deprecated the
  *  `max_tokens` parameter. The model will automatically convert the incoming `max_tokens` parameter
  * to `max_completion_tokens` for you. But you should be aware that o1 has hidden token usage and costs
  * that aren't constrained by the `max_completion_tokens` parameter. This means that you may see an
  * increase in token usage and costs when using the o1 models.
  * - The o1 models do not currently support the sending of system messages which just means that the
  * `useSystemMessages` parameter is ignored when calling the o1 models.
- * - The o1 models do not currently support setting the `temperature`, `top_p`, and `presence_penalty`
+ * - The o1 and gpt-5 models do not currently support setting the `temperature`, `top_p`, and `presence_penalty`
  * parameters so they will be ignored.
  * - The o1 models do not currently support the use of tools so you will need to use the "monologue"
  * augmentation to call actions.
@@ -324,6 +324,7 @@ export class OpenAIModel implements PromptCompletionModel {
         // Check for use of system messages
         // - 'user' messages tend to be followed better by the model then 'system' messages.
         const isThinkingModel = model.startsWith('o1') || model.startsWith('o3');
+        const isGpt5Model = model.startsWith('gpt-5')
         const useSystemMessages = !isThinkingModel && this.options.useSystemMessages;
         if (!useSystemMessages && result.output.length > 0 && result.output[0].role == 'system') {
             result.output[0].role = 'user';
@@ -344,7 +345,7 @@ export class OpenAIModel implements PromptCompletionModel {
         try {
             // Get the chat completion parameters
             const params = this.getChatCompletionParams(model, updatedMessages, template);
-            if (isThinkingModel) {
+            if (isThinkingModel || isGpt5Model) {
                 if (params.max_tokens) {
                     params.max_completion_tokens = params.max_tokens;
                     delete params.max_tokens;


### PR DESCRIPTION
OpenAi released gpt-5 in Aug 7, 2025. gpt-5 has deprecated the max_tokens parameter and old variable temperatures, having an api similar to the o* models. This change fixes gpt-5 usage and allows users to choose cheaper/better gpt-5 models as their base model.

Since gpt-5 models allows for tools usage and system messages but do not allow for temperature, top_p and presence_penalty parameters, a new flag has been added to toggle on just the parameters handling. This is going to fix the bad request error that happens when trying to use gpt-5 models using teams-ai

## Linked issues

closes: #2560

## Details

Added a new isGpt5Model flag to toggle off deprecated api parameters, but keeping tool usage as system prompts.

#### Change details

Create a new flag variable named isGpt5Model to toggle off new max_completion_tokens and other parameters when detected (just like reasoning models) 

**code snippets**:


```typescript       
const isGpt5Model = model.startsWith('gpt-5')
// --- ... --  
if (isThinkingModel || isGpt5Model) {
          if (params.max_tokens) {
              params.max_completion_tokens = params.max_tokens;
              delete params.max_tokens;
          }
          params.temperature = 1;
          params.top_p = 1;
          params.presence_penalty = 0;
      }
          
```

## Attestation Checklist

- [X] My code follows the style guidelines of this project

- I have checked for/fixed spelling, linting, and other errors
- I have commented my code for clarity
- I have made corresponding changes to the documentation (updating the doc strings in the code is sufficient)
- My changes generate no new warnings
- I have added tests that validates my changes, and provides sufficient test coverage. I have tested with:
  - Local testing
  - E2E testing in Teams
- New and existing unit tests pass locally with my changes
