### PR TITLE
Update llmstxt for typescript

### DIFF
--- a/teams.md/docs/csharp/essentials/README.md
+++ b/teams.md/docs/csharp/essentials/README.md
@@ -5,7 +5,7 @@ summary: Introduction to core concepts and paradigms for building C# Teams AI ap
 
 # Essentials
 
-At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a task module, or clicks a button — your app is there to interpret the event and act on it.
+At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a dialog, or clicks a button — your app is there to interpret the event and act on it.
 
 With Teams AI Library v2, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
 

--- a/teams.md/docs/csharp/getting-started/quickstart.md
+++ b/teams.md/docs/csharp/getting-started/quickstart.md
@@ -15,19 +15,19 @@ Get started with Teams AI Library (v2) quickly using the Teams CLI.
 
 ## Instructions
 
-### Install the Teams CLI
+### Use the Teams CLI
 
-Use your terminal to install the Teams CLI globally using npm:
+Use your terminal to run the Teams CLI using npx:
 
 
 ```sh
-npm install -g @microsoft/teams.cli
+npx @microsoft/teams.cli --version
 ```
 
 
 :::info
 _The [Teams CLI](/developer-tools/cli) is a command-line tool that helps you create and manage Teams applications. It provides a set of commands to simplify the development process._<br /><br />
-After installation, you can run `teams --version` to verify the installation.
+Using `npx` allows you to run the Teams CLI without installing it globally. You can verify it works by running the version command above.
 :::
 
 ## Creating Your First Agent
@@ -36,7 +36,7 @@ Let's begin by creating a simple echo agent that responds to messages. Run:
 
 
 ```sh
-teams new csharp quote-agent --template echo
+npx @microsoft/teams.cli new csharp quote-agent --template echo
 ```
 
 

--- a/teams.md/docs/python/essentials/README.md
+++ b/teams.md/docs/python/essentials/README.md
@@ -5,7 +5,7 @@ summary: Introduction to core concepts and paradigms for building Python Teams A
 
 # Essentials
 
-At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a task module, or clicks a button — your app is there to interpret the event and act on it.
+At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a dialog, or clicks a button — your app is there to interpret the event and act on it.
 
 With Teams AI Library v2, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
 

--- a/teams.md/docs/python/getting-started/quickstart.md
+++ b/teams.md/docs/python/getting-started/quickstart.md
@@ -20,19 +20,19 @@ UV is a fast Python package installer and resolver. While you can use other pack
 
 ## Instructions
 
-### Install the Teams CLI
+### Use the Teams CLI
 
-Use your terminal to install the Teams CLI globally using npm:
+Use your terminal to run the Teams CLI using npx:
 
 
 ```sh
-npm install -g @microsoft/teams.cli
+npx @microsoft/teams.cli --version
 ```
 
 
 :::info
 _The [Teams CLI](/developer-tools/cli) is a command-line tool that helps you create and manage Teams applications. It provides a set of commands to simplify the development process._<br /><br />
-After installation, you can run `teams --version` to verify the installation.
+Using `npx` allows you to run the Teams CLI without installing it globally. You can verify it works by running the version command above.
 :::
 
 ## Creating Your First Agent
@@ -41,7 +41,7 @@ Let's begin by creating a simple echo agent that responds to messages. Run:
 
 
 ```sh
-teams new python quote-agent --template echo
+npx @microsoft/teams.cli new python quote-agent --template echo
 ```
 
 This command:

--- a/teams.md/docs/typescript/essentials/README.md
+++ b/teams.md/docs/typescript/essentials/README.md
@@ -5,7 +5,7 @@ summary: Introduction to the core concepts of Teams AI applications including ev
 
 # Essentials
 
-At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a task module, or clicks a button — your app is there to interpret the event and act on it.
+At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a dialog, or clicks a button — your app is there to interpret the event and act on it.
 
 With Teams AI Library v2, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
 

--- a/teams.md/docs/typescript/getting-started/LLMs.md
+++ b/teams.md/docs/typescript/getting-started/LLMs.md
@@ -5,7 +5,7 @@ llms: ignore
 
 # LLMs.txt
 
