### PR TITLE
Update typescript documentation for new graph API client

### DIFF
--- a/teams.md/docs/typescript/essentials/api.md
+++ b/teams.md/docs/typescript/essentials/api.md
@@ -30,7 +30,9 @@ app.on('message', async ({ activity, api }) => {
 It's also possible to access the api client from outside a handler via the app instance. Here we have the same example as above, but we're access the api client via the app instance.
 
 ```typescript
-const res = await app.api.graph.chats.getAllMessages.get();
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+
+const res = await app.api.graph.call(endpoints.chats.getAllMessages.get);
 ```
 
 

--- a/teams.md/docs/typescript/essentials/graph.md
+++ b/teams.md/docs/typescript/essentials/graph.md
@@ -6,16 +6,22 @@ sidebar_position: 6
 
 [Microsoft Graph](https://docs.microsoft.com/en-us/graph/overview) gives you access to the wider Microsoft 365 ecosystem. You can enrich your application with data from across Microsoft 365.
 
-The library gives your application easy access to the Microsoft Graph API via the `@microsoft/teams.graph` package.
+The library gives your application easy access to the Microsoft Graph API via the `@microsoft/teams.graph` and `@microsoft/teams.graph-endpoints` packages.
+
+:::note
+If you're migrating from an earlier preview version of the Teams AI v2 library, please see the [migration guide](../migrations/preview/) for details on breaking changes.
+:::
 
 Microsoft Graph can be accessed by your application using its own application token, or by using the user's token. If you need access to resources that your application may not have, but your user does, you will need to use the user's scoped graph client. To grant explicit consent for your application to access resources on behalf of a user, follow the [auth guide](../in-depth-guides/user-authentication).
 
-To access the graph using the Graph using the app, you may use the `app.graph` object. 
+To access the graph using the Graph using the app, you may use the `app.graph` object to call the endpoint of your choice. 
 
 ```typescript
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+
 // Equivalent of https://learn.microsoft.com/en-us/graph/api/user-get
 // Gets the details of the bot-user
-app.graph.me.get().then((user) => {
+app.graph.call(endpoints.me.get).then((user) => {
   console.log(`User ID: ${user.id}`);
   console.log(`User Display Name: ${user.displayName}`);
   console.log(`User Email: ${user.mail}`);
@@ -23,11 +29,14 @@ app.graph.me.get().then((user) => {
 });
 ```
 
-To access the graph using the user's token, you need to do this as part of a message handler:
+You can also access the graph using the user's token from within a message handler via the `userGraph` prop.
 
 ```typescript
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+
+// Gets details of the current user
 app.on('message', async ({ activity, userGraph }) => {
-  const me = await userGraph.me.get();
+  const me = await userGraph.call(endpoints.me.get);
   console.log(`User ID: ${me.id}`);
   console.log(`User Display Name: ${me.displayName}`);
   console.log(`User Email: ${me.mail}`);
@@ -43,9 +52,9 @@ You also have access to the `appGraph` object in the activity handler. This is e
 
 ## The Graph Client
 
-The Graph Client is a wrapper around the Microsoft Graph API. It provides a fluent API for accessing the Graph API and is scoped to a specific user or application. Having an understanding of [how the graph API works](https://learn.microsoft.com/en-us/graph/use-the-api) will help you make the most of the library. Microsoft Graph exposes resources using the OData standard, and the graph client exposes type-safe access to these resources.
+The Graph Client provides a straight-forward `call` method to interact with Microsoft Graph and issue requests scoped to a specific user or application. Paired with the Graph Endpoints packages, it offers discoverable and type-safe access to the vast Microsoft Graph API surface.
 
-For example, to get the `id` of the chat instance between a user and an app, [Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/userscopeteamsappinstallation-get-chat?view=graph-rest-1.0&tabs=http) exposes it via:
+Having an understanding of [how the graph API works](https://learn.microsoft.com/en-us/graph/use-the-api) will help you make the most of the library. For example, to get the `id` of the chat instance between a user and an app, [Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/userscopeteamsappinstallation-get-chat?view=graph-rest-1.0&tabs=http) exposes it via:
 
 ```
 GET /users/{user-id | user-principal-name}/teamwork/installedApps/{app-installation-id}/chat
@@ -54,30 +63,36 @@ GET /users/{user-id | user-principal-name}/teamwork/installedApps/{app-installat
 The equivalent using the graph client would look like this:
 
 ```ts
-const chat = await userGraph.teamwork(user.id).installedApps.chat(appInstallationId).get({
+import { users } from '@microsoft/teams.graph-endpoints';
+
+const chat = await userGraph.call(users.teamwork.installedApps.chat.get, {
   "user-id": user.id,
   "userScopeTeamsAppInstallation-id": appInstallationId,
   "$select": ["id"],
-})
+});
 ```
 
 Here, the client takes care of using the correct token, provides helpful hints via intellisense, and performs the fetch request for you.
 
-## Currently exposed Graph clients
+## Additional resources
+Microsoft Graph offers an extensive and thoroughly documented API surface. These two essential resources will serve as your go-to references for any Graph development work:
+ - The [Microsoft Graph Rest API reference documentation](https://learn.microsoft.com/en-us/graph/api/overview) gives details for each API, including permissions requirements.
+ - The [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer) lets you discover and test drive APIs.
 
-The following clients are currently exposed:
+In addition, the following endpoints may be especially interesting to Teams developers:
 
-| Client Name | Graph endpoint | Description |
-|-------------|----------------|-------------|
-| appCatalogs | [/appCatalogs](https://learn.microsoft.com/en-us/graph/api/appcatalogs-list-teamsapps?view=graph-rest-1.0) | Apps from Teams App Catalog |
-| appRoleAssignments | [/appRoleAssignments](https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list-approleassignments?view=graph-rest-1.0) | List app role assignments |
-| applicationTemplates | [/applicationTemplates](https://learn.microsoft.com/en-us/graph/api/resources/applicationtemplate?view=graph-rest-1.0) | Application in the Microsoft Entra App Gallery |
-| applications | [/applications](https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0) | Application Resources |
-| chats | [/chats](https://learn.microsoft.com/en-us/graph/api/chat-list?view=graph-rest-1.0&tabs=http) | Chat resources between users |
-| communications | [/communications](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0) | Calls and Online meetings |
-| employeeExperience | [/employeeExperience](https://learn.microsoft.com/en-us/graph/api/resources/engagement-api-overview?view=graph-rest-1.0) |  Employee Experience and Engagement |
-| me | [/me](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http) | Same as `/users` but scoped to one user (who is making the request) |
-| teams | [/teams](https://learn.microsoft.com/en-us/graph/api/resources/team?view=graph-rest-1.0) | A Team resource  |
-| teamsTemplates | [/teamsTemplates](https://learn.microsoft.com/en-us/microsoftteams/get-started-with-teams-templates) | A Team Template resource |
-| teamwork | [/teamwork](https://learn.microsoft.com/en-us/graph/api/resources/teamwork?view=graph-rest-1.0) | A range of Microsoft Teams functionalities |
-| users | [/users](https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0) | A user resource |
+| Graph endpoints | Description |
+|----------------|-------------|
+| [appCatalogs](https://learn.microsoft.com/en-us/graph/api/appcatalogs-list-teamsapps?view=graph-rest-1.0) | Apps in the Teams App Catalog |
+| [appRoleAssignments](https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list-approleassignments?view=graph-rest-1.0) | App role assignments |
+| [applicationTemplates](https://learn.microsoft.com/en-us/graph/api/resources/applicationtemplate?view=graph-rest-1.0) | Applications in the Microsoft Entra App Gallery |
+| [applications](https://learn.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0) | Application resources |
+| [chats](https://learn.microsoft.com/en-us/graph/api/chat-list?view=graph-rest-1.0&tabs=http) | Chat resources between users |
+| [communications](https://learn.microsoft.com/en-us/graph/api/application-post-calls?view=graph-rest-1.0) | Calls and Online meetings |
+| [employeeExperience](https://learn.microsoft.com/en-us/graph/api/resources/engagement-api-overview?view=graph-rest-1.0) | Employee Experience and Engagement |
+| [me](https://learn.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http) | Same as `/users` but scoped to one user (who is making the request) |
+| [teams](https://learn.microsoft.com/en-us/graph/api/resources/team?view=graph-rest-1.0) | Team resources in Microsoft Teams |
+| [teamsTemplates](https://learn.microsoft.com/en-us/microsoftteams/get-started-with-teams-templates) | Templates used to create teams |
+| [teamwork](https://learn.microsoft.com/en-us/graph/api/resources/teamwork?view=graph-rest-1.0) | A range of Microsoft Teams functionalities |
+| [users](https://learn.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0) | User resources |
+

--- a/teams.md/docs/typescript/in-depth-guides/tabs/app-options.md
+++ b/teams.md/docs/typescript/in-depth-guides/tabs/app-options.md
@@ -208,6 +208,7 @@ Scope pre-warming can be disabled if needed. This is useful if your app doesn't 
 
 ```typescript
 import { App } from '@microsoft/teams.client';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App(clientId, {
   msalOptions: { prewarmScopes: false },
@@ -218,7 +219,7 @@ await app.start();
 
 // this will prompt for the '.default' scope if the user hasn't already
 // consented to any scope
-const top10Chats = await app.graph.chats.list( { $top: 10 });
+const top10Chats = await app.graph.call(endpoints.chats.list, { $top: 10 });
 ```
 
 

--- a/teams.md/docs/typescript/in-depth-guides/tabs/getting-started.md
+++ b/teams.md/docs/typescript/in-depth-guides/tabs/getting-started.md
@@ -11,7 +11,7 @@ The Teams CLI contains a Microsoft 365 Agents Toolkit configuration and a templa
 
 
 ```sh
-teams new my-first-tab-app --tk embed --template tab
+teams new typescript my-first-tab-app --atk embed --template tab
 ```
 
 

--- a/teams.md/docs/typescript/in-depth-guides/tabs/graph.md
+++ b/teams.md/docs/typescript/in-depth-guides/tabs/graph.md
@@ -12,11 +12,12 @@ After constructing and starting an App instance, you can invoke any graph functi
 
 ```typescript
 import { App } from '@microsoft/teams.client';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App(clientId);
 await app.start();
 
-const top10Chats = await app.graph.chats.list( { $top: 10 });
+const top10Chats = await app.graph.call(endpoints.chats.list, { $top: 10 });
 ```
 
 
@@ -41,6 +42,7 @@ This method is useful for building an incremental, just-in-time, consent model, 
 
 ```typescript
 import { App } from '@microsoft/teams.client';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App(clientId, {
   msalOptions: { prewarmScopes: ['User.Read'] },
@@ -55,7 +57,7 @@ const canReadChat = await app.ensureConsentForScopes(
   );
 
 if (canReadChat) {
-  const top10Chats = await app.graph.chats.list( { $top: 10 });
+  const top10Chats = await app.graph.call(endpoints.chats.list, { $top: 10 });
   // ... do something useful ...
 }
 ```
@@ -68,6 +70,7 @@ The app also provides a `hasConsentForScopes` method to test for consent without
 
 ```typescript
 import { App } from '@microsoft/teams.client';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App(clientId);
 
@@ -81,7 +84,7 @@ const canReadChat = await app.hasConsentForScopes(
   );
 
 if (canReadChat) {
-  const top10Chats = await app.graph.chats.list( { $top: 10 });
+  const top10Chats = await app.graph.call(endpoints.chats.list, { $top: 10 });
   // ... do something useful ...
 }
 ```

--- a/teams.md/docs/typescript/in-depth-guides/tabs/using-the-app.md
+++ b/teams.md/docs/typescript/in-depth-guides/tabs/using-the-app.md
@@ -46,6 +46,7 @@ When the `app.start()` call has completed, you can use the app instance to call 
 ```typescript
 import * as teamsJs from '@microsoft/teams-js';
 import { App } from '@microsoft/teams.client';
+import * as endpoints from '@microsoft/teams.graph-endpoints';
 
 const app = new App(clientId);
 await app.start();
@@ -54,7 +55,7 @@ await app.start();
 const context = await teamsJs.app.getContext();
 
 // ...call Graph end points...
-const presenceResult = await app.graph.me.presence.get();
+const presenceResult = await app.graph.call(endpoints.me.presence.get);
 
 // ...end call remote agent functions...
 const agentResult = await app.exec<string>('hello-world');

--- a/teams.md/docs/typescript/migrations/preview/README.md
+++ b/teams.md/docs/typescript/migrations/preview/README.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3
+---
+
+# From V2 Previews
+
+If you're moving from preview versions of Teams AI v2, you may encounter a few breaking changes along the way. This page outlines those and shows how to get back on track.
+
+## Graph Client
+
+The Graph Client has been redesigned to be more flexible and support far more Graph APIs, while being mindful of code and package size. The Graph endpoints are now an optional dependency, and one that is fully tree-shakable if you're using a modern bundler. 
+
+The redesign changes the calling pattern slightly. If you were using Graph APIs, you may need to update your code.
+
+### Installing endpoints dependency
+The first step in the migration is to install the `@microsoft/teams.graph-endpoints` dependency. This dependency is optional to reduce overhead for for applications that don't need to call Graph APIs. If you're reading this migration guide however, you'll likely want to install it.
+
+This package is installed just like any other NPM package, using your package manager of choice. For instance:
+
+```sh
+npm install @microsoft/teams.graph-endpoints@preview
+```
+
+### Updating code
+Once the endpoints dependency is installed, the code changes should be fairly straight forward as the overall Graph taxonomy and API naming conventions have not changed. The overall change is that instead of invoking an endpoint function directly, you now pass in an endpoint to the `graphClient.call()` method.
+
+#### Calling endpoints
+In earlier preview versions, the way to get details for the current user was:
+
+```typescript
+// GET /me
+const me = await app.graph.me.get();
+```
+
+In current versions, the equivalent method is:
+```typescript
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+
+// GET /me
+const me = await app.graph.call(endpoints.me.get);
+```
+
+#### Providing arguments
+In earlier preview versions, variables were passes as an argument when invoking the endpoint. To get details for a specific user, you would do the following:
+
+```typescript
+// GET /users/{id | userPrincipalName}
+const user = await app.graph.users.get({ 'user-id': userId });
+```
+
+In current versions, the variables are provided as a separate argument after the endpoint:
+```typescript
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+
+// GET /users/{id | userPrincipalName}
+const user = await app.graph.call(endpoints.users.get, { 'user-id': userId });
+```
+
+#### No more redundant arguments
+In earlier preview versions, some endpoints required the same argument to be provided twice. For instance:
+
+```typescript
+// GET /teams/{team-id}/installedApps`
+const apps = await app.graph.teams.installedApps(teamId).list({ 'team-id': teamId });
+```
+
+In current versions, once is enough:
+
+```typescript
+// GET /teams/{team-id}/installedApps`
+const apps = await app.graph.call(endpoints.teams.installedApps.list, { "team-id": teamId });
+```
+
+#### Improving readability
+If you find it helpful for readability, you can scope your endpoint import as you prefer. For instance:
+
+```typescript
+import * as endpoints from '@microsoft/teams.graph-endpoints';
+import { me } from '@microsoft/teams.graph-endpoints';
+import { presence } from '@microsoft/teams.graph-endpoints/me';
+import { setPresence } from '@microsoft/teams.graph-endpoints/me/presence';
+import { create as updatePresence  } from '@microsoft/teams.graph-endpoints/me/presence/setPresence';
+
+// different ways to POST to /me/presence/setPresence
+const newPresence = { availability: 'Away', activity: 'Away', sessionId: clientId };
+await app.graph.call(endpoints.me.presence.setPresence.create, newPresence);
+await app.graph.call(me.presence.setPresence.create, newPresence);
+await app.graph.call(presence.setPresence.create, newPresence);
+await app.graph.call(setPresence.create, newPresence);
+await app.graph.call(updatePresence, newPresence);
+```
+


### PR DESCRIPTION
This updates the Graph documentation to use the new syntax. E.g. from
```
const me = await userGraph.me.get();
```
to
```
import * as endpoints from '@microsoft/teams.graph-endpoints';
const me = await userGraph.call(endpoints.me.get);
```

Also, adds a new `teams.md/docs/typescript/migrations/preview/README.md` migration page for folks moving from older preview builds, to help them update their code for the new usage pattern.