### PR TITLE
[Docs] Add cancellationToken to all C# handler examples

### DIFF
--- a/teams.md/src/components/include/essentials/api/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/api/csharp.incl.md
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 
 
 ```csharp
-app.OnMessage(async context =>
+app.OnMessage(async (context, cancellationToken) =>
 {
     var members = await context.Api.Conversations.Members.Get(context.Conversation.Id);
 });
@@ -31,7 +31,7 @@ app.OnMessage(async context =>
 <!-- meetings-example -->
 
 ```csharp
-app.OnMeetingStart(async context =>
+app.OnMeetingStart(async (context, cancellationToken) =>
 {
     var meetingId = context.Activity.Value.Id;
     var tenantId = context.Activity.ChannelData?.Tenant?.Id;

--- a/teams.md/src/components/include/essentials/graph/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/graph/csharp.incl.md
@@ -41,7 +41,7 @@ import TabItem from '@theme/TabItem';
 
 
 ```csharp
-app.OnMessage(async context =>
+app.OnMessage(async (context, cancellationToken) =>
 {
     var user = await context.UserGraph.Me.GetAsync();
     Console.WriteLine($"User ID: {user.id}");

--- a/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/on-activity/csharp.incl.md
@@ -5,9 +5,9 @@ The Teams SDK exposes a fluent router so you can subscribe to these activities w
 <!-- basic-example -->
 
     ```csharp
-    app.OnMessage(async context =>
+    app.OnMessage(async (context, cancellationToken) =>
     {
-        await context.Send($"you said: {context.activity.Text}");
+        await context.Send($"you said: {context.activity.Text}", cancellationToken);
     });
     ```
 
@@ -21,7 +21,7 @@ The `OnActivity` activity handlers (and attributes) follow a [middleware](https:
 
 <!-- middleware-examples -->
   ```csharp
-  app.OnMessage(async context =>
+  app.OnMessage(async (context, cancellationToken) =>
   {
       Console.WriteLine("global logger");
       context.Next(); // pass control onward
@@ -30,21 +30,21 @@ The `OnActivity` activity handlers (and attributes) follow a [middleware](https:
   ```
 
 ```csharp
-app.OnMessage(async context =>
+app.OnMessage(async (context, cancellationToken) =>
 {
     if (context.Activity.Text == "/help")
     {
-        await context.Send("Here are all the ways I can help you...");
+        await context.Send("Here are all the ways I can help you...", cancellationToken);
     }
 
     // Conditionally pass control to the next handler
     context.Next();
 });
-    
-  app.OnMessage(async context =>
+
+  app.OnMessage(async (context, cancellationToken) =>
   {
       // Fallthrough to the final handler
-      await context.Send($"Hello! you said {context.Activity.Text}");
+      await context.Send($"Hello! you said {context.Activity.Text}", cancellationToken);
   });
   ```
 

--- a/teams.md/src/components/include/essentials/sending-messages/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/sending-messages/csharp.incl.md
@@ -1,18 +1,18 @@
 <!-- basic-message-example -->
 
 ```csharp
-app.OnMessage(async context =>
+app.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Send($"you said: {context.activity.Text}");
+    await context.Send($"you said: {context.activity.Text}", cancellationToken);
 });
 ```
 
 <!-- signin-example -->
 
   ```csharp
-  app.OnVerifyState(async context =>
+  app.OnVerifyState(async (context, cancellationToken) =>
   {
-      await context.Send("You have successfully signed in!");
+      await context.Send("You have successfully signed in!", cancellationToken);
   });
   ```
 
@@ -23,7 +23,7 @@ app.OnMessage(async context =>
 <!-- streaming-example -->
 
 ```csharp
-app.OnMessage(async context =>
+app.OnMessage(async (context, cancellationToken) =>
 {
     context.Stream.Emit("hello");
     context.Stream.Emit(", ");
@@ -40,9 +40,9 @@ app.OnMessage(async context =>
 <!-- mention-example -->
 
 ```csharp
-app.OnMessage(async context =>
+app.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Send(new MessageActivity("hi!").AddMention(activity.From));
+    await context.Send(new MessageActivity("hi!").AddMention(activity.From), cancellationToken);
 });
 ```
 
@@ -53,12 +53,13 @@ app.OnMessage(async context =>
 <!-- targeted-send-example -->
 
 ```csharp
-app.OnMessage(async context =>
+app.OnMessage(async (context, cancellationToken) =>
 {
     // Using WithRecipient with isTargeted=true explicitly targets the specified recipient
     await context.Send(
         new MessageActivity("This message is only visible to you!")
-            .WithRecipient(context.Activity.From, isTargeted: true)
+            .WithRecipient(context.Activity.From, isTargeted: true),
+        cancellationToken
     );
 });
 ```

--- a/teams.md/src/components/include/essentials/sending-messages/proactive-messaging/csharp.incl.md
+++ b/teams.md/src/components/include/essentials/sending-messages/proactive-messaging/csharp.incl.md
@@ -10,11 +10,11 @@ import TabItem from '@theme/TabItem';
 <Tabs>
   <TabItem label="Minimal" value="minimal">
     ```csharp 
-    app.OnInstall(async context =>
+    app.OnInstall(async (context, cancellationToken) =>
     {
-        // Save the conversation id in 
+        // Save the conversation id in
         context.Storage.Set(activity.From.AadObjectId!, activity.Conversation.Id);
-        await context.Send("Hi! I am going to remind you to say something to me soon!");
+        await context.Send("Hi! I am going to remind you to say something to me soon!", cancellationToken);
         notificationQueue.AddReminder(activity.From.AadObjectId!, Notifications.SendProactive, 10_000);
     });
     ```

--- a/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
+++ b/teams.md/src/components/include/getting-started/code-basics/csharp.incl.md
@@ -26,10 +26,10 @@ builder.AddTeams().AddTeamsDevTools();
 var app = builder.Build();
 var teams = app.UseTeams();
 
-teams.OnMessage(async context =>
+teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing();
-    await context.Send($"you said '{context.Activity.Text}'");
+    await context.Typing(cancellationToken);
+    await context.Send($"you said '{context.Activity.Text}'", cancellationToken);
 });
 
 app.Run();
@@ -42,10 +42,10 @@ app.Run();
 <!-- message-handling-code -->
 
 ```csharp title="Program.cs"
-teams.OnMessage(async context =>
+teams.OnMessage(async (context, cancellationToken) =>
 {
-    await context.Typing();
-    await context.Send($"you said \"{context.activity.Text}\"");
+    await context.Typing(cancellationToken);
+    await context.Send($"you said \"{context.activity.Text}\"", cancellationToken);
 });
 ```
 

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/building-adaptive-cards/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/building-adaptive-cards/csharp.incl.md
@@ -148,15 +148,15 @@ await client.Send(card);
 <Tabs>
   <TabItem label="Minimal" value="minimal">
     ```csharp
-    teams.OnMessage(async context =>
+    teams.OnMessage(async (context, cancellationToken) =>
     {
         var text = context.Activity.Text?.ToLowerInvariant() ?? "";
 
         if (text.Contains("form"))
         {
-            await context.Typing();
+            await context.Typing(cancellationToken);
             var card = CreateTaskFormCard();
-            await context.Send(card);
+            await context.Send(card, cancellationToken);
         }
     });
     ```

--- a/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/adaptive-cards/executing-actions/csharp.incl.md
@@ -203,7 +203,7 @@ using Microsoft.Teams.Common.Logging;
 
 //...
 
-teams.OnAdaptiveCardAction(async context =>
+teams.OnAdaptiveCardAction(async (context, cancellationToken) =>
 {
     var activity = context.Activity;
     context.Log.Info("[CARD_ACTION] Card action received");
@@ -242,19 +242,19 @@ teams.OnAdaptiveCardAction(async context =>
     {
         case "submit_basic":
             var notifyValue = GetFormValue("notify") ?? "false";
-            await context.Send($"Basic card submitted! Notify setting: {notifyValue}");
+            await context.Send($"Basic card submitted! Notify setting: {notifyValue}", cancellationToken);
             break;
 
         case "submit_feedback":
             var feedbackText = GetFormValue("feedback") ?? "No feedback provided";
-            await context.Send($"Feedback received: {feedbackText}");
+            await context.Send($"Feedback received: {feedbackText}", cancellationToken);
             break;
 
         case "create_task":
             var title = GetFormValue("title") ?? "Untitled";
             var priority = GetFormValue("priority") ?? "medium";
             var dueDate = GetFormValue("due_date") ?? "No date";
-            await context.Send($"Task created!\nTitle: {title}\nPriority: {priority}\nDue: {dueDate}");
+            await context.Send($"Task created!\nTitle: {title}\nPriority: {priority}\nDue: {dueDate}", cancellationToken);
             break;
 
         case "save_profile":
@@ -270,11 +270,11 @@ teams.OnAdaptiveCardAction(async context =>
             if (location != "Not specified")
                 response += $"\nLocation: {location}";
 
-            await context.Send(response);
+            await context.Send(response, cancellationToken);
             break;
 
         case "test_json":
-            await context.Send("JSON deserialization test successful!");
+            await context.Send("JSON deserialization test successful!", cancellationToken);
             break;
 
         default:

--- a/teams.md/src/components/include/in-depth-guides/ai/chat/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/chat/csharp.incl.md
@@ -40,7 +40,7 @@ var azureOpenAI = new AzureOpenAIClient(
 var aiModel = new OpenAIChatModel(azureOpenAIModel, azureOpenAI);
 
 // Simple chat handler
-teamsApp.OnMessage(async (context) =>
+teamsApp.OnMessage(async (context, cancellationToken) =>
 {
     var prompt = new OpenAIChatPrompt(aiModel, new ChatPromptOptions
     {
@@ -54,7 +54,7 @@ teamsApp.OnMessage(async (context) =>
         {
             Text = result.Content,
         }.AddAIGenerated();
-        await context.Send(messageActivity);
+        await context.Send(messageActivity, cancellationToken);
         // Ahoy, matey! 🏴‍☠️ How be ye doin' this fine day on th' high seas? What can this ol' salty sea dog help ye with? 🚢☠️
     }
 });
@@ -91,7 +91,7 @@ using Microsoft.Teams.Api.Activities;
 var aiModel = new OpenAIChatModel(azureOpenAIModel, azureOpenAI);
 
 // Use the prompt with OpenAIChatPrompt.From()
-teamsApp.OnMessage(async (context) =>
+teamsApp.OnMessage(async (context, cancellationToken) =>
 {
     var prompt = OpenAIChatPrompt.From(aiModel, new Samples.AI.Prompts.PiratePrompt());
 
@@ -99,7 +99,7 @@ teamsApp.OnMessage(async (context) =>
 
     if (!string.IsNullOrEmpty(result.Content))
     {
-        await context.Send(new MessageActivity { Text = result.Content }.AddAIGenerated());
+        await context.Send(new MessageActivity { Text = result.Content }.AddAIGenerated(), cancellationToken);
         // Ahoy, matey! 🏴‍☠️ How be ye doin' this fine day on th' high seas?
     }
 });
@@ -119,7 +119,7 @@ N/A
 
 ```csharp
 // Streaming handler
-teamsApp.OnMessage(async (context) =>
+teamsApp.OnMessage(async (context, cancellationToken) =>
 {
     var match = Regex.Match(context.Activity.Text ?? "", @"^stream\s+(.+)", RegexOptions.IgnoreCase);
     if (match.Success)

--- a/teams.md/src/components/include/in-depth-guides/ai/function-calling/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/function-calling/csharp.incl.md
@@ -176,7 +176,7 @@ import TabItem from '@theme/TabItem';
     var aiModel = new OpenAIChatModel(azureOpenAIModel, azureOpenAI);
 
     // Use the prompt with OpenAIChatPrompt.From()
-    teamsApp.OnMessage(async (context) =>
+    teamsApp.OnMessage(async (context, cancellationToken) =>
     {
         var prompt = OpenAIChatPrompt.From(aiModel, new Samples.AI.Prompts.PokemonPrompt());
 
@@ -184,11 +184,11 @@ import TabItem from '@theme/TabItem';
 
         if (!string.IsNullOrEmpty(result.Content))
         {
-            await context.Send(new MessageActivity { Text = result.Content }.AddAIGenerated());
+            await context.Send(new MessageActivity { Text = result.Content }.AddAIGenerated(), cancellationToken);
         }
         else
         {
-            await context.Reply("Sorry I could not find that pokemon");
+            await context.Reply("Sorry I could not find that pokemon", cancellationToken);
         }
     });
     ```
@@ -343,7 +343,7 @@ Additionally, for complex scenarios, you can add multiple functions to the `Chat
     var aiModel = new OpenAIChatModel(azureOpenAIModel, azureOpenAI);
 
     // Use the prompt with OpenAIChatPrompt.From()
-    teamsApp.OnMessage(async (context) =>
+    teamsApp.OnMessage(async (context, cancellationToken) =>
     {
         var prompt = OpenAIChatPrompt.From(aiModel, new Samples.AI.Prompts.WeatherPrompt());
 
@@ -351,11 +351,11 @@ Additionally, for complex scenarios, you can add multiple functions to the `Chat
 
         if (!string.IsNullOrEmpty(result.Content))
         {
-            await context.Send(new MessageActivity { Text = result.Content }.AddAIGenerated());
+            await context.Send(new MessageActivity { Text = result.Content }.AddAIGenerated(), cancellationToken);
         }
         else
         {
-            await context.Reply("Sorry I could not figure it out");
+            await context.Reply("Sorry I could not figure it out", cancellationToken);
         }
     });
     ```

--- a/teams.md/src/components/include/in-depth-guides/ai/keeping-state/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/keeping-state/csharp.incl.md
@@ -90,7 +90,7 @@ public static async Task HandleStatefulConversation(OpenAIChatModel model, ICont
 ### Usage in your application
 
 ```csharp
-teamsApp.OnMessage(async (context) =>
+teamsApp.OnMessage(async (context, cancellationToken) =>
 {
     await HandleStatefulConversation(aiModel, context);
 });

--- a/teams.md/src/components/include/in-depth-guides/ai/mcp/mcp-client/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/ai/mcp/mcp-client/csharp.incl.md
@@ -67,11 +67,11 @@ import TabItem from '@theme/TabItem';
     prompt.Plugin(new McpClientPlugin().UseMcpServer("https://learn.microsoft.com/api/mcp"));
 
     App app = webApp.UseTeams();
-    app.OnMessage(async context =>
+    app.OnMessage(async (context, cancellationToken) =>
     {
-        await context.Send(new TypingActivity());
+        await context.Send(new TypingActivity(), cancellationToken);
         var result = await prompt.Send(context.Activity.Text);
-        await context.Send(result.Content);
+        await context.Send(result.Content, cancellationToken);
     });
     webApp.Run();
     ```

--- a/teams.md/src/components/include/in-depth-guides/meeting-events/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/meeting-events/csharp.incl.md
@@ -7,7 +7,7 @@ using Microsoft.Teams.Apps.Activities.Events;
 using Microsoft.Teams.Cards;
 
 // Register meeting start handler
-teamsApp.OnMeetingStart(async context =>
+teamsApp.OnMeetingStart(async (context, cancellationToken) =>
 {
     var activity = context.Activity.Value;
     var startTime = activity.StartTime.ToLocalTime();
@@ -32,7 +32,7 @@ teamsApp.OnMeetingStart(async context =>
         }
     };
 
-    await context.Send(card);
+    await context.Send(card, cancellationToken);
 });
 ```
 
@@ -45,7 +45,7 @@ using Microsoft.Teams.Apps.Activities.Events;
 using Microsoft.Teams.Cards;
 
 // Register meeting end handler
-teamsApp.OnMeetingEnd(async context =>
+teamsApp.OnMeetingEnd(async (context, cancellationToken) =>
 {
     var activity = context.Activity.Value;
     var endTime = activity.EndTime.ToLocalTime();
@@ -63,7 +63,7 @@ teamsApp.OnMeetingEnd(async context =>
         }
     };
 
-    await context.Send(card);
+    await context.Send(card, cancellationToken);
 });
 ```
 
@@ -76,7 +76,7 @@ using Microsoft.Teams.Apps.Activities.Events;
 using Microsoft.Teams.Cards;
 
 // Register participant join handler
-teamsApp.OnMeetingJoin(async context =>
+teamsApp.OnMeetingJoin(async (context, cancellationToken) =>
 {
     var activity = context.Activity.Value;
     var member = activity.Members[0].User.Name;
@@ -95,7 +95,7 @@ teamsApp.OnMeetingJoin(async context =>
         }
     };
 
-    await context.Send(card);
+    await context.Send(card, cancellationToken);
 });
 ```
 
@@ -108,7 +108,7 @@ using Microsoft.Teams.Apps.Activities.Events;
 using Microsoft.Teams.Cards;
 
 // Register participant leave handler
-teamsApp.OnMeetingLeave(async context =>
+teamsApp.OnMeetingLeave(async (context, cancellationToken) =>
 {
     var activity = context.Activity.Value;
     var member = activity.Members[0].User.Name;
@@ -126,6 +126,6 @@ teamsApp.OnMeetingLeave(async context =>
         }
     };
 
-    await context.Send(card);
+    await context.Send(card, cancellationToken);
 });
 ```

--- a/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
+++ b/teams.md/src/components/include/in-depth-guides/user-authentication/csharp.incl.md
@@ -22,16 +22,16 @@ var teams = app.UseTeams();
 <!-- signing-in -->
 
 ```cs
-teams.OnMessage("/signin", async context =>
+teams.OnMessage("/signin", async (context, cancellationToken) =>
 {
     if (context.IsSignedIn)
     {
-        await context.Send("you are already signed in!");
+        await context.Send("you are already signed in!", cancellationToken);
         return;
     }
     else
     {
-        await context.SignIn();
+        await context.SignIn(cancellationToken);
     }
 });
 ```
@@ -39,36 +39,36 @@ teams.OnMessage("/signin", async context =>
 <!-- signin-event -->
 
 ```cs
-teams.OnSignIn(async (_, teamsEvent) =>
+teams.OnSignIn(async (_, teamsEvent, cancellationToken) =>
 {
     var context = teamsEvent.Context;
-    await context.Send($"Signed in using OAuth connection {context.ConnectionName}. Please type **/whoami** to see your profile or **/signout** to sign out.");
+    await context.Send($"Signed in using OAuth connection {context.ConnectionName}. Please type **/whoami** to see your profile or **/signout** to sign out.", cancellationToken);
 });
 ```
 
 <!-- using-graph -->
 
 ```cs
-teams.OnMessage("/whoami", async context =>
+teams.OnMessage("/whoami", async (context, cancellationToken) =>
 {
     if (!context.IsSignedIn)
     {
-        await context.Send("you are not signed in!. Please type **/signin** to sign in");
+        await context.Send("you are not signed in!. Please type **/signin** to sign in", cancellationToken);
         return;
     }
     var me = await context.GetUserGraphClient().Me.GetAsync();
-    await context.Send($"user \"{me!.DisplayName}\" signed in.");
+    await context.Send($"user \"{me!.DisplayName}\" signed in.", cancellationToken);
 });
 
-teams.OnMessage(async context =>
+teams.OnMessage(async (context, cancellationToken) =>
 {
     if (context.IsSignedIn)
     {
-        await context.Send($"You said : {context.Activity.Text}.  Please type **/whoami** to see your profile or **/signout** to sign out.");
+        await context.Send($"You said : {context.Activity.Text}.  Please type **/whoami** to see your profile or **/signout** to sign out.", cancellationToken);
     }
     else
     {
-        await context.Send($"You said : {context.Activity.Text}.  Please type **/signin** to sign in.");
+        await context.Send($"You said : {context.Activity.Text}.  Please type **/signin** to sign in.", cancellationToken);
     }
 });
 ```
@@ -76,16 +76,16 @@ teams.OnMessage(async context =>
 <!-- signing-out -->
 
 ```cs
-teams.OnMessage("/signout", async context =>
+teams.OnMessage("/signout", async (context, cancellationToken) =>
 {
     if (!context.IsSignedIn)
     {
-        await context.Send("you are not signed in!");
+        await context.Send("you are not signed in!", cancellationToken);
         return;
     }
 
-    await context.SignOut();
-    await context.Send("you have been signed out!");
+    await context.SignOut(cancellationToken);
+    await context.Send("you have been signed out!", cancellationToken);
 });
 ```
 <!-- signin-failure -->

--- a/teams.md/src/components/include/migrations/botbuilder/integration/csharp.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/integration/csharp.incl.md
@@ -27,10 +27,10 @@
             app.Run();
         }
 
-        teams.OnMessage(async context =>
+        teams.OnMessage(async (context, cancellationToken) =>
         {
-            await context.Client.Typing();
-            await context.Client.Send($"hi from teams...");
+            await context.Client.Typing(cancellationToken);
+            await context.Client.Send($"hi from teams...", cancellationToken);
         });
     }
     ```

--- a/teams.md/src/components/include/migrations/botbuilder/sending-activities/csharp.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/sending-activities/csharp.incl.md
@@ -28,9 +28,9 @@
     // highlight-error-end
     // highlight-success-start
 +   var teams = app.UseTeams();
-+   teams.OnMessage(async (context) =>
++   teams.OnMessage(async (context, cancellationToken) =>
 +   {
-+       await context.Send(new Activity(type:"typing"));
++       await context.Send(new Activity(type:"typing"), cancellationToken);
 +   });
     // highlight-success-end
     ```
@@ -61,10 +61,10 @@
     using Microsoft.Teams.Api.Activities;
 
     var teams = app.UseTeams();
-    teams.OnMessage(async (context) =>
+    teams.OnMessage(async (context, cancellationToken) =>
     {
         // highlight-next-line
-        await context.Send(new Activity(type:"typing"));
+        await context.Send(new Activity(type:"typing"), cancellationToken);
     });
     ```
   </TabItem>
@@ -97,9 +97,9 @@
     // highlight-error-end
     // highlight-success-start
 +   var teams = app.UseTeams();
-+   teams.OnMessage(async (context) =>
++   teams.OnMessage(async (context, cancellationToken) =>
 +   {
-+       await context.Send("hello world");
++       await context.Send("hello world", cancellationToken);
 +   });
     // highlight-success-end
     ```
@@ -127,10 +127,10 @@
     using Microsoft.Teams.Plugins.AspNetCore.Extensions;
 
     var teams = app.UseTeams();
-    teams.OnMessage(async (context) =>
+    teams.OnMessage(async (context, cancellationToken) =>
     {
         // highlight-next-line
-        await context.Send("hello world");
+        await context.Send("hello world", cancellationToken);
     });
     ```
   </TabItem>
@@ -179,9 +179,9 @@
     // highlight-error-end
     // highlight-success-start
 +   var teams = app.UseTeams();
-+   teams.OnMessage(async (context) =>
++   teams.OnMessage(async (context, cancellationToken) =>
 +   {
-+       await context.Send(new AdaptiveCard(new TextBlock("hello world")));
++       await context.Send(new AdaptiveCard(new TextBlock("hello world")), cancellationToken);
 +   });
     // highlight-success-end
     ```
@@ -226,10 +226,10 @@
     using Microsoft.Teams.Plugins.AspNetCore.Extensions;
 
     var teams = app.UseTeams();
-    teams.OnMessage(async (context) =>
+    teams.OnMessage(async (context, cancellationToken) =>
     {
         // highlight-next-line
-        await context.Send(new AdaptiveCard(new TextBlock("hello world")));
+        await context.Send(new AdaptiveCard(new TextBlock("hello world")), cancellationToken);
     });
     ```
   </TabItem>
@@ -264,11 +264,11 @@
     // highlight-error-end
     // highlight-success-start
 +   var teams = app.UseTeams();
-+   teams.OnMessage(async (context) =>
++   teams.OnMessage(async (context, cancellationToken) =>
 +   {
 +       var activity = new MessageActivity();
 +       activity.AddAttachment(new Attachment { /* ... */ });
-+       await context.SendAsync(activity);
++       await context.SendAsync(activity, cancellationToken);
 +   });
     // highlight-success-end
     ```
@@ -299,12 +299,12 @@
     using Microsoft.Teams.Plugins.AspNetCore.Extensions;
     
     var teams = app.UseTeams();
-    teams.OnMessage(async (context) =>
+    teams.OnMessage(async (context, cancellationToken) =>
     {
         // highlight-start
         var activity = new MessageActivity();
         activity.AddAttachment(new Attachment { /* ... */ });
-        await context.SendAsync(activity);
+        await context.SendAsync(activity, cancellationToken);
         // highlight-end
     });
     ```

--- a/teams.md/src/components/include/migrations/botbuilder/the-api-client/csharp.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/the-api-client/csharp.incl.md
@@ -23,7 +23,7 @@
   // highlight-error-end
   // highlight-success-start
 +  var teams = app.UseTeams();
-+  teams.OnMessage(async (context) =>
++  teams.OnMessage(async (context, cancellationToken) =>
 +  {
 +      var members = await context.Api.Conversations.Members.GetAsync(context.Activity.Conversation.Id);
 +  });
@@ -51,7 +51,7 @@
     ```csharp showLineNumbers
     using Microsoft.Teams.Apps;
     
-    app.OnMessage(async (context) =>
+    app.OnMessage(async (context, cancellationToken) =>
     {
         // highlight-next-line
         var members = await context.Api.Conversations.Members.GetAsync(context.Activity.Conversation.Id);

--- a/teams.md/src/components/include/migrations/botbuilder/user-authentication/csharp.incl.md
+++ b/teams.md/src/components/include/migrations/botbuilder/user-authentication/csharp.incl.md
@@ -92,25 +92,25 @@
     var app = builder.Build();
     var teams = app.UseTeams();
 
-    teams.OnMessage("/signout", async (context) =>
+    teams.OnMessage("/signout", async (context, cancellationToken) =>
     {
         if (!context.IsSignedIn) return;
-        await context.SignOut();
-        await context.Send("You have been signed out.");
+        await context.SignOut(cancellationToken);
+        await context.Send("You have been signed out.", cancellationToken);
     });
 
-    teams.OnMessage(async (context) =>
+    teams.OnMessage(async (context, cancellationToken) =>
     {
         if (!context.IsSignedIn)
         {
-            await context.SignIn();
+            await context.SignIn(cancellationToken);
             return;
         }
     });
 
-    teams.OnSignIn(async (_, @event) =>
+    teams.OnSignIn(async (_, @event, cancellationToken) =>
     {
-        await context.Send("You have been signed in.");
+        await context.Send("You have been signed in.", cancellationToken);
     });
 
     app.Run()


### PR DESCRIPTION
## Summary
- Adds `cancellationToken` parameter to all C# handler lambda signatures across 18 doc include files
- Passes `cancellationToken` to all async SDK calls (`Send`, `Typing`, `SignIn`, `SignOut`, `SendAsync`)
- Covers essentials, getting-started, in-depth-guides (AI, adaptive cards, meeting events, user auth), and migration docs

## Test plan
- [x] `npm run generate:docs` succeeds with 0 content gaps
- [x] Grep confirms no remaining async handlers without `cancellationToken` in generated docs
- [ ] Visual review of rendered docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)