-A common practice to speed up development is using Coding Assistants. To better fascilitate this usage, you can provide your coding assistant sufficient context about this library by linking your assistant to the library's llms.txt files:
+A common practice to speed up development is using Coding Assistants. To better facilitate this usage, you can provide your coding assistant sufficient context about this library by linking your assistant to the library's llms.txt files:
 
 Small: [llm_typescript.txt](https://microsoft.github.io/teams-ai/llms_docs/llms_typescript.txt) - This file contains an index of the various pages in the TypeScript documentation. The agent needs to selectively read the relevant pages to answer questions and help with development.
 

--- a/teams.md/docs/typescript/getting-started/README.md
+++ b/teams.md/docs/typescript/getting-started/README.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 summary: Getting started guide for TypeScript Teams AI Library covering application setup, structure, and local development fundamentals.
+llms: ignore-file
 ---
 
 # 🚀 Getting Started

--- a/teams.md/docs/typescript/getting-started/quickstart.md
+++ b/teams.md/docs/typescript/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Step-by-step guide to quickly get started with Teams AI Library v2 using the Teams CLI to create your first agent.
+summary: Step-by-step guide to quickly get started with Teams AI Library v2 using the Teams CLI to create your first agent. Start here to build your first agent or application. We STRONGLY recommend using this as a guide to get started. It will help you build your project structure and scaffold your project.
 ---
 
 # Quickstart
@@ -15,19 +15,19 @@ Get started with Teams AI Library (v2) quickly using the Teams CLI.
 
 ## Instructions
 
-### Install the Teams CLI
+### Use the Teams CLI
 
-Use your terminal to install the Teams CLI globally using npm:
+Use your terminal to run the Teams CLI using npx:
 
 
 ```sh
-npm install -g @microsoft/teams.cli
+npx @microsoft/teams.cli --version
 ```
 
 
 :::info
 _The [Teams CLI](/developer-tools/cli) is a command-line tool that helps you create and manage Teams applications. It provides a set of commands to simplify the development process._<br /><br />
-After installation, you can run `teams --version` to verify the installation.
+Using `npx` allows you to run the Teams CLI without installing it globally. You can verify it works by running the version command above.
 :::
 
 ## Creating Your First Agent
@@ -36,7 +36,7 @@ Let's begin by creating a simple echo agent that responds to messages. Run:
 
 
 ```sh
-teams new typescript quote-agent --template echo
+npx @microsoft/teams.cli new typescript quote-agent --template echo
 ```
 
 

--- a/teams.md/docs/typescript/in-depth-guides/adaptive-cards/building-adaptive-cards.mdx
+++ b/teams.md/docs/typescript/in-depth-guides/adaptive-cards/building-adaptive-cards.mdx
@@ -17,10 +17,25 @@ With `@microsoft/teams.cards` you can build these cards entirely in TypeScript /
 `@microsoft/teams.cards` exposes small **builder helpers** (`Card`, `TextBlock`, `ToggleInput`, `ExecuteAction`, _etc._).
 Each helper wraps raw JSON and provides fluent, chainable methods that keep your code concise and readable.
 
-<FileCodeBlock
-    lang="typescript"
-    src="/generated-snippets/ts/index.snippet.basic-card-building.ts"
-/>
+```ts
+import {
+    AdaptiveCard,
+    TextBlock,
+    ToggleInput,
+    ExecuteAction,
+    ActionSet,
+} from "@microsoft/teams.cards";
+
+const card = new AdaptiveCard(
+    new TextBlock('Hello world', { wrap: true, weight: 'Bolder' }),
+    new ToggleInput('Notify me').withId('notify'),
+    new ActionSet(
+        new ExecuteAction({ title: 'Submit' })
+            .withData({ action: 'submit_basic' })
+            .withAssociatedInputs('auto')
+    )
+);
+```
 
 Benefits:
 
@@ -62,11 +77,51 @@ Prefer a drag‑and‑drop approach? Use [Microsoft's Adaptive Card Designer](ht
 const cardJson = /* copied JSON */;
 const card = new AdaptiveCard().withBody(cardJson);
 ```
-
-<FileCodeBlock
-    lang="typescript"
-    src="/generated-snippets/ts/index.snippet.raw-card-json.ts"
-/>
+```ts
+const rawCard: IAdaptiveCard = {
+  type: 'AdaptiveCard',
+  body: [
+    {
+      text: 'Please fill out the below form to send a game purchase request.',
+      wrap: true,
+      type: 'TextBlock',
+      style: 'heading',
+    },
+    {
+      columns: [
+        {
+          width: 'stretch',
+          items: [
+            {
+              choices: [
+                { title: 'Call of Duty', value: 'call_of_duty' },
+                { title: 'Death\'s Door', value: 'deaths_door' },
+                { title: 'Grand Theft Auto V', value: 'grand_theft' },
+                { title: 'Minecraft', value: 'minecraft' },
+              ],
+              style: 'filtered',
+              placeholder: 'Search for a game',
+              id: 'choiceGameSingle',
+              type: 'Input.ChoiceSet',
+              label: 'Game:',
+            },
+          ],
+          type: 'Column',
+        },
+      ],
+      type: 'ColumnSet',
+    },
+  ],
+  actions: [
+    {
+      title: 'Request purchase',
+      type: 'Action.Execute',
+      data: { action: 'purchase_item' },
+    },
+  ],
+  version: '1.5',
+};
+```
 
 This method leverages the full Adaptive Card schema and ensures that the payload adheres strictly to `IAdaptiveCard`.
 
@@ -80,11 +135,54 @@ You can use a combination of raw JSON and builder helpers depending on whatever 
 
 Below is a complete example showing a task management form. Notice how the builder pattern keeps the file readable and maintainable:
 
-<FileCodeBlock
-    lang="typescript"
-    src="/generated-snippets/ts/index.snippet.sending-adaptive-card-e2e.ts"
-/>
+```ts
+import { MessageActivity } from '@microsoft/teams.api';
+import { TextBlock,
+  TextInput,
+  ChoiceSetInput,
+  DateInput,
+  ActionSet,
+  ExecuteAction
+} from '@microsoft/teams.cards';
 
+app.on('message', async ({ send, activity }) => {
+  await send({ type: 'typing' });
+  const card = new AdaptiveCard(
+    new TextBlock('Create New Task', {
+      size: 'Large',
+      weight: 'Bolder',
+    }),
+    new TextInput({ id: 'title' })
+      .withLabel('Task Title')
+      .withPlaceholder('Enter task title'),
+    new TextInput({ id: 'description' })
+      .withLabel('Description')
+      .withPlaceholder('Enter task details')
+      .withIsMultiline(true),
+    new ChoiceSetInput(
+      { title: 'High', value: 'high' },
+      { title: 'Medium', value: 'medium' },
+      { title: 'Low', value: 'low' }
+    )
+      .withId('priority')
+      .withLabel('Priority')
+      .withValue('medium'),
+    new DateInput({ id: 'due_date' })
+      .withLabel('Due Date')
+      .withValue(new Date().toISOString().split('T')[0]),
+    new ActionSet(
+      new ExecuteAction({ title: 'Create Task' })
+        .withData({ action: 'create_task' })
+        .withAssociatedInputs('auto')
+        .withStyle('positive')
+    )
+  );
+  await send(card);
+  // Or build a complex activity out that includes the card:
+  // const message  = new MessageActivity('Enter this form').addCard('adaptive', card);
+  // await send(message);
+});
+```
 ---
 
 ## Additional Resources

--- a/teams.md/docs/typescript/in-depth-guides/ai/function-calling.mdx
+++ b/teams.md/docs/typescript/in-depth-guides/ai/function-calling.mdx
@@ -5,7 +5,7 @@ summary: How to implement function calling in AI models, allowing the LLM to exe
 
 import FileCodeBlock from '@site/src/components/FileCodeBlock';
 
-# Functions
+# Function / Tool Calling
 
 It's possible to hook up functions that the LLM can decide to call if it thinks it can help with the task at hand. This is done by adding a `function` to the `ChatPrompt`.
 

--- a/teams.md/scripts/generate-llms-txt.js
+++ b/teams.md/scripts/generate-llms-txt.js
@@ -6,8 +6,12 @@ const { collectFiles, getHierarchicalFiles } = require('./lib/file-collector');
 const { processContent, extractSummary } = require('./lib/content-processor');
 
 const COMMON_OVERALL_SUMMARY = (langName) =>
-  `> Microsoft Teams AI Library (v2) - A comprehensive framework for building AI-powered Teams applications using ${langName}. Using this Library, you can easily build and integrate a variety of features in Microsoft Teams by building Agents or Tools. The documentation here helps by giving background information and code samples on how best to do this.
-IMPORTANT: This Library is NOT based off of BotFramework (which the _previous_ version of the Teams AI Library was based on). This Library is a completely new framework.`;
+    `> Microsoft Teams AI Library (v2) - A comprehensive framework for building AI-powered Teams applications using ${langName}. Using this Library, you can easily build and integrate a variety of features in Microsoft Teams by building Agents or Tools. The documentation here helps by giving background information and code samples on how best to do this.
+
+Things to remember:
+- IMPORTANT: This Library is NOT based off of BotFramework (which the _previous_ version of the Teams AI Library was based on). This Library is a completely new framework.
+- When scaffolding new applications, using the CLI is a lot simpler and preferred than doing it all by yourself.
+- It's a good idea to build the application and fix compile time errors to help ensure the app works as expected.`;
 
 /**
  * Reads Docusaurus config to get base URL
@@ -15,25 +19,25 @@ IMPORTANT: This Library is NOT based off of BotFramework (which the _previous_ v
  * @returns {Object} Config object with url and baseUrl
  */
 function getDocusaurusConfig(baseDir) {
-  try {
-    // Read the docusaurus.config.ts file
-    const configPath = path.join(baseDir, 'docusaurus.config.ts');
-    const configContent = fs.readFileSync(configPath, 'utf8');
+    try {
+        // Read the docusaurus.config.ts file
+        const configPath = path.join(baseDir, 'docusaurus.config.ts');
+        const configContent = fs.readFileSync(configPath, 'utf8');
 
-    // Extract URL and baseUrl using regex (simple approach)
-    const urlMatch = configContent.match(/url:\s*['"]([^'"]+)['"]/);
-    const baseUrlMatch =
-      configContent.match(/baseUrl\s*=\s*['"]([^'"]+)['"]/) ||
-      configContent.match(/baseUrl:\s*['"]([^'"]+)['"]/);
+        // Extract URL and baseUrl using regex (simple approach)
+        const urlMatch = configContent.match(/url:\s*['"]([^'"]+)['"]/);
+        const baseUrlMatch =
+            configContent.match(/baseUrl\s*=\s*['"]([^'"]+)['"]/) ||
+            configContent.match(/baseUrl:\s*['"]([^'"]+)['"]/);
 
-    const url = urlMatch ? urlMatch[1] : 'https://microsoft.github.io';
-    const baseUrl = baseUrlMatch ? baseUrlMatch[1] : '/teams-ai/';
+        const url = urlMatch ? urlMatch[1] : 'https://microsoft.github.io';
+        const baseUrl = baseUrlMatch ? baseUrlMatch[1] : '/teams-ai/';
 
-    return { url, baseUrl };
-  } catch (error) {
-    console.warn('⚠️ Could not read Docusaurus config, using defaults');
-    return { url: 'https://microsoft.github.io', baseUrl: '/teams-ai/' };
-  }
+        return { url, baseUrl };
+    } catch (error) {
+        console.warn('⚠️ Could not read Docusaurus config, using defaults');
+        return { url: 'https://microsoft.github.io', baseUrl: '/teams-ai/' };
+    }
 }
 
 /**
@@ -41,36 +45,36 @@ function getDocusaurusConfig(baseDir) {
  * Creates both small and full versions for TypeScript and C# docs
  */
 async function generateLlmsTxt() {
-  console.log('🚀 Starting llms.txt generation...');
+    console.log('🚀 Starting llms.txt generation...');
 
-  const baseDir = path.join(__dirname, '..');
-  const outputDir = path.join(baseDir, 'static', 'llms_docs');
+    const baseDir = path.join(__dirname, '..');
+    const outputDir = path.join(baseDir, 'static', 'llms_docs');
 
-  // Get Docusaurus configuration
-  const config = getDocusaurusConfig(baseDir);
-  const cleanUrl = config.url.replace(/\/$/, '');
-  const cleanBaseUrl = config.baseUrl.startsWith('/') ? config.baseUrl : '/' + config.baseUrl;
-  console.log(`📍 Using base URL: ${cleanUrl}${cleanBaseUrl}`);
+    // Get Docusaurus configuration
+    const config = getDocusaurusConfig(baseDir);
+    const cleanUrl = config.url.replace(/\/$/, '');
+    const cleanBaseUrl = config.baseUrl.startsWith('/') ? config.baseUrl : '/' + config.baseUrl;
+    console.log(`📍 Using base URL: ${cleanUrl}${cleanBaseUrl}`);
 
-  // Ensure output directory exists
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true });
-  }
+    // Ensure output directory exists
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+    }
 
