### PR TITLE
fix: update branch references and links from v2-preview to main

### DIFF
--- a/.github/workflows/deploy-teams-docs.yml
+++ b/.github/workflows/deploy-teams-docs.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - v2-preview
+      - main
     paths:
       - 'teams.md/**'
       - .github/workflows/deploy-teams-docs.yml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Welcome to the Teams AI Library v2
 
-> \[!CAUTION]
-> **PREVIEW VERSION** This is a preview version of the Teams AI Library v2. While we will do our best to avoid breaking changes, some breaking changes should be expected until the first major version.
-
 ## Overview
 
 Teams AI Library v2 represents a fundamental reimagining of how Teams apps and AI agents are built, while maintaining compatibility with existing botframework-based agents. This new version focuses on developer experience, simplified architecture, and enhanced AI capabilities.

--- a/teams.md/docusaurus.config.ts
+++ b/teams.md/docusaurus.config.ts
@@ -48,7 +48,7 @@ const config: Config = {
                     path: 'docs/main',
                     sidebarPath: './sidebars.ts',
                     sidebarCollapsed: false,
-                    editUrl: 'https://github.com/microsoft/teams-ai/tree/v2-preview/teams.md/',
+                    editUrl: 'https://github.com/microsoft/teams-ai/tree/main/teams.md/',
                 },
                 theme: {
                     customCss: ['./src/css/custom.css', './src/css/code-blocks.css'],
@@ -66,7 +66,7 @@ const config: Config = {
                 routeBasePath: '/typescript',
                 sidebarPath: './sidebars.ts',
                 sidebarCollapsed: true,
-                editUrl: 'https://github.com/microsoft/teams-ai/tree/v2-preview/teams.md/',
+                editUrl: 'https://github.com/microsoft/teams-ai/tree/main/teams.md/',
             } satisfies Partial<DocsPlugin.PluginOptions>,
         ],
         [
@@ -77,7 +77,7 @@ const config: Config = {
                 routeBasePath: '/csharp',
                 sidebarPath: './sidebars.ts',
                 sidebarCollapsed: true,
-                editUrl: 'https://github.com/microsoft/teams-ai/tree/v2-preview/teams.md/',
+                editUrl: 'https://github.com/microsoft/teams-ai/tree/main/teams.md/',
             } satisfies Partial<DocsPlugin.PluginOptions>,
         ],
         [
@@ -88,7 +88,7 @@ const config: Config = {
                 routeBasePath: '/python',
                 sidebarPath: './sidebars.ts',
                 sidebarCollapsed: true,
-                editUrl: 'https://github.com/microsoft/teams-ai/tree/v2-preview/teams.md/',
+                editUrl: 'https://github.com/microsoft/teams-ai/tree/main/teams.md/',
             } satisfies Partial<DocsPlugin.PluginOptions>,
         ],
     ],
@@ -143,7 +143,7 @@ const config: Config = {
                     position: 'right',
                 },
                 {
-                    href: 'https://github.com/microsoft/teams-ai/tree/v2-preview',
+                    href: 'https://github.com/microsoft/teams-ai/tree/main',
                     position: 'right',
                     className: 'header-github-link',
                 },
@@ -182,11 +182,11 @@ const config: Config = {
                     items: [
                         {
                             label: 'GitHub',
-                            href: 'https://github.com/microsoft/teams-ai/tree/v2-preview',
+                            href: 'https://github.com/microsoft/teams-ai/tree/main',
                         },
                         {
                             label: 'Contributing',
-                            href: 'https://github.com/microsoft/teams-ai/blob/v2-preview/CONTRIBUTING.md',
+                            href: 'https://github.com/microsoft/teams-ai/blob/main/CONTRIBUTING.md',
                         },
                         {
                             label: 'Blog',

--- a/teams.md/i18n/en/docusaurus-theme-classic/footer.json
+++ b/teams.md/i18n/en/docusaurus-theme-classic/footer.json
@@ -17,7 +17,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/microsoft/teams-ai/tree/v2-preview"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/microsoft/teams-ai/tree/main"
   },
   "copyright": {
     "message": "Copyright © 2025 Microsoft Corporation. All rights reserved.",

--- a/teams.md/i18n/es/docusaurus-theme-classic/footer.json
+++ b/teams.md/i18n/es/docusaurus-theme-classic/footer.json
@@ -17,7 +17,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/microsoft/teams-ai/tree/v2-preview"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/microsoft/teams-ai/tree/main"
   },
   "copyright": {
     "message": "Copyright © 2025 Microsoft Corporation. All rights reserved.",

--- a/teams.md/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/teams.md/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -17,7 +17,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/microsoft/teams-ai/tree/v2-preview"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/microsoft/teams-ai/tree/main"
   },
   "copyright": {
     "message": "Copyright © 2025 Microsoft Corporation. All rights reserved.",


### PR DESCRIPTION
This pull request updates the documentation and configuration to point to the `main` branch instead of the deprecated `v2-preview` branch, reflecting the transition to the stable release of the Teams AI Library v2. It also removes the preview warning from the `README.md` and ensures all documentation edit links, GitHub references, and workflow triggers are aligned with the `main` branch.

**Branch and documentation updates:**

* Changed the deployment workflow in `.github/workflows/deploy-teams-docs.yml` to trigger on pushes to the `main` branch instead of `v2-preview`.
* Updated all `editUrl` and GitHub links in `teams.md/docusaurus.config.ts` to reference the `main` branch, ensuring users are directed to the current stable branch for editing and viewing source code. [[1]](diffhunk://#diff-93623e75bf523adf3d54585b8224d0fb14645f28ef604f6c3b41bfabd150a72aL51-R51) [[2]](diffhunk://#diff-93623e75bf523adf3d54585b8224d0fb14645f28ef604f6c3b41bfabd150a72aL69-R69) [[3]](diffhunk://#diff-93623e75bf523adf3d54585b8224d0fb14645f28ef604f6c3b41bfabd150a72aL80-R80) [[4]](diffhunk://#diff-93623e75bf523adf3d54585b8224d0fb14645f28ef604f6c3b41bfabd150a72aL91-R91) [[5]](diffhunk://#diff-93623e75bf523adf3d54585b8224d0fb14645f28ef604f6c3b41bfabd150a72aL146-R146) [[6]](diffhunk://#diff-93623e75bf523adf3d54585b8224d0fb14645f28ef604f6c3b41bfabd150a72aL185-R189)
* Updated localized footer link descriptions in `teams.md/i18n/en/docusaurus-theme-classic/footer.json`, `teams.md/i18n/es/docusaurus-theme-classic/footer.json`, and `teams.md/i18n/zh-Hans/docusaurus-theme-classic/footer.json` to point to the `main` branch.

**Documentation content:**

* Removed the preview warning from the top of the `README.md`, indicating the library is no longer in preview status.