### PR TITLE
Rename Teams AI SDK/Library to Teams SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Welcome to the Teams AI Library v2 ([Docs](https://microsoft.github.io/teams-ai/))
+# Welcome to the Microsoft Teams SDK ([Docs](https://microsoft.github.io/teams-ai/))
 
-Teams AI Library v2 represents a fundamental reimagining of how Teams apps and AI agents are built, while maintaining compatibility with existing botframework-based agents. This new version focuses on developer experience, simplified architecture, and enhanced AI capabilities.
+Teams SDK represents a fundamental reimagining of how Teams apps and AI agents are built, while maintaining compatibility with existing botframework-based agents. This new version focuses on developer experience, simplified architecture, and enhanced AI capabilities.
 
 For a detailed explanation of the motivations and architectural decisions behind v2, please see our [WHY.md](https://microsoft.github.io/teams-ai/why) document.
 
@@ -30,7 +30,7 @@ For more information, follow our quickstart guide: [C#](http://microsoft.github.
 
 ### SDK
 
-Microsoft Teams has a robust developer ecosystem with a broad suite of capabilities, now unified via Teams AI v2. Whether you are building AI-powered agents ([TS](https://microsoft.github.io/teams-ai/typescript/in-depth-guides/ai/), [C#](https://microsoft.github.io/teams-ai/csharp/in-depth-guides/ai/), [Python](https://microsoft.github.io/teams-ai/python/in-depth-guides/ai/)), Message Extensions ([TS](https://microsoft.github.io/teams-ai/typescript/in-depth-guides/message-extensions/), [C#](https://microsoft.github.io/teams-ai/csharp/in-depth-guides/message-extensions/), [Python](https://microsoft.github.io/teams-ai/python/in-depth-guides/message-extensions/)), embedded web applications, or Graph, Teams AI v2 has you covered.
+Microsoft Teams has a robust developer ecosystem with a broad suite of capabilities, now unified via Teams SDK. Whether you are building AI-powered agents ([TS](https://microsoft.github.io/teams-ai/typescript/in-depth-guides/ai/), [C#](https://microsoft.github.io/teams-ai/csharp/in-depth-guides/ai/), [Python](https://microsoft.github.io/teams-ai/python/in-depth-guides/ai/)), Message Extensions ([TS](https://microsoft.github.io/teams-ai/typescript/in-depth-guides/message-extensions/), [C#](https://microsoft.github.io/teams-ai/csharp/in-depth-guides/message-extensions/), [Python](https://microsoft.github.io/teams-ai/python/in-depth-guides/message-extensions/)), embedded web applications, or Graph, Teams SDK has you covered.
 
 Here is a simple example, which responds to incoming messages with information retrieved from Graph.
 

--- a/teams.md/docs/csharp/essentials/README.md
+++ b/teams.md/docs/csharp/essentials/README.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 2
-summary: Introduction to core concepts and paradigms for building C# Teams AI applications that handle events and activities.
+summary: Introduction to core concepts and paradigms for building C# Teams SDK applications that handle events and activities.
 ---
 
 # Essentials
 
 At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a dialog, or clicks a button — your app is there to interpret the event and act on it.
 
-With Teams AI Library v2, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
+With Teams SDK, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
 
 Before diving in, let’s define a few key terms:
 • Event: Anything interesting that happens on Teams — or within your application as a result of handling an earlier event.

--- a/teams.md/docs/csharp/essentials/on-event.md
+++ b/teams.md/docs/csharp/essentials/on-event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Guide to handling and responding to events in C# Teams AI applications, including user and server-originated events.
+summary: Guide to handling and responding to events in C# Teams SDK applications, including user and server-originated events.
 ---
 
 # Listening To Events
@@ -24,7 +24,7 @@ flowchart LR
     classDef interesting fill:#b1650f,stroke:#333,stroke-width:4px;
 ```
 
-The Teams AI Library v2 makes it easy to subscribe to these events and respond appropriately. You can register event handlers to take custom actions when specific events occur — such as logging errors, triggering workflows, or sending follow-up messages.
+The Teams SDK makes it easy to subscribe to these events and respond appropriately. You can register event handlers to take custom actions when specific events occur — such as logging errors, triggering workflows, or sending follow-up messages.
 
 Here are the events that you can start building handlers for:
 

--- a/teams.md/docs/csharp/getting-started/README.md
+++ b/teams.md/docs/csharp/getting-started/README.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 1
-summary: Getting started guide for C# Teams AI Library covering application setup, structure, and local development.
+summary: Getting started guide for C# Teams SDK covering application setup, structure, and local development.
 llms: ignore-file
 ---
 
 # 🚀 Getting Started
 
-This guide will help you set up your first Teams AI Library application. You'll learn the basics of creating an application, understanding its structure, and running it locally. By the end of this guide, you'll have a solid foundation to build upon as you explore more advanced features and capabilities of the SDK.
+This guide will help you set up your first Teams SDK application. You'll learn the basics of creating an application, understanding its structure, and running it locally. By the end of this guide, you'll have a solid foundation to build upon as you explore more advanced features and capabilities of the SDK.

--- a/teams.md/docs/csharp/getting-started/code-basics.mdx
+++ b/teams.md/docs/csharp/getting-started/code-basics.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Understanding the structure and key components of a C# Teams AI application including the Application class, dependency injection, and project organization.
+summary: Understanding the structure and key components of a C# Teams SDK application including the Application class, dependency injection, and project organization.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/teams.md/docs/csharp/getting-started/quickstart.md
+++ b/teams.md/docs/csharp/getting-started/quickstart.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
-summary: Quick start guide for C# Teams AI Library v2 using the Teams CLI to create and run your first .NET agent.
+summary: Quick start guide for C# Teams SDK using the Teams CLI to create and run your first .NET agent.
 ---
 
 # Quickstart
 
-Get started with Teams AI Library (v2) quickly using the Teams CLI.
+Get started with Teams SDK quickly using the Teams CLI.
 
 ## Set up a new project
 

--- a/teams.md/docs/csharp/getting-started/running-in-teams/running-in-teams.md
+++ b/teams.md/docs/csharp/getting-started/running-in-teams/running-in-teams.md
@@ -103,7 +103,7 @@ If you want to monitor the activities and events in your app, you can still use 
 
 For deployment and resource management we recommend the Microsoft 365 Agents Toolkit. Refer to our [Deployment guide](./deployment-guide.md) for common scenarios and potential issues. 
 
-If you prefer to set everything up by hand, follow the standard [Teams app documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview). The Teams AI library itself doesn't handle deployment or Azure resources, so you'll need to rely on the general [Microsoft Teams deployment documentation](https://learn.microsoft.com/en-us/microsoftteams/deploy-overview) for in-depth help.
+If you prefer to set everything up by hand, follow the standard [Teams app documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview). The Teams SDK itself doesn't handle deployment or Azure resources, so you'll need to rely on the general [Microsoft Teams deployment documentation](https://learn.microsoft.com/en-us/microsoftteams/deploy-overview) for in-depth help.
 
 ## Next steps
 

--- a/teams.md/docs/csharp/in-depth-guides/README.md
+++ b/teams.md/docs/csharp/in-depth-guides/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-summary: Detailed technical guides covering advanced features and capabilities of Teams AI Library in C#, including AI integration, adaptive cards, dialogs, authentication, and message extensions.
+summary: Detailed technical guides covering advanced features and capabilities of Teams SDK in C#, including AI integration, adaptive cards, dialogs, authentication, and message extensions.
 ---
 
 # In-Depth Guides

--- a/teams.md/docs/csharp/in-depth-guides/adaptive-cards/executing-actions.mdx
+++ b/teams.md/docs/csharp/in-depth-guides/adaptive-cards/executing-actions.mdx
@@ -12,7 +12,7 @@ You can use these to collect form input, trigger workflows, show task modules, o
 
 ## Action Types
 
-The Teams AI Library supports several action types for different interaction patterns:
+The Teams SDK supports several action types for different interaction patterns:
 
 | Action Type               | Purpose                | Description                                                                  |
 | ------------------------- | ---------------------- | ---------------------------------------------------------------------------- |

--- a/teams.md/docs/csharp/in-depth-guides/ai/mcp/README.md
+++ b/teams.md/docs/csharp/in-depth-guides/ai/mcp/README.md
@@ -5,7 +5,7 @@ summary: Overview of Model Context Protocol (MCP) integration in C# Teams AI for
 
 # MCP
 
-Teams AI Library has optional packages which support the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as a service or client. This allows you to use MCP to call functions and tools in your application. 
+Teams SDK has optional packages which support the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as a service or client. This allows you to use MCP to call functions and tools in your application. 
 
 MCP servers and MCP clients dynamically load function definitions and tools.
 

--- a/teams.md/docs/csharp/in-depth-guides/ai/setup-and-prereqs.md
+++ b/teams.md/docs/csharp/in-depth-guides/ai/setup-and-prereqs.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Prerequisites and setup guide for integrating LLMs into C# Teams AI applications, including API keys and configuration.
+summary: Prerequisites and setup guide for integrating LLMs into C# Teams SDK applications, including API keys and configuration.
 ---
 
 # Setup & Prerequisites
@@ -10,7 +10,7 @@ There are a few prerequisites to getting started with integrating LLMs into your
 - LLM API Key - To generate messages using an LLM, you will need to have an API Key for the LLM you are using.
   - [Azure OpenAI](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
   - [OpenAI](https://platform.openai.com/)
-- **NuGet Package** - Install the Microsoft Teams AI library:
+- **NuGet Package** - Install the Microsoft Teams SDK:
   ```bash
   dotnet add package Microsoft.Teams.AI
   ```

--- a/teams.md/docs/csharp/in-depth-guides/observability/logging.md
+++ b/teams.md/docs/csharp/in-depth-guides/observability/logging.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Guide to implementing custom logging in C# Teams AI applications using the ConsoleLogger and custom logger options.
+summary: Guide to implementing custom logging in C# Teams SDK applications using the ConsoleLogger and custom logger options.
 ---
 
 # 🗃️ Custom Logger

--- a/teams.md/docs/main/developer-tools/README.md
+++ b/teams.md/docs/main/developer-tools/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-summary: Overview of developer tools in Teams AI Library v2 including the CLI for project management and DevTools for testing and debugging agents.
+summary: Overview of developer tools in Teams SDK including the CLI for project management and DevTools for testing and debugging agents.
 ---
 
 # Developer Tools

--- a/teams.md/docs/main/developer-tools/cli.md
+++ b/teams.md/docs/main/developer-tools/cli.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Comprehensive guide to the Teams CLI tool for creating, managing, and deploying Teams AI applications with simple command-line operations. Use this when you need to set up a new Teams AI agent or manage existing ones.
+summary: Comprehensive guide to the Teams CLI tool for creating, managing, and deploying Teams SDK applications with simple command-line operations. Use this when you need to set up a new Teams SDK agent or manage existing ones.
 ---
 
 # Teams CLI

--- a/teams.md/docs/main/teams/user-authentication/README.md
+++ b/teams.md/docs/main/teams/user-authentication/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Overview of user authentication in Teams AI applications, including OAuth, SSO, and secure resource access.
+summary: Overview of user authentication in Teams SDK applications, including OAuth, SSO, and secure resource access.
 ---
 
 # User Authentication

--- a/teams.md/docs/main/welcome.md
+++ b/teams.md/docs/main/welcome.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
-summary: Welcome guide to Teams AI Library v2, covering the quickstart process and how to build agents and applications for Microsoft Teams.
+summary: Welcome guide to Teams SDK, covering the quickstart process and how to build agents and applications for Microsoft Teams.
 llms: ignore
 ---
 
 # 👋 Welcome
 
-Teams AI Library v2 is a suite of packages used to develop on Microsoft Teams. Rebuilt from the ground up with improved developer experience in mind, it's never been easier to build powerful agents and applications for the hundreds of millions Microsoft Teams users.
+Teams SDK is a suite of packages used to develop on Microsoft Teams. Rebuilt from the ground up with improved developer experience in mind, it's never been easier to build powerful agents and applications for the hundreds of millions Microsoft Teams users.
 
 ## Quickstart
 
@@ -29,7 +29,7 @@ npx @microsoft/teams.cli@latest new python quote-agent --template echo
 
 ## Overview
 
-Microsoft Teams has a robust developer ecosystem with a broad suite of capabilities, now unified via Teams AI library v2. Whether you are building [AI-powered agents](/typescript/in-depth-guides/ai), [message extensions](/typescript/in-depth-guides/message-extensions), embedded web applications, or Graph, Teams AI library v2 has you covered.
+Microsoft Teams has a robust developer ecosystem with a broad suite of capabilities, now unified via Teams SDK. Whether you are building [AI-powered agents](/typescript/in-depth-guides/ai), [message extensions](/typescript/in-depth-guides/message-extensions), embedded web applications, or Graph, Teams SDK has you covered.
 
 ## ⭐ What's new?
 

--- a/teams.md/docs/python/essentials/README.md
+++ b/teams.md/docs/python/essentials/README.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 2
-summary: Introduction to core concepts and paradigms for building Python Teams AI applications that handle events and activities.
+summary: Introduction to core concepts and paradigms for building Python Teams SDK applications that handle events and activities.
 ---
 
 # Essentials
 
 At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a dialog, or clicks a button — your app is there to interpret the event and act on it.
 
-With Teams AI Library v2, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
+With Teams SDK, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
 
 Before diving in, let’s define a few key terms:
 

--- a/teams.md/docs/python/essentials/on-event.md
+++ b/teams.md/docs/python/essentials/on-event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Guide to handling and responding to events in Python Teams AI applications, including user and server-originated events.
+summary: Guide to handling and responding to events in Python Teams SDK applications, including user and server-originated events.
 ---
 
 # Listening To Events
@@ -24,7 +24,7 @@ flowchart LR
     classDef interesting fill:#b1650f,stroke:#333,stroke-width:4px;
 ```
 
-The Teams AI Library v2 makes it easy to subscribe to these events and respond appropriately. You can register event handlers to take custom actions when specific events occur — such as logging errors, triggering workflows, or sending follow-up messages.
+The Teams SDK makes it easy to subscribe to these events and respond appropriately. You can register event handlers to take custom actions when specific events occur — such as logging errors, triggering workflows, or sending follow-up messages.
 
 Here are the events that you can start building handlers for:
 

--- a/teams.md/docs/python/essentials/sending-messages/README.md
+++ b/teams.md/docs/python/essentials/sending-messages/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-summary: Guide to sending messages from your Teams AI agent, including replies, proactive messages, and different message types.
+summary: Guide to sending messages from your Teams SDK agent, including replies, proactive messages, and different message types.
 ---
 
 # Sending Messages

--- a/teams.md/docs/python/getting-started/README.md
+++ b/teams.md/docs/python/getting-started/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Getting started guide for Python Teams AI Library covering application setup, structure, and local development.
+summary: Getting started guide for Python Teams SDK covering application setup, structure, and local development.
 llms: ignore-file
 ---
 
@@ -10,4 +10,4 @@ llms: ignore-file
 Our Python SDK is currently in Public Preview. We're going to do our best to not ship breaking changes, but breaking changes may happen from time to time 
 :::
 
-This guide will help you set up your first Teams AI Library application. You'll learn the basics of creating an application, understanding its structure, and running it locally. By the end of this guide, you'll have a solid foundation to build upon as you explore more advanced features and capabilities of the SDK.
+This guide will help you set up your first Teams SDK application. You'll learn the basics of creating an application, understanding its structure, and running it locally. By the end of this guide, you'll have a solid foundation to build upon as you explore more advanced features and capabilities of the SDK.

--- a/teams.md/docs/python/getting-started/code-basics.md
+++ b/teams.md/docs/python/getting-started/code-basics.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Understanding the structure and key components of a Python Teams AI application including the Application class, dependency injection, and project organization.
+summary: Understanding the structure and key components of a Python Teams SDK application including the Application class, dependency injection, and project organization.
 ---
 
 # Code Basics

--- a/teams.md/docs/python/getting-started/quickstart.md
+++ b/teams.md/docs/python/getting-started/quickstart.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
-summary: Quick start guide for Python Teams AI Library v2 using the Teams CLI to create and run your first Python agent.
+summary: Quick start guide for Python Teams SDK using the Teams CLI to create and run your first Python agent.
 ---
 
 # Quickstart
 
-Get started with Teams AI Library (v2) quickly using the Teams CLI.
+Get started with Teams SDK quickly using the Teams CLI.
 
 ## Set up a new project
 
@@ -15,7 +15,7 @@ Get started with Teams AI Library (v2) quickly using the Teams CLI.
 - **UV** v0.8.11 or higher. Install or upgrade from [https://docs.astral.sh/uv/getting-started/installation/](https://docs.astral.sh/uv/getting-started/installation/)
 
 :::info
-UV is a fast Python package installer and resolver. While you can use other package managers like pip, UV provides better performance and dependency resolution for Teams AI Library projects.
+UV is a fast Python package installer and resolver. While you can use other package managers like pip, UV provides better performance and dependency resolution for Teams SDK projects.
 :::
 
 ## Instructions

--- a/teams.md/docs/python/getting-started/running-in-teams/running-in-teams.md
+++ b/teams.md/docs/python/getting-started/running-in-teams/running-in-teams.md
@@ -105,7 +105,7 @@ If you want to monitor the activities and events in your app, you can still use 
 ## Troubleshooting
 
 For deployment and resource management we recommend the Microsoft 365 Agents Toolkit. Refer to our [Deployment guide](./deployment-guide.md) for common scenarios and potential issues. 
-If you prefer to set everything up by hand, follow the standard [Teams app documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview). The Teams AI library itself doesn't handle deployment or Azure resources, so you'll need to rely on the general [Microsoft Teams deployment documentation](https://learn.microsoft.com/en-us/microsoftteams/deploy-overview) for in-depth help.
+If you prefer to set everything up by hand, follow the standard [Teams app documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview). The Teams SDK itself doesn't handle deployment or Azure resources, so you'll need to rely on the general [Microsoft Teams deployment documentation](https://learn.microsoft.com/en-us/microsoftteams/deploy-overview) for in-depth help.
 
 ## Next steps
 

--- a/teams.md/docs/python/in-depth-guides/README.md
+++ b/teams.md/docs/python/in-depth-guides/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-summary: Detailed technical guides covering advanced features and capabilities of Teams AI Library in Python, including AI integration, adaptive cards, dialogs, authentication, and message extensions.
+summary: Detailed technical guides covering advanced features and capabilities of Teams SDK in Python, including AI integration, adaptive cards, dialogs, authentication, and message extensions.
 ---
 
 # In-Depth Guides

--- a/teams.md/docs/python/in-depth-guides/adaptive-cards/executing-actions.md
+++ b/teams.md/docs/python/in-depth-guides/adaptive-cards/executing-actions.md
@@ -12,7 +12,7 @@ You can use these to collect form input, trigger workflows, show task modules, o
 
 ## Action Types
 
-The Teams AI Library supports several action types for different interaction patterns:
+The Teams SDK supports several action types for different interaction patterns:
 
 | Action Type               | Purpose                | Description                                                                  |
 | ------------------------- | ---------------------- | ---------------------------------------------------------------------------- |

--- a/teams.md/docs/python/in-depth-guides/ai/mcp/README.md
+++ b/teams.md/docs/python/in-depth-guides/ai/mcp/README.md
@@ -5,7 +5,7 @@ summary: Overview of Model Context Protocol (MCP) integration in Python Teams AI
 
 # MCP
 
-Teams AI Library has optional packages which support the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as a service or client. This allows you to use MCP to call functions and tools in your application. 
+Teams SDK has optional packages which support the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as a service or client. This allows you to use MCP to call functions and tools in your application. 
 
 MCP servers and MCP clients dynamically load function definitions and tools.
 

--- a/teams.md/docs/python/in-depth-guides/ai/setup-and-prereqs.md
+++ b/teams.md/docs/python/in-depth-guides/ai/setup-and-prereqs.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Prerequisites and setup guide for integrating LLMs into Python Teams AI applications, including API keys and configuration.
+summary: Prerequisites and setup guide for integrating LLMs into Python Teams SDK applications, including API keys and configuration.
 ---
 
 # Setup & Prerequisites

--- a/teams.md/docs/python/in-depth-guides/observability/logging.md
+++ b/teams.md/docs/python/in-depth-guides/observability/logging.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Guide to implementing custom logging in Python Teams AI applications using the ConsoleLogger and custom logger options.
+summary: Guide to implementing custom logging in Python Teams SDK applications using the ConsoleLogger and custom logger options.
 ---
 
 # 🗃️ Custom Logger

--- a/teams.md/docs/python/in-depth-guides/user-authentication/setup.md
+++ b/teams.md/docs/python/in-depth-guides/user-authentication/setup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-summary: Guide to configuring user authentication in Python Teams AI applications, including OAuth setup and secure API access.
+summary: Guide to configuring user authentication in Python Teams SDK applications, including OAuth setup and secure API access.
 ---
 
 # App Setup

--- a/teams.md/docs/python/in-depth-guides/user-authentication/signin.md
+++ b/teams.md/docs/python/in-depth-guides/user-authentication/signin.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-summary: How to implement user sign-in with OAuth in C# Teams AI applications using the built-in signin method.
+summary: How to implement user sign-in with OAuth in C# Teams SDK applications using the built-in signin method.
 ---
 
 # Signing In

--- a/teams.md/docs/python/migrations/README.md
+++ b/teams.md/docs/python/migrations/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-summary: Migration guides for transitioning from older versions and frameworks to Teams AI Library v2.
+summary: Migration guides for transitioning from older versions and frameworks to Teams SDK.
 llms: ignore
 ---
 

--- a/teams.md/docs/typescript/essentials/README.md
+++ b/teams.md/docs/typescript/essentials/README.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 2
-summary: Introduction to the core concepts of Teams AI applications including events, activities, handlers, and the reactive paradigm for building intelligent agents.
+summary: Introduction to the core concepts of Teams SDK applications including events, activities, handlers, and the reactive paradigm for building intelligent agents.
 ---
 
 # Essentials
 
 At its core, an application that hosts an agent on Microsoft Teams exists to do three things well: listen to events, handle the ones that matter, and respond efficiently. Whether a user sends a message, opens a dialog, or clicks a button — your app is there to interpret the event and act on it.
 
-With Teams AI Library v2, we’ve made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
+With Teams SDK, we've made it easier than ever to build this kind of reactive, conversational logic. The library introduces a few simple but powerful paradigms to help you connect to Teams, register handlers, and build intelligent agent behaviors quickly.
 
 Before diving in, let’s define a few key terms:
 • Event: Anything interesting that happens on Teams — or within your application as a result of handling an earlier event.

--- a/teams.md/docs/typescript/essentials/app-basics.md
+++ b/teams.md/docs/typescript/essentials/app-basics.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Comprehensive guide to the App class, the main entry point for Teams AI agents that handles server hosting, request routing, authentication, and plugin management.
+summary: Comprehensive guide to the App class, the main entry point for Teams SDK agents that handles server hosting, request routing, authentication, and plugin management.
 ---
 
 # App Basics

--- a/teams.md/docs/typescript/essentials/graph.md
+++ b/teams.md/docs/typescript/essentials/graph.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-summary: Guide to using the Microsoft Graph API client to access Microsoft 365 data and services from your Teams AI application.
+summary: Guide to using the Microsoft Graph API client to access Microsoft 365 data and services from your Teams SDK application.
 ---
 
 # Graph API Client
@@ -10,7 +10,7 @@ summary: Guide to using the Microsoft Graph API client to access Microsoft 365 d
 The library gives your application easy access to the Microsoft Graph API via the `@microsoft/teams.graph`, `@microsoft/teams.graph-endpoints` and `@microsoft/teams.graph-endpoints-beta` packages.
 
 :::note
-If you're migrating from an earlier preview version of the Teams AI v2 library, please see the [migration guide](../migrations/preview/) for details on breaking changes.
+If you're migrating from an earlier preview version of the Teams SDK, please see the [migration guide](../migrations/preview/) for details on breaking changes.
 :::
 
 ## Package overview

--- a/teams.md/docs/typescript/essentials/on-activity/README.md
+++ b/teams.md/docs/typescript/essentials/on-activity/README.md
@@ -7,7 +7,7 @@ summary: Guide to handling Teams-specific activities like chat messages, card ac
 
 An **Activity** is the Teams‑specific payload that flows between the user and your bot.  
 Where _events_ describe high‑level happenings inside your app, _activities_ are the raw Teams messages such as chat text, card actions, installs, or invoke calls.  
-The Teams AI Library v2 exposes a fluent router so you can subscribe to these activities with `app.on('<route>', …)`.
+The Teams SDK exposes a fluent router so you can subscribe to these activities with `app.on('<route>', …)`.
 
 ```mermaid
 flowchart LR

--- a/teams.md/docs/typescript/essentials/on-activity/activity-ref.md
+++ b/teams.md/docs/typescript/essentials/on-activity/activity-ref.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Complete reference guide for all activity types and routes available in Teams AI applications, including core activities and configuration routes.
+summary: Complete reference guide for all activity types and routes available in Teams SDK applications, including core activities and configuration routes.
 ---
 
 # Activity Type Reference

--- a/teams.md/docs/typescript/essentials/on-event.md
+++ b/teams.md/docs/typescript/essentials/on-event.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Understanding how to listen to and handle events in Teams AI applications, including user actions and application server events.
+summary: Understanding how to listen to and handle events in Teams SDK applications, including user actions and application server events.
 ---
 
 # Listening To Events
@@ -24,7 +24,7 @@ flowchart LR
     classDef interesting fill:#b1650f,stroke:#333,stroke-width:4px;
 ```
 
-The Teams AI Library v2 makes it easy to subscribe to these events and respond appropriately. You can register event handlers to take custom actions when specific events occur — such as logging errors, triggering workflows, or sending follow-up messages.
+The Teams SDK makes it easy to subscribe to these events and respond appropriately. You can register event handlers to take custom actions when specific events occur — such as logging errors, triggering workflows, or sending follow-up messages.
 
 Here are the events that you can start building handlers for:
 

--- a/teams.md/docs/typescript/essentials/sending-messages/README.md
+++ b/teams.md/docs/typescript/essentials/sending-messages/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-summary: Guide to sending messages from your Teams AI agent, including replies, proactive messages, and different message types.
+summary: Guide to sending messages from your Teams SDK agent, including replies, proactive messages, and different message types.
 ---
 
 # Sending Messages

--- a/teams.md/docs/typescript/getting-started/README.md
+++ b/teams.md/docs/typescript/getting-started/README.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 1
-summary: Getting started guide for TypeScript Teams AI Library covering application setup, structure, and local development fundamentals.
+summary: Getting started guide for TypeScript Teams SDK covering application setup, structure, and local development fundamentals.
 llms: ignore-file
 ---
 
-# 🚀 Getting Started
+# Getting Started
 
-This guide will help you set up your first Teams AI Library application. You'll learn the basics of creating an application, understanding its structure, and running it locally. By the end of this guide, you'll have a solid foundation to build upon as you explore more advanced features and capabilities of the SDK.
+This guide will help you set up your first Teams SDK application. You'll learn the basics of creating an application, understanding its structure, and running it locally. By the end of this guide, you'll have a solid foundation to build upon as you explore more advanced features and capabilities of the SDK.

--- a/teams.md/docs/typescript/getting-started/code-basics.md
+++ b/teams.md/docs/typescript/getting-started/code-basics.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Understanding the structure and key components of a Teams AI application including the App class, plugins, and project organization.
+summary: Understanding the structure and key components of a Teams SDK application including the App class, plugins, and project organization.
 ---
 
 # Code Basics

--- a/teams.md/docs/typescript/getting-started/quickstart.md
+++ b/teams.md/docs/typescript/getting-started/quickstart.md
@@ -1,11 +1,11 @@
 ---
-sidebar_position: 1
-summary: Step-by-step guide to quickly get started with Teams AI Library v2 using the Teams CLI to create your first agent. Start here to build your first agent or application. We STRONGLY recommend using this as a guide to get started. It will help you build your project structure and scaffold your project.
+sidebar_position: 0
+summary: Step-by-step guide to quickly get started with Teams SDK using the Teams CLI to create your first agent. Start here to build your first agent or application. We STRONGLY recommend using this as a guide to get started. It will help you build your project structure and scaffold your project.
 ---
 
 # Quickstart
 
-Get started with Teams AI Library (v2) quickly using the Teams CLI.
+Get started with Teams SDK quickly using the Teams CLI.
 
 ## Set up a new project
 

--- a/teams.md/docs/typescript/getting-started/running-in-teams/running-in-teams.md
+++ b/teams.md/docs/typescript/getting-started/running-in-teams/running-in-teams.md
@@ -44,7 +44,7 @@ This [CLI](/developer-tools/cli) command adds configuration files required by Ag
 
 | Tool Name | Command | Description                                                                                                                                        |
 | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Teams CLI | `teams` | A command-line tool for setting up and utilizing the Teams AI v2 library, including integration with Microsoft 365 Agents Toolkit when desired. |
+| Teams CLI | `teams` | A command-line tool for setting up and utilizing the Teams SDK, including integration with Microsoft 365 Agents Toolkit when desired. |
 | Microsoft 365 Agents Toolkit | `atk`   | A tool for managing provisioning, deployment, and in-client debugging for Teams applications. |
 
 ## Debugging in Teams
@@ -70,7 +70,7 @@ When debugging starts, the Agents Toolkit will:
 - **Launch Teams** in an incognito window in your browser.
 - **Upload the package** to Teams and signal it to sideload (install) the app just for your use.
 
-If you set up Agents Toolkit via the Teams AI CLI, you should see something like the following in your terminal:
+If you set up Agents Toolkit via the Teams CLI, you should see something like the following in your terminal:
 
 
 ```sh
@@ -105,7 +105,7 @@ If you want to monitor the activities and events in your app, you can still use 
 ## Troubleshooting
 
 For deployment and resource management we recommend the Microsoft 365 Agents Toolkit. Refer to our [Deployment guide](./deployment-guide.md) for common scenarios and potential issues. 
-If you prefer to set everything up by hand, follow the standard [Teams app documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview). The Teams AI library itself doesn't handle deployment or Azure resources, so you'll need to rely on the general [Microsoft Teams deployment documentation](https://learn.microsoft.com/en-us/microsoftteams/deploy-overview) for in-depth help.
+If you prefer to set everything up by hand, follow the standard [Teams app documentation](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview). The Teams SDK itself doesn't handle deployment or Azure resources, so you'll need to rely on the general [Microsoft Teams deployment documentation](https://learn.microsoft.com/en-us/microsoftteams/deploy-overview) for in-depth help.
 
 ## Next steps
 

--- a/teams.md/docs/typescript/in-depth-guides/adaptive-cards/README.md
+++ b/teams.md/docs/typescript/in-depth-guides/adaptive-cards/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Introduction to Adaptive Cards in Teams AI applications for creating rich, interactive user experiences across various scenarios.
+summary: Introduction to Adaptive Cards in Teams SDK applications for creating rich, interactive user experiences across various scenarios.
 ---
 
 # Adaptive Cards

--- a/teams.md/docs/typescript/in-depth-guides/adaptive-cards/executing-actions.md
+++ b/teams.md/docs/typescript/in-depth-guides/adaptive-cards/executing-actions.md
@@ -12,7 +12,7 @@ You can use these to collect form input, trigger workflows, show task modules, o
 
 ## Action Types
 
-The Teams AI Library supports several action types for different interaction patterns:
+The Teams SDK supports several action types for different interaction patterns:
 
 | Action Type               | Purpose                | Description                                                                  |
 | ------------------------- | ---------------------- | ---------------------------------------------------------------------------- |

--- a/teams.md/docs/typescript/in-depth-guides/ai/README.md
+++ b/teams.md/docs/typescript/in-depth-guides/ai/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-summary: Overview of AI components in Teams AI library, including Prompts for orchestration and Models for LLM interfaces.
+summary: Overview of AI components in Teams SDK, including Prompts for orchestration and Models for LLM interfaces.
 ---
 
 # 🤖 AI

--- a/teams.md/docs/typescript/in-depth-guides/ai/mcp/README.md
+++ b/teams.md/docs/typescript/in-depth-guides/ai/mcp/README.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 6
-summary: Overview of Model Context Protocol (MCP) integration in Teams AI Library for dynamic function and tool loading.
+summary: Overview of Model Context Protocol (MCP) integration in Teams SDK for dynamic function and tool loading.
 ---
 
 # MCP
 
-Teams AI Library has optional packages which support the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as a service or client. This allows you to use MCP to call functions and tools in your application. 
+Teams SDK has optional packages which support the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) as a service or client. This allows you to use MCP to call functions and tools in your application. 
 
 MCP servers and MCP clients dynamically load function definitions and tools.
 

--- a/teams.md/docs/typescript/in-depth-guides/ai/setup-and-prereqs.md
+++ b/teams.md/docs/typescript/in-depth-guides/ai/setup-and-prereqs.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Prerequisites and setup guide for integrating LLMs into Teams AI applications, including API keys and Azure OpenAI configuration.
+summary: Prerequisites and setup guide for integrating LLMs into Teams SDK applications, including API keys and Azure OpenAI configuration.
 ---
 
 # Setup & Prerequisites

--- a/teams.md/docs/typescript/in-depth-guides/feedback.md
+++ b/teams.md/docs/typescript/in-depth-guides/feedback.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-summary: How to implement user feedback collection in Teams AI applications using specialized UI components and feedback storage.
+summary: How to implement user feedback collection in Teams SDK applications using specialized UI components and feedback storage.
 ---
 
 # Feedback

--- a/teams.md/docs/typescript/in-depth-guides/tabs/README.md
+++ b/teams.md/docs/typescript/in-depth-guides/tabs/README.md
@@ -13,7 +13,7 @@ The `@microsoft/teams.client` package in this library builds on TeamsJS and MSAL
 
 - **Remote Service Authentication** through MSAL-based authentication and token acquisition.
 - **Graph API Integration** by offering a pre-configured and type-safe Microsoft Graph client.
-- **Agent Function Calling** by handling authentication and including app context when calling server-side functions implemented Teams AI agents.
+- **Agent Function Calling** by handling authentication and including app context when calling server-side functions implemented Teams SDK agents.
 - **Scope Consent Management** by providing simple APIs to test for and request user consent.
 
 ## Resources

--- a/teams.md/docs/typescript/migrations/BotBuilder/README.md
+++ b/teams.md/docs/typescript/migrations/BotBuilder/README.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
-summary: Migration guide from BotBuilder to Teams AI Library v2, including the BotBuilder plugin for compatibility with existing activity handlers and adapters.
+summary: Migration guide from BotBuilder to Teams SDK, including the BotBuilder plugin for compatibility with existing activity handlers and adapters.
 llms: ignore
 ---
 
 # From BotBuilder
 
-This new iteration of Teams AI has been rebuilt from the ground up. To easy the migration process
+This new iteration of Teams SDK has been rebuilt from the ground up. To easy the migration process
 we have created a plugin `@microsoft/teams.botbuilder`, which allows you to use a botbuilder `activity handler`
 and `adapter` to send/receive activities through our new abstractions.
 

--- a/teams.md/docs/typescript/migrations/BotBuilder/activity-handlers.mdx
+++ b/teams.md/docs/typescript/migrations/BotBuilder/activity-handlers.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: How to migrate BotBuilder ActivityHandler patterns to Teams AI Library v2 activity routing system.
+summary: How to migrate BotBuilder ActivityHandler patterns to Teams SDK activity routing system.
 ---
 
 # Activity Handlers
@@ -8,14 +8,14 @@ summary: How to migrate BotBuilder ActivityHandler patterns to Teams AI Library 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-A BotBuilder `ActivityHandler` is similar to the activity routing of the Teams AI `App`.
+A BotBuilder `ActivityHandler` is similar to the activity routing of the Teams SDK `App`.
 The `BotBuilderPlugin` accepts a botbuilder Activity Handler instance so you can keep using your
-existing activity handlers while migrating however many you want to new Teams AI handlers. This allows for
+existing activity handlers while migrating however many you want to new Teams SDK handlers. This allows for
 a more incremental migration strategy.
 
 :::info
 this snippet shows how to use the `BotBuilderPlugin` to route activities using
-botbuilder alongside the default Teams AI activity routing.
+botbuilder alongside the default Teams SDK activity routing.
 :::
 
 <Tabs>

--- a/teams.md/docs/typescript/migrations/BotBuilder/adapters.mdx
+++ b/teams.md/docs/typescript/migrations/BotBuilder/adapters.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: How to migrate BotBuilder adapters to Teams AI Library v2 plugins for handling bot communication and middleware.
+summary: How to migrate BotBuilder adapters to Teams SDK plugins for handling bot communication and middleware.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,13 +8,15 @@ import TabItem from '@theme/TabItem';
 
 # Adapters
 
-A BotBuilder `Adapter` is similar to a Teams AI `Plugin` in the sense that they are both
+# Migrating BotBuilder Adapters
+
+A BotBuilder `Adapter` is similar to a Teams SDK `Plugin` in the sense that they are both
 an abstraction that is meant to send/receive activities. To make migrating stress free we have
 shipped a pre-built `BotBuilderPlugin` that can accept a botbuilder Adapter instance.
 
 :::info
 this snippet shows how to use the `BotBuilderPlugin` to send/receive activities using
-botbuilder instead of the default Teams AI http plugin.
+botbuilder instead of the default Teams SDK http plugin.
 :::
 
 <Tabs>

--- a/teams.md/docs/typescript/migrations/BotBuilder/turn-context/README.mdx
+++ b/teams.md/docs/typescript/migrations/BotBuilder/turn-context/README.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-summary: Understand how Teams AI's IActivityContext replaces BotBuilder's TurnContext for handling incoming data and APIs.
+summary: Understand how Teams SDK's IActivityContext replaces BotBuilder's TurnContext for handling incoming data and APIs.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,6 +8,6 @@ import TabItem from '@theme/TabItem';
 
 # Turn Context
 
-While BotBuilder has a `TurnContext`, Teams AI has `IActivityContext` which serves the same purpose.
+While BotBuilder has a `TurnContext`, Teams SDK has `IActivityContext` which serves the same purpose.
 The context is passed into activity handlers and provides a structured way for developers to interface
 with apis and incoming data.

--- a/teams.md/docs/typescript/migrations/BotBuilder/turn-context/proactive-activities.mdx
+++ b/teams.md/docs/typescript/migrations/BotBuilder/turn-context/proactive-activities.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-summary: Migrate from BotBuilder's complex conversation reference handling to Teams AI's simple conversation ID-based proactive messaging.
+summary: Migrate from BotBuilder's complex conversation reference handling to Teams SDK's simple conversation ID-based proactive messaging.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Proactive Activities
 
-The BotBuilder proactive message flow requires you to have a conversation reference stored somewhere. In Teams AI
+The BotBuilder proactive message flow requires you to have a conversation reference stored somewhere. In Teams SDK
 we expose a `send` method almost identical to the one passed into our activity handlers that accepts a `conversationId`,
 so all you need to store is that!
 

--- a/teams.md/docs/typescript/migrations/BotBuilder/turn-context/sending-activities.mdx
+++ b/teams.md/docs/typescript/migrations/BotBuilder/turn-context/sending-activities.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-summary: Migrate from BotBuilder's TurnContext activity sending to Teams AI's simplified send method with better Adaptive Card support.
+summary: Migrate from BotBuilder's TurnContext activity sending to Teams SDK's simplified send method with better Adaptive Card support.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Sending Activities
 
 BotBuilders pattern for sending activities via its `TurnContext` is similar to that
-in Teams AI, but one key difference is that when sending adaptive cards you don't need
+In Teams SDK, but one key difference is that when sending adaptive cards you don't need
 to construct the entire activity yourself.
 
 <Tabs groupId="sending-activities">

--- a/teams.md/docs/typescript/migrations/BotBuilder/turn-context/the-api-client.mdx
+++ b/teams.md/docs/typescript/migrations/BotBuilder/turn-context/the-api-client.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-summary: Replace BotBuilder's static TeamsInfo class with Teams AI's injected ApiClient for cleaner API interactions.
+summary: Replace BotBuilder's static TeamsInfo class with Teams SDK's injected ApiClient for cleaner API interactions.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # The API Client
 
-BotBuilder exposes a static class `TeamsInfo` that allows you to query the api. In Teams AI
+BotBuilder exposes a static class `TeamsInfo` that allows you to query the api. In Teams SDK
 we pass an instance of our `ApiClient` into all our activity handlers.
 
 <Tabs groupId="sending-activities">

--- a/teams.md/docs/typescript/migrations/BotBuilder/user-authentication.mdx
+++ b/teams.md/docs/typescript/migrations/BotBuilder/user-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-summary: Migrate from BotBuilder's complex OAuthPrompt dialogs to Teams AI's simple signin/signout methods.
+summary: Migrate from BotBuilder's complex OAuthPrompt dialogs to Teams SDK's simple signin/signout methods.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # User Authentication
 
-BotBuilder uses its `dialogs` for authentication via the `OAuthPrompt`. Teams AI doesn't have any
+BotBuilder uses its `dialogs` for authentication via the `OAuthPrompt`. Teams SDK doesn't have any
 equivalent feature to dialogs, but we do support auth flows in our own way via our `signin` and `signout` methods.
 
 <Tabs groupId="sending-activities">
@@ -359,4 +359,4 @@ equivalent feature to dialogs, but we do support auth flows in our own way via o
   </TabItem>
 </Tabs>
 
-## Teams AI
+## Teams SDK

--- a/teams.md/docs/typescript/migrations/README.md
+++ b/teams.md/docs/typescript/migrations/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-summary: Migration guides for transitioning from older versions and frameworks to Teams AI Library v2.
+summary: Migration guides for transitioning from older versions and frameworks to Teams SDK.
 llms: ignore
 ---
 

--- a/teams.md/docs/typescript/migrations/preview/README.md
+++ b/teams.md/docs/typescript/migrations/preview/README.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # From V2 Previews
 
-If you're moving from preview versions of Teams AI v2, you may encounter a few breaking changes along the way. This page outlines those and shows how to get back on track.
+If you're moving from preview versions of Teams SDK, you may encounter a few breaking changes along the way. This page outlines those and shows how to get back on track.
 
 ## Graph Client
 

--- a/teams.md/docs/typescript/migrations/v1/README.md
+++ b/teams.md/docs/typescript/migrations/v1/README.md
@@ -1,18 +1,18 @@
 ---
 sidebar_position: 2
-summary: Migration guide from Teams AI v1 to v2 highlighting the key changes and upgrade steps.
+summary: Migration guide from Teams SDK v1 to v2 highlighting the key changes and upgrade steps.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Migrating from Teams AI v1
+# Migrating from Teams SDK v1
 
-Welcome, fellow agent developer! You've made it through a full major release of Teams AI, and now you want to take the plunge into v2. In this guide, we'll walk you through everything you need to know, from migrating core features like message handlers and auth, to optional AI features like `ActionPlanner`. We'll also discuss how you can migrate features over incrementally via the [botbuilder adapter](../BotBuilder/README.md).
+Welcome, fellow agent developer! You've made it through a full major release of Teams SDK, and now you want to take the plunge into v2. In this guide, we'll walk you through everything you need to know, from migrating core features like message handlers and auth, to optional AI features like `ActionPlanner`. We'll also discuss how you can migrate features over incrementally via the [botbuilder adapter](../BotBuilder/README.md).
 
-## Installing Teams AI v2
+## Installing Teams SDK
 
-First, let's install Teams AI v2 into your project. Notably, this won't replace any existing installation of Teams AI v1. When you've completed your migration, you can safely remove the `@microsoft/teams-ai` dependency from your `package.json` file.
+First, let's install Teams SDK into your project. Notably, this won't replace any existing installation of Teams SDK v1. When you've completed your migration, you can safely remove the `@microsoft/teams-ai` dependency from your `package.json` file.
 
 ```sh
 npm install @microsoft/teams.apps
@@ -23,7 +23,7 @@ npm install @microsoft/teams.apps
 First, migrate your `Application` class from v1 to the new `App` class.
 
 <Tabs>
-  <TabItem value="v2" label="Teams AI v2">
+  <TabItem value="v2" label="Teams SDK">
     ```ts
     import { App } from '@microsoft/teams.apps';
     import { LocalStorage } from '@microsoft/teams.common/storage';
@@ -59,7 +59,7 @@ First, migrate your `Application` class from v1 to the new `App` class.
     ```
 
   </TabItem>
-  <TabItem value="v1" label="Teams AI v1">
+  <TabItem value="v1" label="Teams SDK v1">
     ```ts
     import {
       ConfigurationServiceClientCredentialFactory,
@@ -118,12 +118,12 @@ First, migrate your `Application` class from v1 to the new `App` class.
 
 ## Migrate activity handlers
 
-Both Teams AI v1 and v2 are built atop incoming `Activity` requests, which trigger handlers in your code when specific type of activities are received. The syntax for how you register different types of `Activity` handlers differs between the v1 and v2 versions of our SDK.
+Both Teams SDK v1 and v2 are built atop incoming `Activity` requests, which trigger handlers in your code when specific type of activities are received. The syntax for how you register different types of `Activity` handlers differs between the v1 and v2 versions of our SDK.
 
 ### Message handlers
 
 <Tabs>
-  <TabItem value="v1" label="Teams AI v1">
+  <TabItem value="v1" label="Teams SDK v1">
     ```ts
     // triggers when user sends "/hi" or "@bot /hi"
     app.message("/hi", async (context) => {
@@ -141,7 +141,7 @@ Both Teams AI v1 and v2 are built atop incoming `Activity` requests, which trigg
     );
     ```
   </TabItem>
-  <TabItem value="v2" label="Teams AI v2">
+  <TabItem value="v2" label="Teams SDK">
     ```ts
     // triggers when user sends "/hi" or "@bot /hi"
     app.message('/hi', async (client) => {
@@ -163,7 +163,7 @@ Both Teams AI v1 and v2 are built atop incoming `Activity` requests, which trigg
 ### Task modules
 
 <Tabs>
-  <TabItem value="v2" label="Teams AI v2">
+  <TabItem value="v2" label="Teams SDK">
     ```ts
     app.on('dialog.open', (client) => {
       const dialogType = client.activity.value.data?.opendialogtype;
@@ -195,7 +195,7 @@ Both Teams AI v1 and v2 are built atop incoming `Activity` requests, which trigg
     ```
 
   </TabItem>
-  <TabItem value="v1" label="Teams AI v1">
+  <TabItem value="v1" label="Teams SDK v1">
     ```ts
     app.taskModules.fetch('connect-account', async (context, state, data) => {
       const taskInfo: TaskModuleTaskInfo = {
@@ -224,11 +224,11 @@ Learn more [here](../../in-depth-guides/dialogs/README.md).
 
 ## Adaptive cards
 
-In Teams AI v2, cards have much more rich type validation than existed in v1. However, assuming your cards were valid, it should be easy to migrate to v2.
+In Teams SDK, cards have much more rich type validation than existed in v1. However, assuming your cards were valid, it should be easy to migrate to v2.
 
 <Tabs>
-  <TabItem value="v2-option1" label="Teams AI v2 (Option 1)">
-    For existing cards like this, the simplest way to convert that to Teams AI v2 is this:
+  <TabItem value="v2-option1" label="Teams SDK (Option 1)">
+    For existing cards like this, the simplest way to convert that to Teams SDK is this:
 
     ```ts
     app.message('/card', async (client) => {
@@ -252,7 +252,7 @@ In Teams AI v2, cards have much more rich type validation than existed in v1. Ho
     ```
 
   </TabItem>
-  <TabItem value="v2-option2" label="Teams AI v2 (Option 2)">
+  <TabItem value="v2-option2" label="Teams SDK (Option 2)">
     For a more thorough port, you could also do the following:
 
     ```ts
@@ -268,7 +268,7 @@ In Teams AI v2, cards have much more rich type validation than existed in v1. Ho
     ```
 
   </TabItem>
-  <TabItem value="v1" label="Teams AI v1">
+  <TabItem value="v1" label="Teams SDK v1">
     ```ts
     app.message('/card', async (context: TurnContext) => {
       const card = CardFactory.adaptiveCard({
@@ -299,10 +299,10 @@ Learn more [here](../../in-depth-guides/adaptive-cards/README.md).
 
 ## Authentication
 
-Most agents feature authentication for user identification, interacting with APIs, etc. Whether your Teams AI v1 app used Entra SSO or custom OAuth, porting to v2 should be simple.
+Most agents feature authentication for user identification, interacting with APIs, etc. Whether your Teams SDK v1 app used Entra SSO or custom OAuth, porting to v2 should be simple.
 
 <Tabs>
-  <TabItem value="v2" label="Teams AI v2">
+  <TabItem value="v2" label="Teams SDK">
     ```ts
     const app = new App({
       oauth: {
@@ -348,7 +348,7 @@ Most agents feature authentication for user identification, interacting with API
     ```
 
   </TabItem>
-  <TabItem value="v1" label="Teams AI v1">
+  <TabItem value="v1" label="Teams SDK v1">
     ```ts
     const storage = new MemoryStorage();
     const app = new Application({
@@ -434,11 +434,11 @@ Most agents feature authentication for user identification, interacting with API
 
 ### Action planner
 
-When we created Teams AI v1, LLM's didn't natively support tool calling or orchestration. A lot has changed since then, which is why we decided to deprecate `ActionPlanner` from Teams AI v1, and replace it with something a bit more lightweight. Notably, Teams AI v1 had two similar concepts: functions and actions. In Teams AI v2, these are consolidated into functions.
+When we created Teams SDK v1, LLM's didn't natively support tool calling or orchestration. A lot has changed since then, which is why we decided to deprecate `ActionPlanner` from Teams SDK v1, and replace it with something a bit more lightweight. Notably, Teams SDK v1 had two similar concepts: functions and actions. In Teams SDK, these are consolidated into functions.
 
 <Tabs>
-  <TabItem value="v2" label="Teams AI v2">
-    In Teams AI v2, there is no `actions.json` file. Instead, function prompts, parameters, etc. are declared in your code.
+  <TabItem value="v2" label="Teams SDK">
+    In Teams SDK, there is no `actions.json` file. Instead, function prompts, parameters, etc. are declared in your code.
 
     ```ts
     import '@azure/openai/types';
@@ -517,7 +517,7 @@ When we created Teams AI v1, LLM's didn't natively support tool calling or orche
     ```
 
   </TabItem>
-  <TabItem value="v1" label="Teams AI v1">
+  <TabItem value="v1" label="Teams SDK v1">
 
     ```ts
     // Create AI components
@@ -621,7 +621,7 @@ When we created Teams AI v1, LLM's didn't natively support tool calling or orche
 If you supported feedback for AI generated messages, migrating is simple.
 
 <Tabs>
-  <TabItem value="v2" label="Teams AI v2">
+  <TabItem value="v2" label="Teams SDK">
     ```ts
     import { MessageActivity } from '@microsoft/teams.api';
 
@@ -640,10 +640,10 @@ If you supported feedback for AI generated messages, migrating is simple.
     });
     ```
 
-    _Note:_ In Teams AI v2, you do not need to opt into feedback at the `App` level.
+    _Note:_ In Teams SDK, you do not need to opt into feedback at the `App` level.
 
   </TabItem>
-  <TabItem value="v1" label="Teams AI v1">
+  <TabItem value="v1" label="Teams SDK v1">
     ```ts
     export const app = new Application({
       ai: {
@@ -674,7 +674,7 @@ If you supported feedback for AI generated messages, migrating is simple.
   </TabItem>
 </Tabs>
 
-You can learn more about feedback in Teams AI v2 [here](../../in-depth-guides/feedback.md).
+You can learn more about feedback in Teams SDK [here](../../in-depth-guides/feedback.md).
 
 ## Incrementally migrating code via botbuilder plugin
 
@@ -682,4 +682,4 @@ You can learn more about feedback in Teams AI v2 [here](../../in-depth-guides/fe
 Comparison code coming soon!
 :::
 
-If you aren't ready to migrate all of your code, you can run your existing Teams AI v1 code in parallel with Teams AI v2. Learn more [here](../BotBuilder/adapters.mdx).
+If you aren't ready to migrate all of your code, you can run your existing Teams SDK v1 code in parallel with Teams SDK. Learn more [here](../BotBuilder/adapters.mdx).

--- a/teams.md/docusaurus.config.ts
+++ b/teams.md/docusaurus.config.ts
@@ -7,7 +7,7 @@ import { themes as prismThemes } from 'prism-react-renderer';
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 const baseUrl = '/teams-ai/';
 const config: Config = {
-    title: 'Teams AI Library (v2)',
+    title: 'Teams SDK',
     favicon: 'img/msft-logo-48x48.png',
 
     // Set the production url of your site here
@@ -121,10 +121,10 @@ const config: Config = {
             respectPrefersColorScheme: true,
         },
         navbar: {
-            title: 'Teams AI (v2)',
+            title: 'Teams SDK',
             hideOnScroll: true,
             logo: {
-                alt: 'Teams AI (v2)',
+                alt: 'Teams SDK',
                 src: 'img/teams.png',
             },
             items: [

--- a/teams.md/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/teams.md/i18n/en/docusaurus-theme-classic/navbar.json
@@ -1,10 +1,10 @@
 {
   "title": {
-    "message": "Teams AI (v2)",
+    "message": "Teams SDK",
     "description": "The title in the navbar"
   },
   "logo.alt": {
-    "message": "Teams AI (v2)",
+    "message": "Teams SDK",
     "description": "The alt text of navbar logo"
   },
   "item.label.Typescript": {

--- a/teams.md/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/teams.md/i18n/es/docusaurus-theme-classic/navbar.json
@@ -1,10 +1,10 @@
 {
   "title": {
-    "message": "Teams AI (v2)",
+    "message": "Teams SDK",
     "description": "The title in the navbar"
   },
   "logo.alt": {
-    "message": "Teams AI (v2)",
+    "message": "Teams SDK",
     "description": "The alt text of navbar logo"
   },
   "item.label.Typescript": {

--- a/teams.md/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/teams.md/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -1,10 +1,10 @@
 {
   "title": {
-    "message": "Teams AI (v2)",
+    "message": "Teams SDK",
     "description": "The title in the navbar"
   },
   "logo.alt": {
-    "message": "Teams AI (v2)",
+    "message": "Teams SDK",
     "description": "The alt text of navbar logo"
   },
   "item.label.Typescript": {

--- a/teams.md/scripts/generate-llms-txt.ts
+++ b/teams.md/scripts/generate-llms-txt.ts
@@ -33,10 +33,10 @@ const COMMON_OVERALL_SUMMARY = (language: Language) => {
     const tips = LANGUAGE_SPECIFIC_TIPS[language];
     const formattedTips = tips.map(tip => `- ${tip}`).join('\n');
 
-    return `> Microsoft Teams AI Library (v2) - A comprehensive framework for building AI-powered Teams applications using ${langName}. Using this Library, you can easily build and integrate a variety of features in Microsoft Teams by building Agents or Tools. The documentation here helps by giving background information and code samples on how best to do this.
+    return `> Microsoft Teams SDK - A comprehensive framework for building AI-powered Teams applications using ${langName}. Using this SDK, you can easily build and integrate a variety of features in Microsoft Teams by building Agents or Tools. The documentation here helps by giving background information and code samples on how best to do this.
 
 IMPORTANT THINGS TO REMEMBER:
-- This Library is NOT based off of BotFramework (which the _previous_ version of the Teams AI Library was based on). This Library is a completely new framework. Use this guide to find snippets to drive your decisions.
+- This SDK is NOT based off of BotFramework (which the _previous_ version of the Teams SDK was based on). This SDK is a completely new framework. Use this guide to find snippets to drive your decisions.
 - When scaffolding new applications, using the CLI is a lot simpler and preferred than doing it all by yourself. See the Quickstart guide for that.
 ${formattedTips}
 
@@ -100,7 +100,7 @@ function getDocusaurusConfig(baseDir: string): DocusaurusConfig {
 }
 
 /**
- * Generates llms.txt files for Teams AI documentation
+ * Generates llms.txt files for Teams SDK documentation
  * Creates both small and full versions for TypeScript and C# docs
  */
 async function generateLlmsTxt(): Promise<void> {
@@ -314,7 +314,7 @@ async function generateSmallVersionHierarchical(language: Language, baseDir: str
     const cleanBaseUrl = config.baseUrl.startsWith('/') ? config.baseUrl : '/' + config.baseUrl;
     const fullBaseUrl = `${cleanUrl}${cleanBaseUrl}`;
 
-    let content = `# Teams AI Library - ${langName} Documentation\n\n`;
+    let content = `# Teams SDK - ${langName} Documentation\n\n`;
     content += COMMON_OVERALL_SUMMARY(language) + '\n\n';
 
     // Get hierarchical structure
@@ -507,7 +507,7 @@ function extractSummaryFromFile(filePath: string): string {
  */
 async function generateFullVersion(language: Language, processedFiles: ProcessedFile[], baseDir: string): Promise<string> {
     const langName = LANG_NAME_BY_LANGUAGE[language]
-    let content = `# Teams AI Library - ${langName} Documentation (Complete)\n\n`;
+    let content = `# Teams SDK - ${langName} Documentation (Complete)\n\n`;
     content += COMMON_OVERALL_SUMMARY(language) + '\n\n';
 
     // Group files by section

--- a/teams.md/static/llms_docs/llms.txt
+++ b/teams.md/static/llms_docs/llms.txt
@@ -1,6 +1,6 @@
-# Teams AI Library Documentation
+# Teams SDK Documentation
 
-This website contains documentation for interacting with Teams AI Library, an SDK built to simplify building agents and applications that will integrate with Microsoft Teams.
+This website contains documentation for interacting with Teams SDK, an SDK built to simplify building agents and applications that will integrate with Microsoft Teams.
 IMPORTANT: This SDK is NOT built using BotFramework (which was an older iteration).
 
 Language Specific URLs:


### PR DESCRIPTION
## Summary
This PR updates all documentation to reflect the rename from 'Teams AI SDK' / 'Teams AI Library' to simply 'Teams SDK'.

## Changes Made
- ✅ Updated all documentation references from 'Teams AI Library' and 'Teams AI SDK' to 'Teams SDK'
- ✅ Removed version indicators (v2, (v2)) from product name throughout documentation
- ✅ Updated docusaurus configuration and site title
- ✅ Updated internationalization files (en, es, zh-Hans)
- ✅ Updated README.md and welcome documentation
- ✅ Updated migration guides and all markdown/mdx files
- ✅ Updated llms.txt generation script
- ✅ Updated static llms.txt file

## Files Affected
- 66 files changed across documentation (TypeScript, Python, C#)
- Configuration files (docusaurus.config.ts)
- Internationalization files
- Migration guides
- Scripts

## Notes
- Version numbers (v1, v2) are maintained in migration guides where contextually appropriate for clarity
- The product is now consistently referred to as **Teams SDK** throughout all documentation