-  try {
-    // Generate TypeScript version (main + typescript)
-    console.log('📝 Generating TypeScript llms.txt files...');
-    await generateLanguageFiles('typescript', baseDir, outputDir, config);
+    try {
+        // Generate TypeScript version (main + typescript)
+        console.log('📝 Generating TypeScript llms.txt files...');
+        await generateLanguageFiles('typescript', baseDir, outputDir, config);
 
-    // Generate C# version (main + csharp)
-    console.log('📝 Generating C# llms.txt files...');
-    await generateLanguageFiles('csharp', baseDir, outputDir, config);
+        // Generate C# version (main + csharp)
+        console.log('📝 Generating C# llms.txt files...');
+        await generateLanguageFiles('csharp', baseDir, outputDir, config);
 
-    console.log('✅ Successfully generated all llms.txt files!');
-  } catch (error) {
-    console.error('❌ Error generating llms.txt files:', error);
-    process.exit(1);
-  }
+        console.log('✅ Successfully generated all llms.txt files!');
+    } catch (error) {
+        console.error('❌ Error generating llms.txt files:', error);
+        process.exit(1);
+    }
 }
 
 /**
@@ -81,47 +85,48 @@ async function generateLlmsTxt() {
  * @param {Object} config - Docusaurus config object
  */
 async function generateLanguageFiles(language, baseDir, outputDir, config) {
-  // Collect all relevant files
-  const mainFiles = collectFiles(path.join(baseDir, 'docs', 'main'));
-  const langFiles = collectFiles(path.join(baseDir, 'docs', language));
+    // Collect all relevant files
+    // const mainFiles = collectFiles(path.join(baseDir, 'docs', 'main'));
+    const mainFiles = []
+    const langFiles = collectFiles(path.join(baseDir, 'docs', language));
 
-  // Process all files to get metadata and file mapping
-  const { processedFiles, fileMapping } = await processAllFiles(
-    [...mainFiles, ...langFiles],
-    baseDir
-  );
+    // Process all files to get metadata and file mapping
+    const { processedFiles, fileMapping } = await processAllFiles(
+        [...mainFiles, ...langFiles],
+        baseDir
+    );
 
-  // Generate individual TXT files for each doc
-  await generateIndividualTxtFiles(
-    processedFiles,
-    outputDir,
-    language,
-    baseDir,
-    config,
-    fileMapping
-  );
+    // Generate individual TXT files for each doc
+    await generateIndividualTxtFiles(
+        processedFiles,
+        outputDir,
+        language,
+        baseDir,
+        config,
+        fileMapping
+    );
 
-  // Process content for small version (navigation index)
-  const smallContent = await generateSmallVersionHierarchical(
-    language,
-    baseDir,
-    config,
-    fileMapping
-  );
+    // Process content for small version (navigation index)
+    const smallContent = await generateSmallVersionHierarchical(
+        language,
+        baseDir,
+        config,
+        fileMapping
+    );
 
-  // Process content for full version (all documentation)
-  const fullContent = await generateFullVersion(language, processedFiles, baseDir);
+    // Process content for full version (all documentation)
+    const fullContent = await generateFullVersion(language, processedFiles, baseDir);
 
-  // Write main llms.txt files
-  const smallPath = path.join(outputDir, `llms_${language}.txt`);
-  const fullPath = path.join(outputDir, `llms_${language}_full.txt`);
+    // Write main llms.txt files
+    const smallPath = path.join(outputDir, `llms_${language}.txt`);
+    const fullPath = path.join(outputDir, `llms_${language}_full.txt`);
 
-  fs.writeFileSync(smallPath, smallContent, 'utf8');
-  fs.writeFileSync(fullPath, fullContent, 'utf8');
+    fs.writeFileSync(smallPath, smallContent, 'utf8');
+    fs.writeFileSync(fullPath, fullContent, 'utf8');
 
-  console.log(`  ✓ Generated ${path.basename(smallPath)} (${formatBytes(smallContent.length)})`);
-  console.log(`  ✓ Generated ${path.basename(fullPath)} (${formatBytes(fullContent.length)})`);
-  console.log(`  ✓ Generated ${processedFiles.length} individual .txt files`);
+    console.log(`  ✓ Generated ${path.basename(smallPath)} (${formatBytes(smallContent.length)})`);
+    console.log(`  ✓ Generated ${path.basename(fullPath)} (${formatBytes(fullContent.length)})`);
+    console.log(`  ✓ Generated ${processedFiles.length} individual .txt files`);
 }
 
 /**
@@ -131,47 +136,47 @@ async function generateLanguageFiles(language, baseDir, outputDir, config) {
  * @returns {Promise<Object>} Object with processedFiles array and fileMapping Map
  */
 async function processAllFiles(allFiles, baseDir) {
-  const processedFiles = [];
+    const processedFiles = [];
 
-  // First pass: build file mapping
-  const fileMapping = new Map();
-  for (const file of allFiles) {
-    // Generate the same filename logic as used in generateIndividualTxtFiles
-    const tempProcessed = await processContent(file, baseDir, false); // Quick pass for title
-    if (tempProcessed) {
-      // Only process files that aren't marked to ignore
-      let fileName;
-      if (path.basename(file) === 'README.md') {
-        const parentDir = path.basename(path.dirname(file));
-        fileName = generateSafeFileName(parentDir);
-      } else {
-        fileName = generateSafeFileName(tempProcessed.title || file);
-      }
-      fileMapping.set(file, fileName);
-    }
-  }
-
-  // Second pass: process files with mapping for link resolution
-  for (const file of allFiles) {
-    const processed = await processContent(file, baseDir, true, fileMapping);
-    if (processed && (processed.title || processed.content)) {
-      processedFiles.push(processed);
-    }
-  }
-
-  // Sort by sidebar position, then by title
-  const sortedFiles = processedFiles.sort((a, b) => {
-    const posA = a.sidebarPosition || 999;
-    const posB = b.sidebarPosition || 999;
-
-    if (posA !== posB) {
-      return posA - posB;
+    // First pass: build file mapping
+    const fileMapping = new Map();
+    for (const file of allFiles) {
+        // Generate the same filename logic as used in generateIndividualTxtFiles
+        const tempProcessed = await processContent(file, baseDir, false); // Quick pass for title
+        if (tempProcessed) {
+            // Only process files that aren't marked to ignore
+            let fileName;
+            if (path.basename(file) === 'README.md') {
+                const parentDir = path.basename(path.dirname(file));
+                fileName = generateSafeFileName(parentDir);
+            } else {
+                fileName = generateSafeFileName(tempProcessed.title || file);
+            }
+            fileMapping.set(file, fileName);
+        }
     }
 
-    return (a.title || '').localeCompare(b.title || '');
-  });
+    // Second pass: process files with mapping for link resolution
+    for (const file of allFiles) {
+        const processed = await processContent(file, baseDir, true, fileMapping);
+        if (processed && (processed.title || processed.content)) {
+            processedFiles.push(processed);
+        }
+    }
 
-  return { processedFiles: sortedFiles, fileMapping };
+    // Sort by sidebar position, then by title
+    const sortedFiles = processedFiles.sort((a, b) => {
+        const posA = a.sidebarPosition || 999;
+        const posB = b.sidebarPosition || 999;
+
+        if (posA !== posB) {
+            return posA - posB;
+        }
+
+        return (a.title || '').localeCompare(b.title || '');
+    });
+
+    return { processedFiles: sortedFiles, fileMapping };
 }
 
 /**
@@ -184,50 +189,50 @@ async function processAllFiles(allFiles, baseDir) {
  * @param {Map} fileMapping - File mapping for link resolution
  */
 async function generateIndividualTxtFiles(
-  processedFiles,
-  outputDir,
-  language,
-  baseDir,
-  config,
-  fileMapping
+    processedFiles,
+    outputDir,
+    language,
+    baseDir,
+    config,
+    fileMapping
 ) {
-  const docsDir = path.join(outputDir, `docs_${language}`);
+    const docsDir = path.join(outputDir, `docs_${language}`);
 
-  // Create docs directory
-  if (!fs.existsSync(docsDir)) {
-    fs.mkdirSync(docsDir, { recursive: true });
-  }
-
-  for (const file of processedFiles) {
-    if (!file.content) continue;
-
-    // Re-process the file with full URL generation for individual files
-    const reprocessed = await processContent(
-      file.filePath,
-      baseDir,
-      true,
-      fileMapping,
-      config,
-      language
-    );
-
-    // Generate safe filename - use folder name for README.md files
-    let fileName;
-    if (path.basename(file.filePath) === 'README.md') {
-      // Use parent folder name for README files
-      const parentDir = path.basename(path.dirname(file.filePath));
-      fileName = generateSafeFileName(parentDir);
-    } else {
-      fileName = generateSafeFileName(file.title || file.filePath);
+    // Create docs directory
+    if (!fs.existsSync(docsDir)) {
+        fs.mkdirSync(docsDir, { recursive: true });
     }
 
-    const outputPath = path.join(docsDir, `${fileName}.txt`);
+    for (const file of processedFiles) {
+        if (!file.content) continue;
 
-    // Use the reprocessed content directly without adding metadata header
-    let txtContent = reprocessed.content || file.content; // Use reprocessed content with full URLs
+        // Re-process the file with full URL generation for individual files
+        const reprocessed = await processContent(
+            file.filePath,
+            baseDir,
+            true,
+            fileMapping,
+            config,
+            language
+        );
 
-    fs.writeFileSync(outputPath, txtContent, 'utf8');
-  }
+        // Generate safe filename - use folder name for README.md files
+        let fileName;
+        if (path.basename(file.filePath) === 'README.md') {
+            // Use parent folder name for README files
+            const parentDir = path.basename(path.dirname(file.filePath));
+            fileName = generateSafeFileName(parentDir);
+        } else {
+            fileName = generateSafeFileName(file.title || file.filePath);
+        }
+
+        const outputPath = path.join(docsDir, `${fileName}.txt`);
+
+        // Use the reprocessed content directly without adding metadata header
+        let txtContent = reprocessed.content || file.content; // Use reprocessed content with full URLs
+
+        fs.writeFileSync(outputPath, txtContent, 'utf8');
+    }
 }
 
 /**
@@ -239,27 +244,27 @@ async function generateIndividualTxtFiles(
  * @returns {string} Generated navigation content
  */
 async function generateSmallVersionHierarchical(language, baseDir, config, fileMapping) {
-  const langName = language === 'typescript' ? 'TypeScript' : 'C#';
-  // Remove trailing slash from URL and ensure baseUrl starts with slash
-  const cleanUrl = config.url.replace(/\/$/, '');
-  const cleanBaseUrl = config.baseUrl.startsWith('/') ? config.baseUrl : '/' + config.baseUrl;
-  const fullBaseUrl = `${cleanUrl}${cleanBaseUrl}`;
+    const langName = language === 'typescript' ? 'TypeScript' : 'C#';
+    // Remove trailing slash from URL and ensure baseUrl starts with slash
+    const cleanUrl = config.url.replace(/\/$/, '');
+    const cleanBaseUrl = config.baseUrl.startsWith('/') ? config.baseUrl : '/' + config.baseUrl;
+    const fullBaseUrl = `${cleanUrl}${cleanBaseUrl}`;
 
-  let content = `# Teams AI Library - ${langName} Documentation\n\n`;
-  content += COMMON_OVERALL_SUMMARY(langName) + '\n\n';
+    let content = `# Teams AI Library - ${langName} Documentation\n\n`;
+    content += COMMON_OVERALL_SUMMARY(langName) + '\n\n';
 
-  // Get hierarchical structure
-  const hierarchical = getHierarchicalFiles(baseDir, language);
+    // Get hierarchical structure
+    const hierarchical = getHierarchicalFiles(baseDir, language);
 
-  // Add Main Documentation
-  content += `## Main Documentation\n\n`;
-  content += renderHierarchicalStructure(hierarchical.main, fullBaseUrl, language, fileMapping);
+    // Add Main Documentation
+    // content += `## Main Documentation\n\n`;
+    // content += renderHierarchicalStructure(hierarchical.main, fullBaseUrl, language, fileMapping, 3);
 
-  // Add Language-specific Documentation
-  content += `## ${langName} Specific Documentation\n\n`;
-  content += renderHierarchicalStructure(hierarchical.language, fullBaseUrl, language, fileMapping);
+    // Add Language-specific Documentation
+    // content += `## ${langName} Specific Documentation\n\n`;
+    content += renderHierarchicalStructure(hierarchical.language, fullBaseUrl, language, fileMapping, 0);
 
-  return content;
+    return content;
 }
 
 /**
@@ -268,27 +273,27 @@ async function generateSmallVersionHierarchical(language, baseDir, config, fileM
  * @returns {Object} Parsed frontmatter
  */
 function parseFrontmatterSimple(frontmatterText) {
-  const frontmatter = {};
-  const lines = frontmatterText.split('\n');
+    const frontmatter = {};
+    const lines = frontmatterText.split('\n');
 
-  for (const line of lines) {
-    const match = line.match(/^(\w+):\s*(.+)$/);
-    if (match) {
-      let value = match[2].trim();
+    for (const line of lines) {
+        const match = line.match(/^(\w+):\s*(.+)$/);
+        if (match) {
+            let value = match[2].trim();
 
-      // Remove quotes
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
-        value = value.slice(1, -1);
-      }
+            // Remove quotes
+            if (
+                (value.startsWith('"') && value.endsWith('"')) ||
+                (value.startsWith("'") && value.endsWith("'"))
+            ) {
+                value = value.slice(1, -1);
+            }
 
-      frontmatter[match[1]] = value;
+            frontmatter[match[1]] = value;
+        }
     }
-  }
 
-  return frontmatter;
+    return frontmatter;
 }
 
 /**
@@ -297,113 +302,135 @@ function parseFrontmatterSimple(frontmatterText) {
  * @param {string} baseUrl - Base URL for links
  * @param {string} language - Language identifier
  * @param {Map} fileMapping - Mapping of source files to generated filenames
+ * @param {number} indentLevel - Current indentation level (0 = section headers, 1+ = bullet points)
  * @returns {string} Rendered content with proper hierarchy
  */
-function renderHierarchicalStructure(structure, baseUrl, language, fileMapping) {
-  let content = '';
+function renderHierarchicalStructure(structure, baseUrl, language, fileMapping, indentLevel = 0) {
+    let content = '';
 
-  // Convert structure to sorted array
-  const folders = Object.entries(structure)
-    .map(([key, value]) => ({ key, ...value }))
-    .sort((a, b) => {
-      const orderA = a.order || 999;
-      const orderB = b.order || 999;
-      if (orderA !== orderB) return orderA - orderB;
-      return a.key.localeCompare(b.key);
-    });
-
-  for (const folder of folders) {
-    // Check if this folder has any content (files or children)
-    const hasFiles = folder.files && folder.files.length > 0;
-    const hasChildren = folder.children && Object.keys(folder.children).length > 0;
-    const hasContent = hasFiles || hasChildren;
-
-    if (hasContent) {
-      // Check if this folder has a README file to make the header clickable
-      const readmeFile = hasFiles
-        ? folder.files.find((f) => path.basename(f.path) === 'README.md')
-        : null;
-      const displayTitle =
-        folder.title && folder.title !== folder.key ? folder.title : formatFolderName(folder.key);
-
-      if (readmeFile) {
-        // Make folder header clickable by linking to the README
-        let folderFileName;
-        if (fileMapping && fileMapping.has(readmeFile.path)) {
-          folderFileName = fileMapping.get(readmeFile.path);
-        } else {
-          folderFileName = generateSafeFileName(folder.key);
-        }
-        content += `### [${displayTitle}](${baseUrl}llms_docs/docs_${language}/${folderFileName}.txt)\n\n`;
-
-        // Add summary from README if available
-        try {
-          const readmeContent = fs.readFileSync(readmeFile.path, 'utf8');
-          const frontmatterMatch = readmeContent.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
-          if (frontmatterMatch) {
-            const frontmatter = parseFrontmatterSimple(frontmatterMatch[1]);
-            if (frontmatter.summary) {
-              content += `${frontmatter.summary}\n\n`;
-            }
-          }
-        } catch (error) {
-          // Ignore errors reading README summary
-        }
-      } else {
-        // No README, just show header
-        content += `### ${displayTitle}\n\n`;
-      }
-
-      // Add files in this folder (sorted by order), excluding README
-      if (hasFiles) {
-        const sortedFiles = [...folder.files]
-          .filter((f) => path.basename(f.path) !== 'README.md') // Exclude README since it's now the header link
-          .sort((a, b) => {
+    // Convert structure to sorted array
+    const folders = Object.entries(structure)
+        .map(([key, value]) => ({ key, ...value }))
+        .sort((a, b) => {
             const orderA = a.order || 999;
             const orderB = b.order || 999;
             if (orderA !== orderB) return orderA - orderB;
-            return a.name.localeCompare(b.name);
-          });
+            return a.key.localeCompare(b.key);
+        });
 
-        for (const file of sortedFiles) {
-          // Use file mapping to get the correct generated filename
-          let fileName;
-          if (fileMapping && fileMapping.has(file.path)) {
-            fileName = fileMapping.get(file.path);
-          } else {
-            fileName = generateSafeFileName(file.title || file.name);
-          }
+    for (const folder of folders) {
+        // Check if this folder has any content (files or children)
+        const hasFiles = folder.files && folder.files.length > 0;
+        const hasChildren = folder.children && Object.keys(folder.children).length > 0;
+        const hasContent = hasFiles || hasChildren;
 
-          const summary = extractSummaryFromFile(file.path);
+        if (hasContent) {
+            // Check if this folder has a README file to make the header clickable
+            const readmeFile = hasFiles
+                ? folder.files.find((f) => path.basename(f.path) === 'README.md')
+                : null;
+            const displayTitle =
+                folder.title && folder.title !== folder.key ? folder.title : formatFolderName(folder.key);
 
-          content += `- [${file.title}](${baseUrl}llms_docs/docs_${language}/${fileName}.txt)`;
-          if (summary) {
-            content += `: ${summary}`;
-          }
-          content += '\n';
+            // Generate indent for nested folders (use spaces, 2 per level)
+            const indent = '  '.repeat(indentLevel);
+
+            if (readmeFile) {
+                // Make folder header clickable by linking to the README
+                let folderFileName;
+                if (fileMapping && fileMapping.has(readmeFile.path)) {
+                    folderFileName = fileMapping.get(readmeFile.path);
+                } else {
+                    folderFileName = generateSafeFileName(folder.key);
+                }
+
+                // Use ### header for top-level sections (indentLevel 0), bullet points for nested
+                if (indentLevel === 0) {
+                    content += `### [${displayTitle}](${baseUrl}llms_docs/docs_${language}/${folderFileName}.txt)\n\n`;
+                } else {
+                    content += `${indent}- [${displayTitle}](${baseUrl}llms_docs/docs_${language}/${folderFileName}.txt)`;
+                }
+
+                // Add summary from README if available
+                try {
+                    const readmeContent = fs.readFileSync(readmeFile.path, 'utf8');
+                    const frontmatterMatch = readmeContent.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
+                    if (frontmatterMatch) {
+                        const frontmatter = parseFrontmatterSimple(frontmatterMatch[1]);
+                        if (frontmatter.summary) {
+                            if (indentLevel === 0) {
+                                content += `${frontmatter.summary}\n\n`;
+                            } else {
+                                content += `: ${frontmatter.summary}`;
+                            }
+                        }
+                    }
+                } catch (error) {
+                    // Ignore errors reading README summary
+                }
+
+                if (indentLevel > 0) {
+                    content += '\n';
+                }
+            } else {
+                // No README
+                if (indentLevel === 0) {
+                    content += `### ${displayTitle}\n\n`;
+                } else {
+                    content += `${indent}- ${displayTitle}\n`;
+                }
+            }
+
+            // Add files in this folder (sorted by order), excluding README
+            if (hasFiles) {
+                const sortedFiles = [...folder.files]
+                    .filter((f) => path.basename(f.path) !== 'README.md') // Exclude README since it's now the header link
+                    .sort((a, b) => {
+                        const orderA = a.order || 999;
+                        const orderB = b.order || 999;
+                        if (orderA !== orderB) return orderA - orderB;
+                        return a.name.localeCompare(b.name);
+                    });
+
+                for (const file of sortedFiles) {
+                    // Use file mapping to get the correct generated filename
+                    let fileName;
+                    if (fileMapping && fileMapping.has(file.path)) {
+                        fileName = fileMapping.get(file.path);
+                    } else {
+                        fileName = generateSafeFileName(file.title || file.name);
+                    }
+
+                    const summary = extractSummaryFromFile(file.path);
+
+                    // Files are always indented one level deeper than their parent folder
+                    const fileIndent = '  '.repeat(indentLevel + 1);
+                    content += `${fileIndent}- [${file.title}](${baseUrl}llms_docs/docs_${language}/${fileName}.txt)`;
+                    if (summary) {
+                        content += `: ${summary}`;
+                    }
+                    content += '\n';
+                }
+            }
+
+            // Recursively render children with increased indent
+            if (hasChildren) {
+                content += renderHierarchicalStructure(folder.children, baseUrl, language, fileMapping, indentLevel + 1);
+            }
+
+            // Add spacing after top-level sections
+            if (indentLevel === 0) {
+                content += '\n';
+            }
         }
-
-        // Add extra spacing after files if there are children
-        if (hasChildren) {
-          content += '\n';
-        }
-      }
-
-      // Recursively render children
-      if (hasChildren) {
-        content += renderHierarchicalStructure(folder.children, baseUrl, language, fileMapping);
-      }
-
-      content += '\n';
     }
-  }
 
-  // Helper function for folder name formatting
-  function formatFolderName(name) {
-    return name.replace(/[-_]/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
-  }
+    // Helper function for folder name formatting
+    function formatFolderName(name) {
+        return name.replace(/[-_]/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
+    }
 
-  return content;
+    return content;
 }
 
 /**
@@ -412,50 +439,50 @@ function renderHierarchicalStructure(structure, baseUrl, language, fileMapping) 
  * @returns {string} File summary or empty string
  */
 function extractSummaryFromFile(filePath) {
-  try {
-    const content = fs.readFileSync(filePath, 'utf8');
+    try {
+        const content = fs.readFileSync(filePath, 'utf8');
 
-    // First check for summary in frontmatter
-    const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
-    if (frontmatterMatch) {
-      const frontmatterText = frontmatterMatch[1];
-      const summaryMatch = frontmatterText.match(/^summary:\s*(.+)$/m);
-      if (summaryMatch) {
-        let summary = summaryMatch[1].trim();
-        // Remove quotes if present
-        if (
-          (summary.startsWith('"') && summary.endsWith('"')) ||
-          (summary.startsWith("'") && summary.endsWith("'"))
-        ) {
-          summary = summary.slice(1, -1);
+        // First check for summary in frontmatter
+        const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n/);
+        if (frontmatterMatch) {
+            const frontmatterText = frontmatterMatch[1];
+            const summaryMatch = frontmatterText.match(/^summary:\s*(.+)$/m);
+            if (summaryMatch) {
+                let summary = summaryMatch[1].trim();
+                // Remove quotes if present
+                if (
+                    (summary.startsWith('"') && summary.endsWith('"')) ||
+                    (summary.startsWith("'") && summary.endsWith("'"))
+                ) {
+                    summary = summary.slice(1, -1);
+                }
+                return summary;
+            }
         }
-        return summary;
-      }
+
+        // Fallback to extracting first meaningful paragraph if no summary in frontmatter
+        const withoutFrontmatter = content.replace(/^---\s*\n[\s\S]*?\n---\s*\n/, '');
+
+        // Extract first meaningful paragraph
+        const paragraphs = withoutFrontmatter.split('\n\n');
+        for (const paragraph of paragraphs) {
+            const clean = paragraph
+                .replace(/#+\s*/g, '') // Remove headers
+                .replace(/\*\*(.+?)\*\*/g, '$1') // Remove bold
+                .replace(/\*(.+?)\*/g, '$1') // Remove italic
+                .replace(/`(.+?)`/g, '$1') // Remove inline code
+                .replace(/\[(.+?)\]\(.+?\)/g, '$1') // Remove links, keep text
+                .trim();
+
+            if (clean.length > 20 && !clean.startsWith('```') && !clean.startsWith('import')) {
+                return clean.length > 100 ? clean.substring(0, 100) + '...' : clean;
+            }
+        }
+    } catch (error) {
+        // Ignore file read errors
     }
 
-    // Fallback to extracting first meaningful paragraph if no summary in frontmatter
-    const withoutFrontmatter = content.replace(/^---\s*\n[\s\S]*?\n---\s*\n/, '');
-
-    // Extract first meaningful paragraph
-    const paragraphs = withoutFrontmatter.split('\n\n');
-    for (const paragraph of paragraphs) {
-      const clean = paragraph
-        .replace(/#+\s*/g, '') // Remove headers
-        .replace(/\*\*(.+?)\*\*/g, '$1') // Remove bold
-        .replace(/\*(.+?)\*/g, '$1') // Remove italic
-        .replace(/`(.+?)`/g, '$1') // Remove inline code
-        .replace(/\[(.+?)\]\(.+?\)/g, '$1') // Remove links, keep text
-        .trim();
-
-      if (clean.length > 20 && !clean.startsWith('```') && !clean.startsWith('import')) {
-        return clean.length > 100 ? clean.substring(0, 100) + '...' : clean;
-      }
-    }
-  } catch (error) {
-    // Ignore file read errors
-  }
-
-  return '';
+    return '';
 }
 
 /**
@@ -466,28 +493,28 @@ function extractSummaryFromFile(filePath) {
  * @returns {string} Generated content
  */
 async function generateFullVersion(language, processedFiles, baseDir) {
-  const langName = language === 'typescript' ? 'TypeScript' : 'C#';
+    const langName = language === 'typescript' ? 'TypeScript' : 'C#';
 
-  let content = `# Teams AI Library - ${langName} Documentation (Complete)\n\n`;
-  content += COMMON_OVERALL_SUMMARY(langName) + '\n\n';
+    let content = `# Teams AI Library - ${langName} Documentation (Complete)\n\n`;
+    content += COMMON_OVERALL_SUMMARY(langName) + '\n\n';
 
-  // Group files by section
-  const sections = groupFilesBySection(processedFiles, baseDir);
+    // Group files by section
+    const sections = groupFilesBySection(processedFiles, baseDir);
 
-  // Process all sections
-  for (const [sectionName, files] of Object.entries(sections)) {
-    if (!files || files.length === 0) continue;
+    // Process all sections
+    for (const [sectionName, files] of Object.entries(sections)) {
+        if (!files || files.length === 0) continue;
 
-    content += `## ${formatSectionName(sectionName)}\n\n`;
+        content += `## ${formatSectionName(sectionName)}\n\n`;
 
-    for (const file of files) {
-      if (file.content) {
-        content += `### ${file.title}\n\n${file.content}\n\n---\n\n`;
-      }
+        for (const file of files) {
+            if (file.content) {
+                content += `### ${file.title}\n\n${file.content}\n\n---\n\n`;
+            }
+        }
     }
-  }
 
-  return content;
+    return content;
 }
 
 /**
@@ -497,55 +524,55 @@ async function generateFullVersion(language, processedFiles, baseDir) {
  * @returns {Object} Grouped files by section
  */
 function groupFilesBySection(processedFiles, baseDir) {
-  const sections = {
-    main: [],
-    gettingStarted: [],
-    essentials: [],
-    inDepthGuides: [],
-    migrations: [],
-  };
+    const sections = {
+        main: [],
+        gettingStarted: [],
+        essentials: [],
+        inDepthGuides: [],
+        migrations: [],
+    };
 
-  for (const file of processedFiles) {
-    const relativePath = path.relative(path.join(baseDir, 'docs'), file.filePath);
+    for (const file of processedFiles) {
+        const relativePath = path.relative(path.join(baseDir, 'docs'), file.filePath);
 
-    if (relativePath.startsWith('main/')) {
-      sections.main.push(file);
-    } else if (relativePath.includes('getting-started/')) {
-      sections.gettingStarted.push(file);
-    } else if (relativePath.includes('essentials/')) {
-      sections.essentials.push(file);
-    } else if (relativePath.includes('in-depth-guides/')) {
-      sections.inDepthGuides.push(file);
-    } else if (relativePath.includes('migrations/')) {
-      sections.migrations.push(file);
-    } else {
-      // Create dynamic section based on directory
-      const parts = relativePath.split('/');
-      if (parts.length > 1) {
-        const sectionKey = parts[1].replace(/[^a-zA-Z0-9]/g, '');
-        if (!sections[sectionKey]) {
-          sections[sectionKey] = [];
+        if (relativePath.startsWith('main/')) {
+            sections.main.push(file);
+        } else if (relativePath.includes('getting-started/')) {
+            sections.gettingStarted.push(file);
+        } else if (relativePath.includes('essentials/')) {
+            sections.essentials.push(file);
+        } else if (relativePath.includes('in-depth-guides/')) {
+            sections.inDepthGuides.push(file);
+        } else if (relativePath.includes('migrations/')) {
+            sections.migrations.push(file);
+        } else {
+            // Create dynamic section based on directory
+            const parts = relativePath.split('/');
+            if (parts.length > 1) {
+                const sectionKey = parts[1].replace(/[^a-zA-Z0-9]/g, '');
+                if (!sections[sectionKey]) {
+                    sections[sectionKey] = [];
+                }
+                sections[sectionKey].push(file);
+            }
         }
-        sections[sectionKey].push(file);
-      }
     }
-  }
 
-  // Sort files within each section by sidebar position
-  for (const sectionFiles of Object.values(sections)) {
-    sectionFiles.sort((a, b) => {
-      const posA = a.sidebarPosition || 999;
-      const posB = b.sidebarPosition || 999;
+    // Sort files within each section by sidebar position
+    for (const sectionFiles of Object.values(sections)) {
+        sectionFiles.sort((a, b) => {
+            const posA = a.sidebarPosition || 999;
+            const posB = b.sidebarPosition || 999;
 
-      if (posA !== posB) {
-        return posA - posB;
-      }
+            if (posA !== posB) {
+                return posA - posB;
+            }
 
-      return (a.title || '').localeCompare(b.title || '');
-    });
-  }
+            return (a.title || '').localeCompare(b.title || '');
+        });
+    }
 
-  return sections;
+    return sections;
 }
 
 /**
@@ -554,16 +581,16 @@ function groupFilesBySection(processedFiles, baseDir) {
  * @returns {string} Safe filename
  */
 function generateSafeFileName(title) {
-  return (
-    title
-      .toLowerCase()
-      .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
-      .replace(/\s+/g, '-') // Replace spaces with hyphens
-      .replace(/-+/g, '-') // Replace multiple hyphens with single
-      .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
-      .substring(0, 50) || // Limit length
-    'untitled'
-  );
+    return (
+        title
+            .toLowerCase()
+            .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
+            .replace(/\s+/g, '-') // Replace spaces with hyphens
+            .replace(/-+/g, '-') // Replace multiple hyphens with single
+            .replace(/^-|-$/g, '') // Remove leading/trailing hyphens
+            .substring(0, 50) || // Limit length
+        'untitled'
+    );
 }
 
 /**
@@ -572,21 +599,21 @@ function generateSafeFileName(title) {
  * @returns {string} Formatted section name
  */
 function formatSectionName(sectionName) {
-  const nameMap = {
-    main: 'Main Documentation',
-    gettingStarted: 'Getting Started',
-    essentials: 'Essentials',
-    inDepthGuides: 'In-Depth Guides',
-    migrations: 'Migrations',
-  };
+    const nameMap = {
+        main: 'Main Documentation',
+        gettingStarted: 'Getting Started',
+        essentials: 'Essentials',
+        inDepthGuides: 'In-Depth Guides',
+        migrations: 'Migrations',
+    };
 
-  return (
-    nameMap[sectionName] ||
-    sectionName
-      .replace(/([A-Z])/g, ' $1') // Add spaces before capitals
-      .replace(/^./, (str) => str.toUpperCase()) // Capitalize first letter
-      .trim()
-  );
+    return (
+        nameMap[sectionName] ||
+        sectionName
+            .replace(/([A-Z])/g, ' $1') // Add spaces before capitals
+            .replace(/^./, (str) => str.toUpperCase()) // Capitalize first letter
+            .trim()
+    );
 }
 
 /**
@@ -595,16 +622,16 @@ function formatSectionName(sectionName) {
  * @returns {string} Formatted string
  */
 function formatBytes(bytes) {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const sizes = ['B', 'KB', 'MB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
 
 // Run the generator if this file is executed directly
 if (require.main === module) {
-  generateLlmsTxt();
+    generateLlmsTxt();
 }
 
 module.exports = { generateLlmsTxt };


### PR DESCRIPTION
1. Add some more context for llmstxt in some docs (mainly tested for typescript right now)
2. Switch to using npx instead of installing teams cli globally (easier for agents to run, and ppl too)
3. Updated llmstxt generation script to skip "main" section since it's not super helpful for agents. Then added some code to detect duplicate names (they were clobbering each other before)