### PR TITLE
fix: lang to teams new command docs

### DIFF
--- a/teams.md/docs/csharp/in-depth-guides/tabs/getting-started.md
+++ b/teams.md/docs/csharp/in-depth-guides/tabs/getting-started.md
@@ -12,7 +12,7 @@ The Teams CLI contains a Microsoft 365 Agents Toolkit configuration and a templa
 
 
 ```sh
-teams new my-first-tab-app --tk embed --template tab
+teams new csharp my-first-tab-app --tk embed --template tab
 ```
 
 

--- a/teams.md/docs/csharp/in-depth-guides/user-authentication/quickstart.md
+++ b/teams.md/docs/csharp/in-depth-guides/user-authentication/quickstart.md
@@ -35,7 +35,7 @@ Use your terminal to run the following command:
 
 
 ```sh
-teams new oauth-app --template graph
+teams new csharp oauth-app --template graph
 ```
 
 

--- a/teams.md/docs/typescript/in-depth-guides/user-authentication/quickstart.md
+++ b/teams.md/docs/typescript/in-depth-guides/user-authentication/quickstart.md
@@ -35,7 +35,7 @@ Use your terminal to run the following command:
 
 
 ```sh
-teams new oauth-app --template graph
+teams new typescript oauth-app --template graph
 ```
 
 


### PR DESCRIPTION
In UserAuth quickstarts, the `teams new` command is missing the first param with the language

